### PR TITLE
Improve chatbot visuals

### DIFF
--- a/src/components/chatbot/Chatbot.tsx
+++ b/src/components/chatbot/Chatbot.tsx
@@ -2,6 +2,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { BookOpen, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { useChatbot } from '@/contexts/ChatbotContext';
 import { cn } from '@/lib/utils';
 
@@ -27,19 +32,26 @@ const Chatbot = () => {
   };
 
   if (!isOpen) {
-    return (
+    const button = (
       <button
         id="chatbot-icon"
         onClick={toggleChat}
         className={cn(
-          'fixed z-50 flex items-center justify-center rounded-full bg-black text-white cursor-pointer',
-          floating && 'animate-float'
+          'fixed z-50 flex items-center justify-center rounded-full text-white cursor-pointer',
+          floating ? 'animate-float animate-vibrant' : 'bg-black'
         )}
         style={{ width: '50px', height: '50px', bottom: '30px', right: '30px' }}
         aria-label="Open chat with Book Expert"
       >
         <BookOpen className="h-6 w-6" />
       </button>
+    );
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent>Book Expert</TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -98,3 +98,15 @@
 .animate-float {
   animation: float 2s ease-in-out infinite;
 }
+
+@keyframes vibrant {
+  0% { background-color: #f43f5e; }
+  25% { background-color: #f97316; }
+  50% { background-color: #eab308; }
+  75% { background-color: #22c55e; }
+  100% { background-color: #3b82f6; }
+}
+
+.animate-vibrant {
+  animation: vibrant 2s linear infinite;
+}


### PR DESCRIPTION
## Summary
- animate chatbot icon colours for first 10s
- show tooltip text "Book Expert" on hover

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861440279f88320a0bf9dbb4f304b1c