### PR TITLE
Add book cover thumbnails

### DIFF
--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -124,15 +124,22 @@ const AddBookDialog = ({ onAddBook }: AddBookDialogProps) => {
           <div className="grid md:grid-cols-2 gap-4 max-h-[400px] overflow-y-auto">
             {filteredBooks.map((book) => (
               <Card key={book.id} className="bg-white/70 backdrop-blur-sm border-amber-200 hover:shadow-lg transition-all duration-300">
-                <CardHeader className="pb-3">
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <CardTitle className="text-lg text-gray-900 mb-1">{book.title}</CardTitle>
-                      <p className="text-gray-600 text-sm">by {book.author}</p>
+                <CardHeader className="pb-3 flex flex-col sm:flex-row sm:space-x-4 space-y-3 sm:space-y-0 items-start">
+                  <img
+                    src="https://via.placeholder.com/120x160.png?text=Cover"
+                    alt={`Cover of ${book.title}`}
+                    className="w-full sm:w-24 h-36 object-cover rounded-md"
+                  />
+                  <div className="flex-1 w-full">
+                    <div className="flex justify-between items-start">
+                      <div className="flex-1">
+                        <CardTitle className="text-lg text-gray-900 mb-1">{book.title}</CardTitle>
+                        <p className="text-gray-600 text-sm">by {book.author}</p>
+                      </div>
+                      <Badge variant="outline" className="ml-2">
+                        {book.genre}
+                      </Badge>
                     </div>
-                    <Badge variant="outline" className="ml-2">
-                      {book.genre}
-                    </Badge>
                   </div>
                 </CardHeader>
                 

--- a/src/pages/Bookshelf.tsx
+++ b/src/pages/Bookshelf.tsx
@@ -200,31 +200,38 @@ const Bookshelf = () => {
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredBooks.map((book) => (
             <Card key={book.id} className="bg-white/70 backdrop-blur-sm border-amber-200 hover:shadow-xl transition-all duration-300">
-              <CardHeader>
-                <div className="flex justify-between items-start mb-4">
-                  <div className="flex-1">
-                    <CardTitle className="text-xl text-gray-900 mb-2">{book.title}</CardTitle>
-                    <p className="text-gray-600">by {book.author}</p>
+              <CardHeader className="flex flex-col sm:flex-row sm:space-x-4 space-y-4 sm:space-y-0">
+                <img
+                  src="https://via.placeholder.com/120x160.png?text=Cover"
+                  alt={`Cover of ${book.title}`}
+                  className="w-full sm:w-32 h-48 object-cover rounded-md"
+                />
+                <div className="flex-1">
+                  <div className="flex justify-between items-start mb-4">
+                    <div className="flex-1">
+                      <CardTitle className="text-xl text-gray-900 mb-2">{book.title}</CardTitle>
+                      <p className="text-gray-600">by {book.author}</p>
+                    </div>
+                    <Badge className={statusColors[book.status as keyof typeof statusColors]}>
+                      {book.status}
+                    </Badge>
                   </div>
-                  <Badge className={statusColors[book.status as keyof typeof statusColors]}>
-                    {book.status}
-                  </Badge>
-                </div>
-                
-                {/* Progress Bar */}
-                <div className="space-y-2">
-                  <div className="flex justify-between text-sm text-gray-600">
-                    <span>Progress</span>
-                    <span>{book.currentPage} / {book.totalPages} pages</span>
-                  </div>
-                  <div className="w-full bg-gray-200 rounded-full h-2">
-                    <div 
-                      className="bg-amber-600 h-2 rounded-full transition-all duration-300" 
-                      style={{ width: `${book.progress}%` }}
-                    ></div>
-                  </div>
-                  <div className="text-center text-sm font-medium text-amber-600">
-                    {book.progress}% Complete
+
+                  {/* Progress Bar */}
+                  <div className="space-y-2">
+                    <div className="flex justify-between text-sm text-gray-600">
+                      <span>Progress</span>
+                      <span>{book.currentPage} / {book.totalPages} pages</span>
+                    </div>
+                    <div className="w-full bg-gray-200 rounded-full h-2">
+                      <div
+                        className="bg-amber-600 h-2 rounded-full transition-all duration-300"
+                        style={{ width: `${book.progress}%` }}
+                      ></div>
+                    </div>
+                    <div className="text-center text-sm font-medium text-amber-600">
+                      {book.progress}% Complete
+                    </div>
                   </div>
                 </div>
               </CardHeader>


### PR DESCRIPTION
## Summary
- add placeholder book cover to each card in the bookshelf
- display book cover thumbnails when adding books

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685640f82b3c83208c86aa0538466f94