### PR TITLE
Fix missing Read More button on Godan book card

### DIFF
--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { BookOpen, Download, Info } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type { Book } from '@/hooks/useLibraryBooks';
@@ -90,6 +91,13 @@ const BookCard = ({ book, onDownloadPDF }: BookCardProps) => {
           </div>
         )}
       </CardContent>
+      <CardFooter className="pt-0 px-4 pb-4">
+        <Link to={`/books/${book.id}`} className="w-full">
+          <Button variant="outline" size="sm" className="w-full">
+            Read More
+          </Button>
+        </Link>
+      </CardFooter>
     </Card>
   );
 };


### PR DESCRIPTION
## Summary
- include CardFooter and Button imports in `BookCard`
- add a persistent **Read More** button so mobile users can open book details

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686303c135f08320a830fdab332b0de8