### PR TITLE
Sanitize Gemini key & fix lint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # API key for Google Gemini
-VITE_GEMINI_API_KEY=AIzaSyBwEOGoiOqVdqjEaraIeT48QIMKN8GeFnM
+VITE_GEMINI_API_KEY=your_key_here

--- a/src/components/library/InternetArchiveReader.tsx
+++ b/src/components/library/InternetArchiveReader.tsx
@@ -20,8 +20,8 @@ const InternetArchiveReader = ({ book, isOpen, onClose }: InternetArchiveReaderP
   const [isFullscreen, setIsFullscreen] = useState(false);
   
   // Extract Internet Archive identifier from the book's internet_archive_url
-  const archiveId = book?.internet_archive_url ? 
-    book.internet_archive_url.match(/archive\.org\/details\/([^\/\?]+)/)?.[1] : null;
+  const archiveId = book?.internet_archive_url ?
+    book.internet_archive_url.match(/archive\.org\/details\/([^/?]+)/)?.[1] : null;
 
   const { data: bookMetadata, isLoading: isMetadataLoading } = useInternetArchiveBook(archiveId || '');
   const { data: pages = [], isLoading: isPagesLoading } = useBookPages(archiveId || '');

--- a/src/components/library/MostReadBooks.tsx
+++ b/src/components/library/MostReadBooks.tsx
@@ -29,7 +29,7 @@ const MostReadBooks = ({
   const [readerBook, setReaderBook] = React.useState<Book | null>(null);
 
   const filteredBooks = useMemo(() => {
-    let filtered = books.filter(book => {
+    const filtered = books.filter(book => {
       // Search filter
       if (searchQuery) {
         const query = searchQuery.toLowerCase();

--- a/src/hooks/useInternetArchive.ts
+++ b/src/hooks/useInternetArchive.ts
@@ -94,6 +94,6 @@ export const useBookPages = (identifier: string) => {
 
 export const getInternetArchiveBookId = (url: string): string | null => {
   // Extract book ID from Internet Archive URL
-  const match = url.match(/archive\.org\/details\/([^\/\?]+)/);
+  const match = url.match(/archive\.org\/details\/([^/?]+)/);
   return match ? match[1] : null;
 };


### PR DESCRIPTION
## Summary
- sanitize the example Gemini API key
- fix regex escapes in InternetArchive utilities and reader
- prefer const in `MostReadBooks`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68613a469ce08320892aa84879d89969