### PR TITLE
Document supabase env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
+# Supabase credentials
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your_anon_key_here
+
 # API key for Google Gemini
-VITE_GEMINI_API_KEY=AIzaSyBwEOGoiOqVdqjEaraIeT48QIMKN8GeFnM
+VITE_GEMINI_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ This project is built with:
 
 ## Environment variables
 
-Create a `.env` file based on `.env.example` and provide your Gemini API key:
+Create a `.env` file based on `.env.example` and add your Supabase credentials
+along with the Gemini API key:
 
 ```env
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 VITE_GEMINI_API_KEY=your_key_here
 ```
-This key is required for the chatbot to fetch responses from the Gemini API.
+These values are required for the application to connect to Supabase and for the
+chatbot to fetch responses from the Gemini API.
 
 ## How can I deploy this project?
 


### PR DESCRIPTION
## Summary
- add supabase keys to `.env.example`
- update README with instructions for setting these env vars

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68613f5380a4832088f2dd8090b01353