### PR TITLE
Fix TypeScript lint errors

### DIFF
--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Search, BookOpen } from "lucide-react";
 
-interface Book {
+export interface Book {
   id: number;
   title: string;
   author: string;

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -2,12 +2,14 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { BookOpen, Plus } from 'lucide-react';
-import AddBookDialog from '@/components/AddBookDialog';
+import { BookOpen } from 'lucide-react';
+import AddBookDialog, { Book } from '@/components/AddBookDialog';
+import { User } from '@supabase/supabase-js';
+import { Profile } from '@/hooks/useProfile';
 
 interface DashboardHeaderProps {
-  user: any;
-  profile: any;
+  user: User | null;
+  profile: Profile | null;
 }
 
 const DashboardHeader: React.FC<DashboardHeaderProps> = ({ user, profile }) => {
@@ -18,7 +20,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({ user, profile }) => {
     profile.full_name.split(' ').map((n: string) => n[0]).join('').toUpperCase() : 
     firstName.charAt(0).toUpperCase();
 
-  const handleAddBook = (book: any) => {
+  const handleAddBook = (book: Book) => {
     console.log('Adding book:', book);
     // Here you would typically add the book to the user's library
     setShowAddBook(false);

--- a/src/components/profile/BasicProfileFields.tsx
+++ b/src/components/profile/BasicProfileFields.tsx
@@ -1,8 +1,16 @@
 
 import React from "react";
-import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { UseFormReturn } from "react-hook-form";
+import { ProfileFormValues } from "./types";
 
 const GENDER_OPTIONS = [
   { label: "Male", value: "male" },
@@ -11,7 +19,7 @@ const GENDER_OPTIONS = [
 ];
 
 type BasicProfileFieldsProps = {
-  form: any;
+  form: UseFormReturn<ProfileFormValues>;
 };
 
 const BasicProfileFields: React.FC<BasicProfileFieldsProps> = ({ form }) => {

--- a/src/components/profile/EditProfileDialog.tsx
+++ b/src/components/profile/EditProfileDialog.tsx
@@ -1,19 +1,29 @@
 
 import React from "react";
-import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription, DialogClose } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import ProfileFormContent from "./ProfileFormContent";
+import { UseFormReturn } from "react-hook-form";
+import { ProfileFormValues } from "./types";
 
 type EditProfileDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  form: any;
-  onSubmit: (values: any) => Promise<void>;
+  form: UseFormReturn<ProfileFormValues>;
+  onSubmit: (values: ProfileFormValues) => Promise<void>;
   upsertProfilePending: boolean;
-  defaultValues: any;
+  defaultValues: ProfileFormValues;
 };
 
 const EditProfileDialog: React.FC<EditProfileDialogProps> = ({
@@ -44,7 +54,7 @@ const EditProfileDialog: React.FC<EditProfileDialogProps> = ({
     return !data; // Available if no data found
   };
 
-  const handleSubmit = async (values: any) => {
+  const handleSubmit = async (values: ProfileFormValues) => {
     // Check username availability before submitting
     if (values.username && values.username !== defaultValues.username) {
       const isAvailable = await checkUsernameAvailability(values.username);

--- a/src/components/profile/LifePhasesField.tsx
+++ b/src/components/profile/LifePhasesField.tsx
@@ -1,13 +1,15 @@
 
 import React from "react";
 import { FormField, FormItem, FormLabel } from "@/components/ui/form";
+import { UseFormReturn } from "react-hook-form";
+import { ProfileFormValues } from "./types";
 
 const PHASES = [
   "School Life", "College Days", "Startup Journey", "Parenting", "Travelling", "Remote Work", "Self Discovery"
 ];
 
 type LifePhasesFieldProps = {
-  form: any;
+  form: UseFormReturn<ProfileFormValues>;
 };
 
 const LifePhasesField: React.FC<LifePhasesFieldProps> = ({ form }) => {

--- a/src/components/profile/ProfileFormContent.tsx
+++ b/src/components/profile/ProfileFormContent.tsx
@@ -4,10 +4,12 @@ import { Form } from "@/components/ui/form";
 import BasicProfileFields from "./BasicProfileFields";
 import LifePhasesField from "./LifePhasesField";
 import SocialLinksField from "./SocialLinksField";
+import { UseFormReturn } from "react-hook-form";
+import { ProfileFormValues } from "./types";
 
 type ProfileFormContentProps = {
-  form: any;
-  onSubmit: (values: any) => Promise<void>;
+  form: UseFormReturn<ProfileFormValues>;
+  onSubmit: (values: ProfileFormValues) => Promise<void>;
 };
 
 const ProfileFormContent: React.FC<ProfileFormContentProps> = ({ form, onSubmit }) => {

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -13,6 +13,7 @@ import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "
 import { toast } from "@/components/ui/use-toast";
 import { Calendar } from "lucide-react";
 import { useForm } from "react-hook-form";
+import { ProfileFormValues } from "./types";
 import { Pencil, Trash, MapPin, AtSign, Mail, Hash, User, Link2 } from "lucide-react";
 import { format } from "date-fns";
 import ProfileAvatar from "./ProfileAvatar";
@@ -53,7 +54,7 @@ export const ProfileView: React.FC = () => {
   const [editMode, setEditMode] = useState<EditMode>("view");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const defaultValues = {
+  const defaultValues: ProfileFormValues = {
     name: profile?.name || "",
     username: profile?.username || "",
     bio: profile?.bio || "",
@@ -64,7 +65,7 @@ export const ProfileView: React.FC = () => {
     social_links: profile?.social_links ?? {},
   };
 
-  const form = useForm({ defaultValues });
+  const form = useForm<ProfileFormValues>({ defaultValues });
 
   // Handle profile image upload
   const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -75,8 +76,9 @@ export const ProfileView: React.FC = () => {
       const url = await uploadProfilePicture(files[0], user.id);
       await upsertProfile.mutateAsync({ profile_picture_url: url });
       toast({ title: "Profile Picture Updated", description: "Your photo was uploaded successfully." });
-    } catch (err: any) {
-      toast({ title: "Upload failed", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast({ title: "Upload failed", description: message, variant: "destructive" });
     }
   };
 
@@ -100,7 +102,7 @@ export const ProfileView: React.FC = () => {
     openPopupWindow("https://jeevan-katha-anek-hai1.lovable.app/", "My Life Stories");
   };
 
-  const onSubmit = async (values: any) => {
+  const onSubmit = async (values: ProfileFormValues) => {
     try {
       await upsertProfile.mutateAsync({
         ...values,
@@ -112,8 +114,9 @@ export const ProfileView: React.FC = () => {
       });
       toast({ title: "Profile updated", description: "Your changes were saved." });
       setEditMode("view");
-    } catch (err: any) {
-      toast({ title: "Update failed", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast({ title: "Update failed", description: message, variant: "destructive" });
     }
   };
 

--- a/src/components/profile/SocialLinksField.tsx
+++ b/src/components/profile/SocialLinksField.tsx
@@ -2,6 +2,8 @@
 import React from "react";
 import { FormField, FormItem, FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { UseFormReturn } from "react-hook-form";
+import { ProfileFormValues } from "./types";
 
 const SOCIAL_FIELDS = [
   { key: "instagram", label: "Instagram" },
@@ -11,7 +13,7 @@ const SOCIAL_FIELDS = [
 ];
 
 type SocialLinksFieldProps = {
-  form: any;
+  form: UseFormReturn<ProfileFormValues>;
 };
 
 const SocialLinksField: React.FC<SocialLinksFieldProps> = ({ form }) => {

--- a/src/components/profile/types.ts
+++ b/src/components/profile/types.ts
@@ -1,0 +1,11 @@
+export interface ProfileFormValues {
+  name: string;
+  username: string;
+  bio: string;
+  dob: string;
+  gender: string;
+  location: string;
+  life_tags: string[];
+  social_links: Record<string, string>;
+}
+

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -13,11 +13,11 @@ export interface Profile {
   writing_frequency: string | null;
   stories_written_count: number | null;
   stories_read_count: number | null;
-  tags_used: any; // jsonb, typically string[]
+  tags_used: string[] | null; // jsonb, typically string[]
   created_at: string;
   updated_at: string | null;
   // The following fields are unused/substituted for legacy reasons — fill or omit as needed:
-  notification_settings?: any;
+  notification_settings?: Record<string, unknown>;
 }
 
 export const useProfile = () => {

--- a/src/pages/Bookshelf.tsx
+++ b/src/pages/Bookshelf.tsx
@@ -5,14 +5,24 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { BookOpen, Download, Play, MessageCircle, Plus, Search, Filter } from "lucide-react";
-import AddBookDialog from "@/components/AddBookDialog";
+import AddBookDialog, { Book } from "@/components/AddBookDialog";
+
+interface ShelfBook extends Book {
+  currentPage: number;
+  status: string;
+  progress: number;
+  notes: string;
+  downloadUrl: string;
+  hasAiChat: boolean;
+  totalPages: number;
+}
 
 const Bookshelf = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterStatus, setFilterStatus] = useState("All");
   const [aiQuestion, setAiQuestion] = useState("");
 
-  const [myBooks, setMyBooks] = useState([
+  const [myBooks, setMyBooks] = useState<ShelfBook[]>([
     {
       id: 1,
       title: "The Midnight Library",
@@ -90,7 +100,7 @@ const Bookshelf = () => {
     setAiQuestion("");
   };
 
-  const handleAddBook = (newBook: any) => {
+  const handleAddBook = (newBook: Book) => {
     const bookToAdd = {
       ...newBook,
       currentPage: 0,

--- a/src/pages/ReaderMap.tsx
+++ b/src/pages/ReaderMap.tsx
@@ -6,11 +6,19 @@ import { Badge } from "@/components/ui/badge";
 import { Map, Users, MapPin, Search, BookOpen } from "lucide-react";
 import { useState } from "react";
 
+interface ReaderLocation {
+  city: string;
+  state: string;
+  country: string;
+  totalReaders: number;
+  popularBooks: { title: string; readers: number }[];
+}
+
 const ReaderMap = () => {
   const [searchLocation, setSearchLocation] = useState("");
   const [selectedBook, setSelectedBook] = useState("All Books");
 
-  const readerData = [
+  const readerData: ReaderLocation[] = [
     {
       city: "Mumbai",
       state: "Maharashtra",
@@ -89,9 +97,9 @@ const ReaderMap = () => {
     return matchesSearch;
   });
 
-  const getBookReaders = (location: any, bookTitle: string) => {
+  const getBookReaders = (location: ReaderLocation, bookTitle: string) => {
     if (bookTitle === "All Books") return location.totalReaders;
-    const book = location.popularBooks.find((b: any) => b.title === bookTitle);
+    const book = location.popularBooks.find((b) => b.title === bookTitle);
     return book ? book.readers : 0;
   };
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -41,8 +41,9 @@ const SignIn = () => {
       if (error) throw error;
 
       navigate('/dashboard');
-    } catch (error: any) {
-      setError(error.message);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      setError(message);
     } finally {
       setLoading(false);
     }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -77,8 +77,9 @@ const SignUp = () => {
         navigate('/dashboard');
       }, 2000);
       
-    } catch (error: any) {
-      setError(error.message);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      setError(message);
     } finally {
       setLoading(false);
     }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -114,5 +115,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add shared profile form values type
- use explicit types across profile and dashboard components
- export Book type from AddBookDialog and use it
- type bookshelf and reader map data structures
- clean up require usage in tailwind config
- convert empty interfaces to type aliases

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685554b5851c832096b988a4e21923bd