### PR TITLE
Improve SEO metadata

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,6 @@
 User-agent: *
+Disallow: /dashboard
+Disallow: /profile
+Disallow: /signin
 Allow: /
 Sitemap: https://www.sahadhyayi.com/sitemap.xml

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -4,14 +4,31 @@ interface SEOProps {
   title: string;
   description: string;
   canonical?: string;
+  url?: string;
+  image?: string;
 }
 
-const SEO = ({ title, description, canonical }: SEOProps) => (
-  <Helmet>
-    <title>{title}</title>
-    <meta name="description" content={description} />
-    {canonical && <link rel="canonical" href={canonical} />}
-  </Helmet>
-);
+const DEFAULT_IMAGE = '/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png';
+
+const SEO = ({ title, description, canonical, url, image = DEFAULT_IMAGE }: SEOProps) => {
+  const pageUrl = url || canonical;
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      {canonical && <link rel="canonical" href={canonical} />}
+      <meta property="og:type" content="website" />
+      {pageUrl && <meta property="og:url" content={pageUrl} />}
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={image} />
+      <meta name="twitter:card" content="summary_large_image" />
+      {pageUrl && <meta name="twitter:url" content={pageUrl} />}
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+    </Helmet>
+  );
+};
 
 export default SEO;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -147,6 +147,7 @@ const About = () => {
         title="About Sahadhyayi - Reviving Reading Culture Worldwide"
         description="Learn about Sahadhyayi's mission to revive deep reading culture. Discover how we connect readers globally and promote meaningful literary engagement."
         canonical="https://sahadhyayi.com/about"
+        url="https://sahadhyayi.com/about"
       />
       <script type="application/ld+json">
         {JSON.stringify(structuredData)}

--- a/src/pages/AuthorConnect.tsx
+++ b/src/pages/AuthorConnect.tsx
@@ -107,6 +107,7 @@ const AuthorConnect = () => {
         title="Meet Authors - Connect with Writers & Creators | Sahadhyayi"
         description="Connect with talented authors on Sahadhyayi. Read biographies, schedule live sessions, and discover books by your favorite writers in our author community."
         canonical="https://sahadhyayi.com/authors"
+        url="https://sahadhyayi.com/authors"
       />
       <script type="application/ld+json">
         {JSON.stringify(structuredData)}

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -61,9 +61,17 @@ const BookDetails = () => {
     console.log('Author clicked:', book.author);
   };
 
+  const canonicalUrl = `https://sahadhyayi.com/books/${id}`;
+
   return (
     <>
-      <SEO title={`${book.title} - Sahadhyayi`} description={book.description} />
+      <SEO
+        title={`${book.title} - Sahadhyayi`}
+        description={book.description}
+        canonical={canonicalUrl}
+        url={canonicalUrl}
+        image={book.cover_image_url}
+      />
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
       {/* Header */}
       <div className="bg-white/80 backdrop-blur-sm border-b border-blue-200 sticky top-0 z-10">

--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -60,6 +60,7 @@ const BookLibrary = () => {
         title="Digital Book Library - Browse 10,000+ Books | Sahadhyayi"
         description="Browse our extensive digital library with 10,000+ books across all genres. Find your next great read with free PDFs, community reviews, and personalized recommendations."
         canonical="https://sahadhyayi.com/library"
+        url="https://sahadhyayi.com/library"
       />
       <script type="application/ld+json">
         {JSON.stringify(structuredData)}

--- a/src/pages/Bookshelf.tsx
+++ b/src/pages/Bookshelf.tsx
@@ -65,7 +65,37 @@ const Bookshelf = () => {
     <>
       <SEO
         title="My Bookshelf - Track Your Reading | Sahadhyayi"
-        description="Manage your books, track reading progress, and get AI-powered assistance in your personal digital bookshelf." />
+        description="Manage your books, track reading progress, and get AI-powered assistance in your personal digital bookshelf."
+        canonical="https://sahadhyayi.com/bookshelf"
+        url="https://sahadhyayi.com/bookshelf"
+      />
+      <script type="application/ld+json">
+        {JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'CollectionPage',
+          name: 'My Bookshelf',
+          description:
+            'Manage your books, track reading progress, and get AI-powered assistance in your personal digital bookshelf.',
+          url: 'https://sahadhyayi.com/bookshelf',
+          breadcrumb: {
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+              {
+                '@type': 'ListItem',
+                position: 1,
+                name: 'Home',
+                item: 'https://sahadhyayi.com'
+              },
+              {
+                '@type': 'ListItem',
+                position: 2,
+                name: 'Bookshelf',
+                item: 'https://sahadhyayi.com/bookshelf'
+              }
+            ]
+          }
+        })}
+      </script>
       <div className="min-h-screen py-8 px-4">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -43,7 +43,10 @@ const Dashboard = () => {
     <SidebarProvider>
       <SEO
         title="Dashboard - Overview of Your Reading | Sahadhyayi"
-        description="View your current reads, reading goals, groups, and recommendations on your personal dashboard." />
+        description="View your current reads, reading goals, groups, and recommendations on your personal dashboard."
+        canonical="https://sahadhyayi.com/dashboard"
+        url="https://sahadhyayi.com/dashboard"
+      />
       <div className="flex min-h-screen w-full">
         <div className="hidden lg:block w-64 flex-shrink-0">
           <AppSidebar />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -83,6 +83,7 @@ const Index = () => {
         title="Sahadhyayi - Digital Reading Community & Book Library"
         description="Join Sahadhyayi's vibrant reading community. Discover thousands of books, connect with fellow readers, track your progress, and explore our digital library platform."
         canonical="https://sahadhyayi.com/"
+        url="https://sahadhyayi.com/"
       />
       <script type="application/ld+json">
         {JSON.stringify(structuredData)}

--- a/src/pages/Investors.tsx
+++ b/src/pages/Investors.tsx
@@ -102,7 +102,10 @@ const Investors = () => {
     <>
       <SEO
         title="Invest in Sahadhyayi - Reading Community Platform"
-        description="Learn about our market opportunity, growth plans, and how you can support Sahadhyayi's mission." />
+        description="Learn about our market opportunity, growth plans, and how you can support Sahadhyayi's mission."
+        canonical="https://sahadhyayi.com/investors"
+        url="https://sahadhyayi.com/investors"
+      />
       <div className="min-h-screen py-8 px-4">
       <div className="max-w-7xl mx-auto">
         {/* Hero Section */}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -16,7 +16,10 @@ const NotFound = () => {
     <>
       <SEO
         title="Page Not Found - Sahadhyayi"
-        description="Sorry, the page you're looking for doesn't exist. Return to the Sahadhyayi home page." />
+        description="Sorry, the page you're looking for doesn't exist. Return to the Sahadhyayi home page."
+        canonical="https://sahadhyayi.com/404"
+        url="https://sahadhyayi.com/404"
+      />
       <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -7,7 +7,10 @@ const ProfilePage: React.FC = () => (
   <>
     <SEO
       title="User Profile - Sahadhyayi"
-      description="View and manage your reader profile, update information, and explore your reading activity." />
+      description="View and manage your reader profile, update information, and explore your reading activity."
+      canonical="https://sahadhyayi.com/profile"
+      url="https://sahadhyayi.com/profile"
+    />
     <ProfileView />
   </>
 );

--- a/src/pages/Quotes.tsx
+++ b/src/pages/Quotes.tsx
@@ -30,7 +30,10 @@ const QuotesPage = () => {
     <>
       <SEO
         title="Save Favorite Quotes - Sahadhyayi"
-        description="Store inspiring book quotes, add sources, and revisit them anytime in your personal collection." />
+        description="Store inspiring book quotes, add sources, and revisit them anytime in your personal collection."
+        canonical="https://sahadhyayi.com/quotes"
+        url="https://sahadhyayi.com/quotes"
+      />
       <div className="min-h-screen py-8 px-4">
       <div className="max-w-xl mx-auto space-y-6">
         <Card>

--- a/src/pages/ReaderMap.tsx
+++ b/src/pages/ReaderMap.tsx
@@ -110,7 +110,10 @@ const ReaderMap = () => {
     <>
       <SEO
         title="Reader Map - Find Local Book Communities | Sahadhyayi"
-        description="Discover reading groups near you and see where book lovers are located around the world." />
+        description="Discover reading groups near you and see where book lovers are located around the world."
+        canonical="https://sahadhyayi.com/map"
+        url="https://sahadhyayi.com/map"
+      />
       <div className="min-h-screen py-8 px-4">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">

--- a/src/pages/ReadingGroups.tsx
+++ b/src/pages/ReadingGroups.tsx
@@ -60,7 +60,10 @@ const ReadingGroups = () => {
     <>
       <SEO
         title="Reading Groups - Connect with Fellow Readers | Sahadhyayi"
-        description="Join or create book discussion groups and participate in engaging events with readers who share your interests." />
+        description="Join or create book discussion groups and participate in engaging events with readers who share your interests."
+        canonical="https://sahadhyayi.com/groups"
+        url="https://sahadhyayi.com/groups"
+      />
       <div className="min-h-screen py-8 px-4">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -152,7 +152,19 @@ const Reviews = () => {
     <>
       <SEO
         title="Community Reviews"
-        description="Read and share book reviews with the Sahadhyayi community."/>
+        description="Read and share book reviews with the Sahadhyayi community."
+        canonical="https://sahadhyayi.com/reviews"
+        url="https://sahadhyayi.com/reviews"
+      />
+      <script type="application/ld+json">
+        {JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'WebPage',
+          name: 'Community Reviews',
+          description: 'Read and share book reviews with the Sahadhyayi community.',
+          url: 'https://sahadhyayi.com/reviews'
+        })}
+      </script>
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-orange-50">
       <div className="flex max-w-7xl mx-auto py-8 px-4 gap-6">
         

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -99,7 +99,12 @@ const SignIn = () => {
 
   return (
     <>
-      <SEO title="Sign In - Sahadhyayi" description="Access your Sahadhyayi account and continue reading." />
+      <SEO
+        title="Sign In - Sahadhyayi"
+        description="Access your Sahadhyayi account and continue reading."
+        canonical="https://sahadhyayi.com/signin"
+        url="https://sahadhyayi.com/signin"
+      />
       <div className="min-h-screen flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -164,7 +164,12 @@ const SignUp = () => {
 
   return (
     <>
-      <SEO title="Sign Up - Sahadhyayi" description="Create your free Sahadhyayi account to join the reading community." />
+      <SEO
+        title="Sign Up - Sahadhyayi"
+        description="Create your free Sahadhyayi account to join the reading community."
+        canonical="https://sahadhyayi.com/signup"
+        url="https://sahadhyayi.com/signup"
+      />
       <div className="min-h-screen flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">


### PR DESCRIPTION
## Summary
- expand SEO component with Open Graph & Twitter meta tags
- add canonical URLs and structured data across pages
- block dashboard, profile and sign-in from robots
- run build and lint checks

## Testing
- `npm run build`
- `npm run lint`
- `npx -y lighthouse http://localhost:4173 --quiet --chrome-flags="--headless" --output=json --output-path=./dist/lighthouse-report.json` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6865ea53174c832096292ee8c3a3f594