### PR TITLE
Add sample book grid to library page

### DIFF
--- a/src/components/library/BookCardGrid.tsx
+++ b/src/components/library/BookCardGrid.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { Card, CardContent, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface Book {
+  id: number;
+  title: string;
+  author: string;
+  description: string;
+}
+
+const mockBooks: Book[] = [
+  {
+    id: 1,
+    title: "Learning React",
+    author: "John Doe",
+    description:
+      "A practical guide to building modern user interfaces with React.",
+  },
+  {
+    id: 2,
+    title: "JavaScript Patterns",
+    author: "Jane Smith",
+    description:
+      "Best practices for writing maintainable and efficient JavaScript code.",
+  },
+  {
+    id: 3,
+    title: "CSS Mastery",
+    author: "Alex Johnson",
+    description:
+      "Advanced tips for developing responsive and accessible web designs.",
+  },
+];
+
+const BookCardGrid: React.FC = () => {
+  const [readIds, setReadIds] = useState<number[]>([]);
+
+  const markAsRead = (id: number) => {
+    if (!readIds.includes(id)) {
+      setReadIds([...readIds, id]);
+    }
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto p-4">
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {mockBooks.map((book) => (
+          <Card key={book.id} className="flex flex-col">
+            <CardContent className="flex-1 space-y-1 p-6">
+              <h3 className="text-lg font-semibold">{book.title}</h3>
+              <p className="text-sm text-gray-500">{book.author}</p>
+              <p className="text-sm text-gray-700 line-clamp-2">
+                {book.description}
+              </p>
+            </CardContent>
+            <CardFooter className="pt-0">
+              <Button
+                size="sm"
+                onClick={() => markAsRead(book.id)}
+                disabled={readIds.includes(book.id)}
+                className="ml-auto bg-amber-600 hover:bg-amber-700"
+              >
+                {readIds.includes(book.id) ? "Read" : "Mark as Read"}
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default BookCardGrid;

--- a/src/index.css
+++ b/src/index.css
@@ -101,3 +101,10 @@
     @apply bg-background text-foreground;
   }
 }
+/* Utility for clamping text to two lines */
+.line-clamp-2 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}

--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { BookOpen } from "lucide-react";
+import BookCardGrid from "@/components/library/BookCardGrid";
 
 const sampleBooks = [
   {
@@ -81,6 +82,8 @@ const BookLibrary = () => {
 
   return (
     <div className="min-h-screen py-8 px-4">
+      {/* Sample book grid */}
+      <BookCardGrid />
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
           <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">Book Library</h1>


### PR DESCRIPTION
## Summary
- add a responsive BookCardGrid component with mock data
- integrate BookCardGrid in BookLibrary page
- add `line-clamp-2` helper class to limit description text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856402590088320bc6b39b33e3fd4c0