### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,27 @@
+import { Moon, Sun } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useDarkMode } from '@/hooks/useDarkMode';
+
+type Props = {
+  className?: string;
+  showLabel?: boolean;
+};
+
+const DarkModeToggle = ({ className, showLabel = false }: Props) => {
+  const { isDark, toggle } = useDarkMode();
+
+  return (
+    <Button
+      variant="ghost"
+      size={showLabel ? undefined : 'icon'}
+      aria-label="Toggle dark mode"
+      onClick={toggle}
+      className={`text-gray-700 hover:bg-amber-50 dark:text-gray-200 dark:hover:bg-amber-900 ${className ?? ''}`}
+    >
+      {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+      {showLabel && <span className="ml-2">{isDark ? 'Light' : 'Dark'} Mode</span>}
+    </Button>
+  );
+};
+
+export default DarkModeToggle;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,6 +4,7 @@ import NavLogo from "./navigation/NavLogo";
 import DesktopNavItems from "./navigation/DesktopNavItems";
 import AuthSection from "./navigation/AuthSection";
 import MobileNavMenu from "./navigation/MobileNavMenu";
+import DarkModeToggle from "./DarkModeToggle";
 
 const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -17,11 +18,12 @@ const Navigation = () => {
           {/* Desktop Navigation */}
           <div className="hidden lg:flex items-center space-x-6">
             <DesktopNavItems />
+            <DarkModeToggle />
             <AuthSection />
           </div>
 
           {/* Mobile menu button */}
-          <div className="lg:hidden">
+          <div className="lg:hidden flex items-center space-x-2">
             <button
               className="text-gray-700 p-2"
               aria-label="Open main menu"
@@ -35,6 +37,7 @@ const Navigation = () => {
                 )}
               </svg>
             </button>
+            <DarkModeToggle />
           </div>
         </div>
         {/* Mobile Navigation */}

--- a/src/components/navigation/MobileNavMenu.tsx
+++ b/src/components/navigation/MobileNavMenu.tsx
@@ -6,6 +6,7 @@ import { Bell, User, Book, Upload, BookOpen, Settings, LogOut, LogIn } from "luc
 import { useAuth } from "@/contexts/AuthContext";
 import { useProfile } from "@/hooks/useProfile";
 import { useState } from "react";
+import DarkModeToggle from "../DarkModeToggle";
 
 type Props = {
   isOpen: boolean;
@@ -68,6 +69,7 @@ const MobileNavMenu = ({ isOpen, setIsOpen }: Props) => {
             </Link>
           );
         })}
+        <DarkModeToggle className="w-full justify-start" showLabel />
         <div className="border-t pt-2 mt-2">
           {user ? (
             <>

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+export const useDarkMode = () => {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      setIsDark(stored === 'dark');
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setIsDark(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const root = document.documentElement;
+    if (isDark) {
+      root.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      root.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDark]);
+
+  const toggle = () => setIsDark((prev) => !prev);
+
+  return { isDark, toggle };
+};


### PR DESCRIPTION
## Summary
- add `useDarkMode` hook to manage theme with localStorage
- create `DarkModeToggle` component
- add dark mode toggle button to desktop and mobile navigation

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6856410212388320b7f634692a0a03d9