### PR TITLE
Add book details page and update library buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import Quotes from "./pages/Quotes";
 import NotFound from "./pages/NotFound";
 import Dashboard from "./pages/Dashboard";
 import Profile from "./pages/Profile";
+import BookDetails from "./pages/BookDetails";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -65,6 +66,7 @@ const App = () => (
                     </ProtectedRoute>
                   } />
                   <Route path="/library" element={<BookLibrary />} />
+                  <Route path="/books/:id" element={<BookDetails />} />
                   <Route path="/groups" element={
                     <ProtectedRoute>
                       <ReadingGroups />

--- a/src/components/library/BookCardGrid.tsx
+++ b/src/components/library/BookCardGrid.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 
 interface Book {
   id: number;
@@ -55,14 +56,11 @@ const BookCardGrid: React.FC = () => {
               </p>
             </CardContent>
             <CardFooter className="pt-0">
-              <Button
-                size="sm"
-                onClick={() => markAsRead(book.id)}
-                disabled={readIds.includes(book.id)}
-                className="ml-auto bg-amber-600 hover:bg-amber-700"
-              >
-                {readIds.includes(book.id) ? "Read" : "Mark as Read"}
-              </Button>
+              <Link to={`/books/${book.id}`} className="ml-auto">
+                <Button size="sm" className="bg-amber-600 hover:bg-amber-700">
+                  About
+                </Button>
+              </Link>
             </CardFooter>
           </Card>
         ))}

--- a/src/components/library/BookGrid.tsx
+++ b/src/components/library/BookGrid.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Link } from 'react-router-dom';
 import { BookOpen } from 'lucide-react';
 import { useBooksByGenre, useGenres } from '@/hooks/useLibraryBooks';
 import type { Book, Genre } from '@/hooks/useLibraryBooks';
@@ -76,14 +77,11 @@ const BookGrid = () => {
               )}
             </CardContent>
             <CardFooter className="pt-0">
-              <Button
-                size="sm"
-                onClick={() => markAsRead(book.id)}
-                disabled={readIds.includes(book.id)}
-                className="ml-auto bg-amber-600 hover:bg-amber-700"
-              >
-                {readIds.includes(book.id) ? "Read" : "Mark as Read"}
-              </Button>
+              <Link to={`/books/${book.id}`} className="ml-auto">
+                <Button size="sm" className="bg-amber-600 hover:bg-amber-700">
+                  About
+                </Button>
+              </Link>
             </CardFooter>
           </Card>
         ))}

--- a/src/components/library/BookGridView.tsx
+++ b/src/components/library/BookGridView.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Star, StarHalf, ExternalLink, Eye } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import BookDetailModal from './BookDetailModal';
 import BookReader from './BookReader';
 import type { Book } from '@/hooks/useLibraryBooks';
@@ -156,15 +157,12 @@ const BookGridView = ({ books }: BookGridViewProps) => {
             <CardFooter className="p-4 pt-0 space-y-2">
               {/* Action Buttons */}
               <div className="flex gap-2 w-full">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleViewBook(book)}
-                  className="flex-1"
-                >
-                  <Eye className="w-4 h-4 mr-1" />
-                  Details
-                </Button>
+                <Link to={`/books/${book.id}`} className="flex-1">
+                  <Button variant="outline" size="sm" className="w-full">
+                    <Eye className="w-4 h-4 mr-1" />
+                    About
+                  </Button>
+                </Link>
               </div>
 
               {/* External Link */}

--- a/src/components/library/BooksCollection.tsx
+++ b/src/components/library/BooksCollection.tsx
@@ -6,6 +6,7 @@ import { Star, Eye, Library } from 'lucide-react';
 import { useLibraryBooks } from '@/hooks/useLibraryBooks';
 import InternetArchiveReader from './InternetArchiveReader';
 import type { Book } from '@/hooks/useLibraryBooks';
+import { Link } from 'react-router-dom';
 
 interface BooksCollectionProps {
   searchQuery: string;
@@ -204,7 +205,13 @@ const BooksCollection = ({
                   )}
 
                   {/* Action Buttons */}
-                  <div className="flex gap-2 pt-2"></div>
+                  <div className="flex gap-2 pt-2">
+                    <Link to={`/books/${book.id}`} className="flex-1">
+                      <Button variant="outline" size="sm" className="w-full">
+                        About
+                      </Button>
+                    </Link>
+                  </div>
                 </CardContent>
               </Card>
             ))}

--- a/src/hooks/useBookById.ts
+++ b/src/hooks/useBookById.ts
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { Book } from './useLibraryBooks';
+
+export const useBookById = (id?: string) => {
+  return useQuery({
+    queryKey: ['book', id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('books_library')
+        .select(`
+          id,
+          title,
+          author,
+          genre,
+          description,
+          author_bio,
+          cover_image_url,
+          pdf_url,
+          price,
+          amazon_url,
+          google_books_url,
+          internet_archive_url,
+          isbn,
+          publication_year,
+          pages,
+          language,
+          created_at
+        `)
+        .eq('id', id)
+        .single();
+
+      if (error) {
+        console.error('Error fetching book:', error);
+        throw error;
+      }
+
+      if (!data) return null;
+
+      return {
+        id: data.id,
+        title: data.title,
+        author: data.author || 'Unknown Author',
+        genre: data.genre,
+        description: data.description,
+        author_bio: data.author_bio,
+        cover_image_url: data.cover_image_url,
+        ebook_url: data.pdf_url,
+        pdf_url: data.pdf_url,
+        price: data.price,
+        amazon_url: data.amazon_url,
+        google_books_url: data.google_books_url,
+        internet_archive_url: data.internet_archive_url,
+        isbn: data.isbn,
+        publication_year: data.publication_year,
+        pages: data.pages,
+        language: data.language,
+        rating: Math.random() * 2 + 3.5,
+        created_at: data.created_at || new Date().toISOString(),
+      } as Book;
+    },
+  });
+};

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -1,0 +1,133 @@
+import { Link, useParams } from 'react-router-dom';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Star, ExternalLink, BookOpen, Calendar, Globe, ArrowLeft } from 'lucide-react';
+import { useBookById } from '@/hooks/useBookById';
+
+const BookDetails = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: book, isLoading } = useBookById(id);
+
+  const renderStars = (rating: number) => {
+    const stars = [];
+    const fullStars = Math.floor(rating);
+    const hasHalfStar = rating % 1 >= 0.5;
+    for (let i = 0; i < fullStars; i++) {
+      stars.push(<Star key={i} className="w-4 h-4 fill-yellow-400 text-yellow-400" />);
+    }
+    if (hasHalfStar) {
+      stars.push(<Star key="half" className="w-4 h-4 fill-yellow-400 text-yellow-400 opacity-50" />);
+    }
+    const remainingStars = 5 - fullStars - (hasHalfStar ? 1 : 0);
+    for (let i = 0; i < remainingStars; i++) {
+      stars.push(<Star key={`empty-${i}`} className="w-4 h-4 text-gray-300" />);
+    }
+    return stars;
+  };
+
+  if (isLoading) {
+    return <div className="min-h-screen flex items-center justify-center">Loading...</div>;
+  }
+
+  if (!book) {
+    return <div className="min-h-screen flex items-center justify-center">Book not found.</div>;
+  }
+
+  const purchaseLinks = [
+    { name: 'Amazon', url: book.amazon_url, icon: ExternalLink },
+    { name: 'Google Books', url: book.google_books_url, icon: ExternalLink },
+    { name: 'Internet Archive', url: book.internet_archive_url, icon: ExternalLink },
+  ].filter(link => link.url);
+
+  return (
+    <div className="min-h-screen py-8 px-4">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <Link to="/library" className="inline-flex items-center text-sm text-blue-600 hover:underline">
+          <ArrowLeft className="w-4 h-4 mr-1" /> Back to Library
+        </Link>
+        <h1 className="text-3xl font-bold text-gray-900">{book.title}</h1>
+        <div className="grid md:grid-cols-3 gap-6">
+          <div className="md:col-span-1">
+            <div className="aspect-[3/4] bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg overflow-hidden shadow-lg">
+              {book.cover_image_url ? (
+                <img src={book.cover_image_url} alt={book.title} className="w-full h-full object-cover" loading="lazy" />
+              ) : (
+                <div className="flex items-center justify-center h-full text-white font-bold text-lg p-4 text-center">
+                  {book.title}
+                </div>
+              )}
+            </div>
+            <div className="mt-4 space-y-3">
+              {book.price && (
+                <div className="text-center">
+                  <span className="text-2xl font-bold text-green-600">${book.price}</span>
+                </div>
+              )}
+              <div className="space-y-2">
+                {purchaseLinks.map(link => (
+                  <Button key={link.name} asChild className="w-full" variant={link.name === 'Amazon' ? 'default' : 'outline'}>
+                    <a href={link.url!} target="_blank" rel="noopener noreferrer">
+                      <link.icon className="w-4 h-4 mr-2" />
+                      {link.name === 'Amazon' ? 'Buy on Amazon' : link.name === 'Google Books' ? 'Google Books' : 'Read Free'}
+                    </a>
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="md:col-span-2 space-y-6">
+            <div>
+              <h3 className="text-xl font-semibold mb-2">by {book.author}</h3>
+              <div className="flex items-center gap-4 mb-4">
+                <div className="flex items-center gap-1">
+                  {renderStars(book.rating || 0)}
+                  <span className="ml-2 font-medium">{(book.rating || 0).toFixed(1)}</span>
+                </div>
+                {book.genre && <Badge variant="secondary">{book.genre}</Badge>}
+              </div>
+              <div className="grid grid-cols-2 gap-4 text-sm text-gray-600 mb-4">
+                {book.publication_year && (
+                  <div className="flex items-center gap-2">
+                    <Calendar className="w-4 h-4" />
+                    <span>Published {book.publication_year}</span>
+                  </div>
+                )}
+                {book.pages && (
+                  <div className="flex items-center gap-2">
+                    <BookOpen className="w-4 h-4" />
+                    <span>{book.pages} pages</span>
+                  </div>
+                )}
+                {book.language && (
+                  <div className="flex items-center gap-2">
+                    <Globe className="w-4 h-4" />
+                    <span>{book.language}</span>
+                  </div>
+                )}
+                {book.isbn && (
+                  <div className="text-xs">
+                    <span className="font-medium">ISBN:</span> {book.isbn}
+                  </div>
+                )}
+              </div>
+            </div>
+            {book.description && (
+              <div>
+                <h4 className="font-semibold text-lg mb-2">About the Book</h4>
+                <p className="text-gray-700 leading-relaxed">{book.description}</p>
+              </div>
+            )}
+            {book.author_bio && (
+              <div>
+                <h4 className="font-semibold text-lg mb-2">About the Author</h4>
+                <p className="text-gray-700 leading-relaxed">{book.author_bio}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BookDetails;


### PR DESCRIPTION
## Summary
- create `useBookById` hook for fetching individual books
- add new `BookDetails` page with comprehensive book info
- link `/books/:id` route
- replace Read buttons with About buttons linking to the new page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686198d27b8c8320b784a733cff7f46a