### PR TITLE
Resolve book cover upload conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,23 @@ To connect a domain, navigate to Project > Settings > Domains and click Connect 
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
 
+## Uploading book covers
+
+To store custom cover images in Supabase Storage:
+
+1. In your Supabase project, create (or use) a **public** bucket named `book-covers`.
+   Make sure the bucket's permissions allow public reads so images are accessible.
+2. Use the `uploadAndSaveBookCover` helper to upload an image for each book and automatically update its record:
+
+   ```ts
+   import { uploadAndSaveBookCover } from '@/hooks/useBookCoverUpload';
+
+   const url = await uploadAndSaveBookCover(file, bookId);
+   ```
+
+   The helper trims slashes from the ID and sanitizes the filename so the final URL
+   doesn't contain double slashes or invalid characters.
+
+3. If you uploaded manually, update the `cover_image_url` field in `books_library` with the returned URL.
+   The library page will automatically display the uploaded cover. This step is skipped when using `uploadAndSaveBookCover`.
+

--- a/src/hooks/useBookCoverUpload.ts
+++ b/src/hooks/useBookCoverUpload.ts
@@ -1,0 +1,56 @@
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Upload a book cover image to the `book-covers` bucket in Supabase Storage.
+ * Ensures the bucket exists and returns the public URL of the uploaded image.
+ */
+export async function uploadBookCover(
+  file: File,
+  bookId: string,
+): Promise<string> {
+  const bucket = 'book-covers';
+  // Trim slashes from the ID and sanitize the filename so the final URL
+  // doesn't contain double slashes or invalid characters.
+  const safeBookId = bookId.replace(/^\/+|\/+$/g, '');
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const filePath = `${safeBookId}/${Date.now()}_${safeName}`;
+
+  if (!file.type.startsWith('image/')) {
+    throw new Error('Only image uploads allowed');
+  }
+
+  // Create the bucket if it doesn't already exist
+  await supabase.storage
+    .createBucket(bucket, { public: true })
+    .catch(() => ({ error: null }));
+
+  const { error: uploadError } = await supabase.storage
+    .from(bucket)
+    .upload(filePath, file, { upsert: true });
+  if (uploadError) throw uploadError;
+
+  const publicUrl = supabase.storage
+    .from(bucket)
+    .getPublicUrl(filePath).data.publicUrl;
+
+  return publicUrl;
+}
+
+/**
+ * Upload a book cover and update the corresponding `books_library` row.
+ * Returns the uploaded cover URL.
+ */
+export async function uploadAndSaveBookCover(
+  file: File,
+  bookId: string,
+): Promise<string> {
+  const url = await uploadBookCover(file, bookId);
+
+  const { error } = await supabase
+    .from('books_library')
+    .update({ cover_image_url: url })
+    .eq('id', bookId);
+
+  if (error) throw error;
+  return url;
+}

--- a/src/hooks/useLibraryBooks.ts
+++ b/src/hooks/useLibraryBooks.ts
@@ -71,17 +71,13 @@ export const useLibraryBooks = () => {
         genre: book.genre,
         description: book.description,
         author_bio: book.author_bio,
-        cover_image_url: book.title.toLowerCase().includes('brief history of time') ? 
-          'https://m.media-amazon.com/images/I/A1gXUtzHh6L._SY466_.jpg' : 
-          book.cover_image_url,
+        cover_image_url: book.cover_image_url,
         ebook_url: book.pdf_url,
         pdf_url: book.pdf_url,
         price: book.price,
         amazon_url: book.amazon_url,
         google_books_url: book.google_books_url,
-        internet_archive_url: book.title.toLowerCase().includes('brief history of time') ? 
-          'https://archive.org/details/briefhistoryofti0000hawk' : 
-          book.internet_archive_url,
+        internet_archive_url: book.internet_archive_url,
         isbn: book.isbn,
         publication_year: book.publication_year,
         pages: book.pages,


### PR DESCRIPTION
## Summary
- sanitize the upload path in `useBookCoverUpload`
- add `uploadAndSaveBookCover` helper and document usage
- remove the hardcoded fallback for "A Brief History of Time" covers
- clarify that the bucket must be public when uploading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614c51f5648320bd8d7d2535011ee9