### PR TITLE
Add canonical tag to 404 and expand SEO metadata

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -4,13 +4,32 @@ interface SEOProps {
   title: string;
   description: string;
   canonical?: string;
+  image?: string;
+  url?: string;
+  type?: string;
 }
 
-const SEO = ({ title, description, canonical }: SEOProps) => (
+const defaultImage = "/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png";
+const defaultUrl = "https://sahadhyayi.com";
+
+const SEO = ({ title, description, canonical, image = defaultImage, url = defaultUrl, type = "website" }: SEOProps) => (
   <Helmet>
     <title>{title}</title>
     <meta name="description" content={description} />
     {canonical && <link rel="canonical" href={canonical} />}
+    <meta property="og:type" content={type} />
+    <meta property="og:url" content={url} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={image} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content={url} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={image} />
   </Helmet>
 );
 

--- a/src/pages/Bookshelf.tsx
+++ b/src/pages/Bookshelf.tsx
@@ -8,6 +8,7 @@ import { BookOpen, MessageCircle, Search, Filter } from "lucide-react";
 import { useUserBooks, useUpdateBookStatus } from "@/hooks/useBooks";
 import type { UserBook } from "@/hooks/useBooks";
 import { Link } from "react-router-dom";
+import SEO from "@/components/SEO";
 
 const Bookshelf = () => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -61,7 +62,13 @@ const Bookshelf = () => {
   }
 
   return (
-    <div className="min-h-screen py-8 px-4">
+    <>
+      <SEO
+        title="My Bookshelf - Track Your Reading | Sahadhyayi"
+        description="Manage your books, track reading progress, and get AI-powered assistance in your personal digital bookshelf."
+        canonical="https://sahadhyayi.com/bookshelf"
+        url="https://sahadhyayi.com/bookshelf" />
+      <div className="min-h-screen py-8 px-4">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
           <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">My Bookshelf</h1>
@@ -256,6 +263,7 @@ const Bookshelf = () => {
         )}
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import WeeklyReadingSummary from '@/components/dashboard/WeeklyReadingSummary';
 import ReadingGoalTracker from '@/components/dashboard/ReadingGoalTracker';
 import EnhancedBookshelf from '@/components/dashboard/EnhancedBookshelf';
 import MyGroups from '@/components/dashboard/MyGroups';
+import SEO from '@/components/SEO';
 
 const Dashboard = () => {
   const { user } = useAuth();
@@ -40,6 +41,11 @@ const Dashboard = () => {
 
   return (
     <SidebarProvider>
+      <SEO
+        title="Dashboard - Overview of Your Reading | Sahadhyayi"
+        description="View your current reads, reading goals, groups, and recommendations on your personal dashboard."
+        canonical="https://sahadhyayi.com/dashboard"
+        url="https://sahadhyayi.com/dashboard" />
       <div className="flex min-h-screen w-full">
         <div className="hidden lg:block w-64 flex-shrink-0">
           <AppSidebar />

--- a/src/pages/Investors.tsx
+++ b/src/pages/Investors.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { TrendingUp, Users, BookOpen, Map, Target, DollarSign, Globe, Calendar } from "lucide-react";
+import SEO from "@/components/SEO";
 
 const Investors = () => {
   const marketStats = [
@@ -98,7 +99,13 @@ const Investors = () => {
   ];
 
   return (
-    <div className="min-h-screen py-8 px-4">
+    <>
+      <SEO
+        title="Invest in Sahadhyayi - Reading Community Platform"
+        description="Learn about our market opportunity, growth plans, and how you can support Sahadhyayi's mission."
+        canonical="https://sahadhyayi.com/investors"
+        url="https://sahadhyayi.com/investors" />
+      <div className="min-h-screen py-8 px-4">
       <div className="max-w-7xl mx-auto">
         {/* Hero Section */}
         <div className="text-center mb-12">
@@ -328,6 +335,7 @@ const Investors = () => {
         </section>
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import SEO from "@/components/SEO";
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,7 +13,13 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <>
+      <SEO
+        title="Page Not Found - Sahadhyayi"
+        description="Sorry, the page you're looking for doesn't exist. Return to the Sahadhyayi home page."
+        canonical="https://sahadhyayi.com/404"
+        url="https://sahadhyayi.com/404" />
+      <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
@@ -21,6 +28,7 @@ const NotFound = () => {
         </a>
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,7 +1,17 @@
 
 import React from "react";
 import { ProfileView } from "@/components/profile/ProfileView";
+import SEO from "@/components/SEO";
 
-const ProfilePage: React.FC = () => <ProfileView />;
+const ProfilePage: React.FC = () => (
+  <>
+    <SEO
+      title="User Profile - Sahadhyayi"
+      description="View and manage your reader profile, update information, and explore your reading activity."
+      canonical="https://sahadhyayi.com/profile"
+      url="https://sahadhyayi.com/profile" />
+    <ProfileView />
+  </>
+);
 
 export default ProfilePage;

--- a/src/pages/Quotes.tsx
+++ b/src/pages/Quotes.tsx
@@ -3,6 +3,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import SEO from '@/components/SEO';
 
 interface Quote {
   id: number;
@@ -26,7 +27,13 @@ const QuotesPage = () => {
   };
 
   return (
-    <div className="min-h-screen py-8 px-4">
+    <>
+      <SEO
+        title="Save Favorite Quotes - Sahadhyayi"
+        description="Store inspiring book quotes, add sources, and revisit them anytime in your personal collection."
+        canonical="https://sahadhyayi.com/quotes"
+        url="https://sahadhyayi.com/quotes" />
+      <div className="min-h-screen py-8 px-4">
       <div className="max-w-xl mx-auto space-y-6">
         <Card>
           <CardHeader>
@@ -56,6 +63,7 @@ const QuotesPage = () => {
         ))}
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/pages/ReaderMap.tsx
+++ b/src/pages/ReaderMap.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Map, Users, MapPin, Search, BookOpen } from "lucide-react";
+import SEO from "@/components/SEO";
 import { useState } from "react";
 
 interface ReaderLocation {
@@ -106,7 +107,13 @@ const ReaderMap = () => {
   const totalGlobalReaders = readerData.reduce((sum, location) => sum + location.totalReaders, 0);
 
   return (
-    <div className="min-h-screen py-8 px-4">
+    <>
+      <SEO
+        title="Reader Map - Find Local Book Communities | Sahadhyayi"
+        description="Discover reading groups near you and see where book lovers are located around the world."
+        canonical="https://sahadhyayi.com/map"
+        url="https://sahadhyayi.com/map" />
+      <div className="min-h-screen py-8 px-4">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
           <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">Reader Map</h1>
@@ -265,6 +272,7 @@ const ReaderMap = () => {
         </Card>
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/pages/ReadingGroups.tsx
+++ b/src/pages/ReadingGroups.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Users, Calendar, Map, Plus } from "lucide-react";
 import { useGroups, useCreateGroup } from "@/hooks/useGroups";
 import GroupCard from "@/components/groups/GroupCard";
+import SEO from "@/components/SEO";
 
 const ReadingGroups = () => {
   const [showCreateGroup, setShowCreateGroup] = useState(false);
@@ -56,7 +57,13 @@ const ReadingGroups = () => {
   };
 
   return (
-    <div className="min-h-screen py-8 px-4">
+    <>
+      <SEO
+        title="Reading Groups - Connect with Fellow Readers | Sahadhyayi"
+        description="Join or create book discussion groups and participate in engaging events with readers who share your interests."
+        canonical="https://sahadhyayi.com/groups"
+        url="https://sahadhyayi.com/groups" />
+      <div className="min-h-screen py-8 px-4">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
           <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">Reading Groups</h1>
@@ -204,6 +211,7 @@ const ReadingGroups = () => {
         </div>
       </div>
     </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- expand `SEO` component with Open Graph & Twitter tags
- add canonical URLs for Bookshelf, Dashboard and Quotes pages
- include SEO metadata for 404 page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653c21d55c83209e440d60f893746d