### PR TITLE
Add orange border to sign in

### DIFF
--- a/src/components/navigation/MobileNavMenu.tsx
+++ b/src/components/navigation/MobileNavMenu.tsx
@@ -139,7 +139,7 @@ const MobileNavMenu = ({ isOpen, setIsOpen }: Props) => {
               <Button
                 variant="ghost"
                 onClick={handleSignInClick}
-                className="w-full justify-center text-gray-700 hover:text-orange-700 hover:bg-orange-50 py-2.5"
+                className="w-full justify-center text-gray-700 hover:text-orange-700 hover:bg-orange-50 border-2 border-orange-500 py-2.5"
               >
                 <LogIn className="w-4 h-4 mr-2" />
                 Sign In


### PR DESCRIPTION
## Summary
- add orange border around mobile nav sign in button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862ed9bdd888320a0238a1a70cd3774