### PR TITLE
Move mobile search icon to header

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,6 +10,7 @@ const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
@@ -54,9 +55,18 @@ const Navigation = () => {
     <nav className="w-full bg-white border-b border-gray-200 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-3 sm:px-4 lg:px-8">
         <div className="flex justify-between items-center h-16">
-          <div className="flex items-center space-x-6">
+          <div className="flex items-center space-x-3 sm:space-x-6">
             <NavLogo />
-            
+
+            {/* Mobile Search Icon */}
+            <button
+              className="md:hidden p-2 text-gray-700"
+              aria-label="Search"
+              onClick={() => setIsMobileSearchOpen(!isMobileSearchOpen)}
+            >
+              <Search className="w-5 h-5" />
+            </button>
+
             {/* Compact Search Bar */}
             <div className="hidden md:block">
               <div className="relative">
@@ -110,7 +120,43 @@ const Navigation = () => {
             </button>
           </div>
         </div>
-        
+
+        {isMobileSearchOpen && (
+          <div className="md:hidden py-2">
+            <div className="relative">
+              <input
+                type="text"
+                placeholder="Search..."
+                value={searchQuery}
+                onChange={handleSearchChange}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSearch();
+                    setIsMobileSearchOpen(false);
+                  }
+                }}
+                onFocus={() => setIsSearchFocused(true)}
+                onBlur={() => setIsSearchFocused(false)}
+                className={`pl-4 pr-9 py-2 w-full border border-gray-300 rounded-full bg-gray-50 text-gray-900 placeholder-gray-500 transition-all duration-300${
+                  isSearchFocused
+                    ? ' border-orange-400 bg-white shadow-md ring-2 ring-orange-200'
+                    : ' hover:bg-white hover:border-gray-400'
+                }`}
+              />
+              <button
+                onClick={() => {
+                  handleSearch();
+                  setIsMobileSearchOpen(false);
+                }}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-orange-600"
+                aria-label="Search"
+              >
+                <Search className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Mobile Navigation */}
         <MobileNavMenu isOpen={isOpen} setIsOpen={setIsOpen} />
       </div>

--- a/src/components/navigation/MobileNavMenu.tsx
+++ b/src/components/navigation/MobileNavMenu.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Bell, User, Book, Upload, BookOpen, Settings, LogOut, LogIn, Share2, Library, Search, UserPlus } from "lucide-react";
+import { Bell, User, Book, Upload, BookOpen, Settings, LogOut, LogIn, Share2, Library, UserPlus } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useProfile } from "@/hooks/useProfile";
 
@@ -16,7 +16,6 @@ const MobileNavMenu = ({ isOpen, setIsOpen }: Props) => {
   const navigate = useNavigate();
   const { user, signOut } = useAuth();
   const { data: profile } = useProfile();
-  const [searchQuery, setSearchQuery] = useState("");
 
   const avatarFallback =
     profile?.full_name?.charAt(0) ||
@@ -60,19 +59,6 @@ const MobileNavMenu = ({ isOpen, setIsOpen }: Props) => {
   return (
     <div className="lg:hidden">
       <div className="px-2 pt-2 pb-3 space-y-1 bg-white rounded-lg shadow-lg mt-2 mx-2 sm:mx-0">
-        {/* Mobile Search */}
-        <div className="px-3 pb-3 mb-2 border-b">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
-            <input
-              type="text"
-              placeholder="Search..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-9 pr-4 py-2 border border-gray-300 rounded-full bg-gray-50 text-gray-900 placeholder-gray-500 focus:border-orange-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-orange-200"
-            />
-          </div>
-        </div>
 
         {navItems.map((item) => {
           const Icon = item.icon;


### PR DESCRIPTION
## Summary
- place a search icon next to Sahadhyayi logo
- remove search bar from mobile sidebar
- add expandable search input for mobile view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618aab7e208320a888eae18a50f876