### PR TITLE
Resolve book cover upload conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,30 @@ To connect a domain, navigate to Project > Settings > Domains and click Connect 
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
 
+## Uploading book cover images
+
+To display your own book covers in the Library, you need a public Storage bucket:
+
+1. Sign in to your **Supabase** project and open **Storage** from the sidebar.
+2. Click **Create bucket** and name it `book-covers`.
+3. Leave the bucket **Public** so the app can load images directly.
+4. Save the bucket. You can now upload files into `book-covers/`.
+
+When uploading, pass the book's ID to the helper so each file is stored under
+its own folder:
+
+The helper function in `src/hooks/useBookCoverUpload.ts` can be used to upload an
+image programmatically:
+
+```ts
+const publicUrl = await uploadBookCover(file, bookId);
+```
+
+The helper trims slashes from the book ID and sanitizes the filename so the
+final URL won't contain double slashes or other invalid characters.
+
+Store the returned URL in the `cover_image_url` column of `books_library`.
+Check that the final URL looks correct (no double slashes) and that the bucket
+is public. The library pages will automatically use this URL to display the
+cover image.
+

--- a/src/hooks/useBookCoverUpload.ts
+++ b/src/hooks/useBookCoverUpload.ts
@@ -1,0 +1,24 @@
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Upload a book cover image to the public `book-covers` bucket and
+ * return the public URL of the uploaded file.
+ */
+export async function uploadBookCover(file: File, bookId: string): Promise<string> {
+  if (!file.type.startsWith('image/')) {
+    throw new Error('Only image uploads allowed');
+  }
+
+  const bucket = 'book-covers';
+  const safeBookId = bookId.replace(/^\/+|\/+$/g, '');
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const filePath = `${safeBookId}/${Date.now()}_${safeName}`;
+
+  await supabase.storage.createBucket(bucket, { public: true }).catch(() => ({ error: null }));
+
+  const { error } = await supabase.storage.from(bucket).upload(filePath, file, { upsert: true });
+  if (error) throw error;
+
+  return supabase.storage.from(bucket).getPublicUrl(filePath).data.publicUrl;
+}
+

--- a/src/hooks/useLibraryBooks.ts
+++ b/src/hooks/useLibraryBooks.ts
@@ -71,17 +71,13 @@ export const useLibraryBooks = () => {
         genre: book.genre,
         description: book.description,
         author_bio: book.author_bio,
-        cover_image_url: book.title.toLowerCase().includes('brief history of time') ? 
-          'https://m.media-amazon.com/images/I/A1gXUtzHh6L._SY466_.jpg' : 
-          book.cover_image_url,
+        cover_image_url: book.cover_image_url,
         ebook_url: book.pdf_url,
         pdf_url: book.pdf_url,
         price: book.price,
         amazon_url: book.amazon_url,
         google_books_url: book.google_books_url,
-        internet_archive_url: book.title.toLowerCase().includes('brief history of time') ? 
-          'https://archive.org/details/briefhistoryofti0000hawk' : 
-          book.internet_archive_url,
+        internet_archive_url: book.internet_archive_url,
         isbn: book.isbn,
         publication_year: book.publication_year,
         pages: book.pages,


### PR DESCRIPTION
## Summary
- clarify sanitized upload path in `useBookCoverUpload`
- document storing covers in `book-covers` bucket
- remove fallback URLs so uploaded images show correctly
- document sanitization in README
- rewrite upload helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614c51f5648320bd8d7d2535011ee9