### PR TITLE
Fix library page visibility

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,25 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sahadhyayi</title>
+    <meta name="description" content="Sahadhyayi - Reviving Deep Reading Culture" />
+    <meta name="author" content="Sahadhyayi" />
+
+    <meta property="og:title" content="Sahadhyayi" />
+    <meta property="og:description" content="Sahadhyayi - Reviving Deep Reading Culture" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a `404.html` fallback for GitHub Pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619983f4048320a55465e6ffbf6d70