### PR TITLE
Remove read and download buttons

### DIFF
--- a/src/components/library/BookGridView.tsx
+++ b/src/components/library/BookGridView.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Star, StarHalf, ExternalLink, Eye, BookOpen, Download } from 'lucide-react';
+import { Star, StarHalf, ExternalLink, Eye } from 'lucide-react';
 import BookDetailModal from './BookDetailModal';
 import BookReader from './BookReader';
 import type { Book } from '@/hooks/useLibraryBooks';
@@ -159,16 +159,6 @@ const BookGridView = ({ books }: BookGridViewProps) => {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => handleReadBook(book)}
-                  className="flex-1 bg-orange-600 hover:bg-orange-700 text-white"
-                >
-                  <BookOpen className="w-4 h-4 mr-1" />
-                  Read Now
-                </Button>
-                
-                <Button
-                  variant="outline"
-                  size="sm"
                   onClick={() => handleViewBook(book)}
                   className="flex-1"
                 >
@@ -176,18 +166,6 @@ const BookGridView = ({ books }: BookGridViewProps) => {
                   Details
                 </Button>
               </div>
-
-              {/* Download PDF Button */}
-              {book.pdf_url && (
-                <Button
-                  size="sm"
-                  onClick={() => handleDownloadPDF(book)}
-                  className="w-full bg-green-600 hover:bg-green-700 text-white"
-                >
-                  <Download className="w-4 h-4 mr-1" />
-                  Download PDF
-                </Button>
-              )}
 
               {/* External Link */}
               {getPrimaryPurchaseUrl(book) && (

--- a/src/components/library/BookListView.tsx
+++ b/src/components/library/BookListView.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
-import { Star, StarHalf, BookOpen, Eye } from 'lucide-react';
+import { Star, StarHalf, Eye } from 'lucide-react';
 import BookReader from './BookReader';
 import type { Book } from '@/hooks/useLibraryBooks';
 
@@ -113,13 +113,6 @@ const BookListView = ({ books }: BookListViewProps) => {
 
               {/* Actions */}
               <div className="flex-shrink-0 w-48 space-y-3">
-                <Button
-                  onClick={() => handleReadBook(book)}
-                  className="w-full bg-orange-600 hover:bg-orange-700"
-                >
-                  <BookOpen className="w-4 h-4 mr-2" />
-                  Read Now
-                </Button>
                 
                 <Select
                   value={userShelves[book.id] || 'want-to-read'}

--- a/src/components/library/BooksCollection.tsx
+++ b/src/components/library/BooksCollection.tsx
@@ -2,7 +2,7 @@
 import React, { useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Star, BookOpen, Eye, Library, Download } from 'lucide-react';
+import { Star, Eye, Library } from 'lucide-react';
 import { useLibraryBooks } from '@/hooks/useLibraryBooks';
 import InternetArchiveReader from './InternetArchiveReader';
 import type { Book } from '@/hooks/useLibraryBooks';
@@ -172,27 +172,6 @@ const BooksCollection = ({
                     </div>
                   </div>
                   
-                  {/* Hover Overlay */}
-                  <div className="absolute inset-0 bg-black bg-opacity-60 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center gap-2">
-                    <Button
-                      onClick={() => handleReadBook(book)}
-                      className="bg-white text-black hover:bg-gray-100 transform scale-90 group-hover:scale-100 transition-transform duration-300"
-                      size="sm"
-                    >
-                      <Eye className="w-4 h-4 mr-1" />
-                      Read
-                    </Button>
-                    {book.pdf_url && (
-                      <Button
-                        onClick={() => handleDownloadPDF(book)}
-                        className="bg-green-600 text-white hover:bg-green-700 transform scale-90 group-hover:scale-100 transition-transform duration-300"
-                        size="sm"
-                      >
-                        <Download className="w-4 h-4 mr-1" />
-                        Download
-                      </Button>
-                    )}
-                  </div>
                 </div>
 
                 <CardContent className="p-4 space-y-3">
@@ -225,26 +204,7 @@ const BooksCollection = ({
                   )}
 
                   {/* Action Buttons */}
-                  <div className="flex gap-2 pt-2">
-                    <Button
-                      onClick={() => handleReadBook(book)}
-                      className="flex-1 bg-blue-600 hover:bg-blue-700 text-white"
-                      size="sm"
-                    >
-                      <Eye className="w-4 h-4 mr-1" />
-                      Read Now
-                    </Button>
-                    {book.pdf_url && (
-                      <Button
-                        onClick={() => handleDownloadPDF(book)}
-                        className="flex-1 bg-green-600 hover:bg-green-700 text-white"
-                        size="sm"
-                      >
-                        <Download className="w-4 h-4 mr-1" />
-                        Download PDF
-                      </Button>
-                    )}
-                  </div>
+                  <div className="flex gap-2 pt-2"></div>
                 </CardContent>
               </Card>
             ))}

--- a/src/pages/Bookshelf.tsx
+++ b/src/pages/Bookshelf.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { BookOpen, Download, Play, MessageCircle, Search, Filter } from "lucide-react";
+import { BookOpen, MessageCircle, Search, Filter } from "lucide-react";
 import { useUserBooks, useUpdateBookStatus } from "@/hooks/useBooks";
 import type { UserBook } from "@/hooks/useBooks";
 import { Link } from "react-router-dom";
@@ -247,15 +247,7 @@ const Bookshelf = () => {
                     </div>
 
                     {/* Action Buttons */}
-                    <div className="flex gap-2">
-                      <Button variant="outline" className="flex-1" size="sm">
-                        <Play className="w-4 h-4 mr-1" />
-                        Read
-                      </Button>
-                      <Button variant="outline" size="sm">
-                        <Download className="w-4 h-4" />
-                      </Button>
-                    </div>
+                    <div className="flex gap-2"></div>
                   </CardContent>
                 </Card>
               );


### PR DESCRIPTION
## Summary
- strip read now buttons from BookListView and BookGridView
- remove download functionality from BookGridView and BooksCollection
- drop read/download buttons from Bookshelf page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619770daec8320baba23280b218acd