### PR TITLE
Simplify library book cards

### DIFF
--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent } from '@/components/ui/card';
 import { BookOpen, Download, Info } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type { Book } from '@/hooks/useLibraryBooks';
-import { renderStars } from './utils/starRating';
 
 interface BookCardProps {
   book: Book;
@@ -78,17 +77,6 @@ const BookCard = ({ book, onDownloadPDF }: BookCardProps) => {
           <h3 className="font-semibold text-lg text-gray-900 line-clamp-2 group-hover:text-amber-600 transition-colors duration-200">
             {book.title}
           </h3>
-          <p className="text-gray-600 text-sm">{book.author}</p>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1">
-            {renderStars(book.rating || 0)}
-            <span className="text-sm font-medium ml-1">{(book.rating || 0).toFixed(1)}</span>
-          </div>
-          {book.price && (
-            <span className="text-lg font-bold text-green-600">${book.price}</span>
-          )}
         </div>
 
         {book.genre && (

--- a/src/components/library/BookGridView.tsx
+++ b/src/components/library/BookGridView.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Star, StarHalf, ExternalLink, Eye } from 'lucide-react';
+import { ExternalLink, Eye } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import BookDetailModal from './BookDetailModal';
 import BookReader from './BookReader';
@@ -40,26 +40,6 @@ const BookGridView = ({ books }: BookGridViewProps) => {
     }
   };
 
-  const renderStars = (rating: number) => {
-    const stars = [];
-    const fullStars = Math.floor(rating);
-    const hasHalfStar = rating % 1 >= 0.5;
-
-    for (let i = 0; i < fullStars; i++) {
-      stars.push(<Star key={i} className="w-4 h-4 fill-yellow-400 text-yellow-400" />);
-    }
-
-    if (hasHalfStar) {
-      stars.push(<StarHalf key="half" className="w-4 h-4 fill-yellow-400 text-yellow-400" />);
-    }
-
-    const remainingStars = 5 - fullStars - (hasHalfStar ? 1 : 0);
-    for (let i = 0; i < remainingStars; i++) {
-      stars.push(<Star key={`empty-${i}`} className="w-4 h-4 text-gray-300" />);
-    }
-
-    return stars;
-  };
 
   const handleShelfChange = (bookId: string, shelf: string) => {
     setUserShelves(prev => ({ ...prev, [bookId]: shelf }));
@@ -126,32 +106,12 @@ const BookGridView = ({ books }: BookGridViewProps) => {
                 {book.title}
               </h3>
 
-              {/* Author */}
-              <p className="text-gray-600 text-sm">{book.author}</p>
-
               {/* Genre and Year */}
               <div className="flex items-center justify-between text-xs text-gray-500">
                 {book.genre && <span className="bg-gray-100 px-2 py-1 rounded">{book.genre}</span>}
                 {book.publication_year && <span>{book.publication_year}</span>}
               </div>
 
-              {/* Rating and Price */}
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-1">
-                  {renderStars(book.rating || 0)}
-                  <span className="text-sm font-medium ml-1">{(book.rating || 0).toFixed(1)}</span>
-                </div>
-                {book.price && (
-                  <span className="text-lg font-bold text-green-600">${book.price}</span>
-                )}
-              </div>
-
-              {/* Description Preview */}
-              {book.description && (
-                <p className="text-sm text-gray-700 line-clamp-2 leading-relaxed">
-                  {book.description}
-                </p>
-              )}
             </CardContent>
 
             <CardFooter className="p-4 pt-0 space-y-2">

--- a/src/components/library/BookListView.tsx
+++ b/src/components/library/BookListView.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
-import { Star, StarHalf, Eye } from 'lucide-react';
+import { Eye } from 'lucide-react';
 import BookReader from './BookReader';
 import type { Book } from '@/hooks/useLibraryBooks';
 
@@ -14,26 +14,6 @@ const BookListView = ({ books }: BookListViewProps) => {
   const [isReaderOpen, setIsReaderOpen] = useState(false);
   const [readerBook, setReaderBook] = useState<Book | null>(null);
 
-  const renderStars = (rating: number) => {
-    const stars = [];
-    const fullStars = Math.floor(rating);
-    const hasHalfStar = rating % 1 >= 0.5;
-
-    for (let i = 0; i < fullStars; i++) {
-      stars.push(<Star key={i} className="w-4 h-4 fill-yellow-400 text-yellow-400" />);
-    }
-
-    if (hasHalfStar) {
-      stars.push(<StarHalf key="half" className="w-4 h-4 fill-yellow-400 text-yellow-400" />);
-    }
-
-    const remainingStars = 5 - fullStars - (hasHalfStar ? 1 : 0);
-    for (let i = 0; i < remainingStars; i++) {
-      stars.push(<Star key={`empty-${i}`} className="w-4 h-4 text-gray-300" />);
-    }
-
-    return stars;
-  };
 
   const handleShelfChange = (bookId: string, shelf: string) => {
     setUserShelves(prev => ({ ...prev, [bookId]: shelf }));
@@ -79,34 +59,17 @@ const BookListView = ({ books }: BookListViewProps) => {
                   <h3 className="font-semibold text-xl text-gray-900 hover:text-orange-600 cursor-pointer">
                     {book.title}
                   </h3>
-                  <p className="text-gray-600 mt-1">by {book.author}</p>
                 </div>
 
-                {/* Rating */}
-                <div className="flex items-center gap-3">
-                  <div className="flex items-center gap-1">
-                    {renderStars(book.rating || 0)}
-                  </div>
-                  <span className="font-medium">{(book.rating || 0).toFixed(1)}</span>
-                  <span className="text-sm text-gray-500">
-                    ({Math.floor(Math.random() * 1000)} ratings)
-                  </span>
-                </div>
-
-                {/* Description */}
-                {book.description && (
-                  <p className="text-gray-700 line-clamp-3 text-sm leading-relaxed">
-                    {book.description}
-                  </p>
-                )}
-
-                {/* Genre */}
+                {/* Genre and Year */}
                 {book.genre && (
                   <div className="flex items-center gap-2">
-                    <span className="text-xs text-gray-500">Genre:</span>
                     <span className="inline-block bg-gray-100 text-gray-700 px-2 py-1 rounded-full text-xs">
                       {book.genre}
                     </span>
+                    {book.publication_year && (
+                      <span className="text-xs text-gray-500">{book.publication_year}</span>
+                    )}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- trim the BookCard to only show title, genre and publication year
- simplify BookGridView and BookListView to match the shorter design
- remove unused star rating imports and helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a009bfc4832098faa653cd035df6