### PR TITLE
Add Supabase upsert example

### DIFF
--- a/scripts/upsertBook.js
+++ b/scripts/upsertBook.js
@@ -1,0 +1,39 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Load environment variables for Supabase credentials
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.error('Missing Supabase configuration');
+  process.exit(1);
+}
+
+// Initialize Supabase client
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+async function upsertBook() {
+  try {
+    const { data, error } = await supabase
+      .from('books')
+      .upsert(
+        {
+          title: 'A Brief History of Time',
+          author: 'Stephen Hawking',
+          cover_url:
+            'https://rknxtatvlzunatpyqxro.supabase.co/storage/v1/object/public/book-covers/9780857501004-jacket-large.webp',
+        },
+        { onConflict: 'title' }
+      )
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    console.log('Upserted book:', data);
+  } catch (error) {
+    console.error('Error upserting book:', error);
+  }
+}
+
+upsertBook();


### PR DESCRIPTION
## Summary
- add a new `scripts/upsertBook.js` example showing how to connect to Supabase and upsert a book record

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68618a69912c8320b19404304c1bf475