### PR TITLE
Add Gemini training data storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,13 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 ## Adding Books to the Library
 
 To display custom books in the Library section you must populate the `books_library` table in Supabase. See [docs/AddBooksToLibrary.md](docs/AddBooksToLibrary.md) for a step-by-step guide on creating the table and uploading covers and PDFs.
+
+## Training Gemini with your chats
+
+Each chat message you send along with the assistant's reply is stored in a new Supabase table called `gemini_training_data`. These prompt/response pairs can be exported for fine‑tuning by running:
+
+```sh
+node scripts/exportGeminiTrainingData.js
+```
+
+The script creates a `gemini_training_data.json` file that can be used with Google's tuning tools or any other model training pipeline.

--- a/scripts/exportGeminiTrainingData.js
+++ b/scripts/exportGeminiTrainingData.js
@@ -1,0 +1,29 @@
+import { createClient } from '@supabase/supabase-js';
+import fs from 'fs';
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.error('Missing Supabase configuration');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+async function exportData() {
+  const { data, error } = await supabase
+    .from('gemini_training_data')
+    .select('prompt,completion')
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error('Failed to fetch training data:', error);
+    process.exit(1);
+  }
+
+  fs.writeFileSync('gemini_training_data.json', JSON.stringify(data, null, 2));
+  console.log(`Exported ${data.length} samples to gemini_training_data.json`);
+}
+
+exportData();

--- a/src/contexts/ChatbotContext.tsx
+++ b/src/contexts/ChatbotContext.tsx
@@ -1,5 +1,6 @@
 
 import React, { createContext, useContext, useState } from 'react';
+import { useGeminiTraining } from '@/hooks/useGeminiTrainingData';
 
 export interface ChatMessage {
   sender: 'user' | 'bot';
@@ -29,6 +30,7 @@ export const ChatbotProvider: React.FC<{ children: React.ReactNode }> = ({ child
   const [messages, setMessages] = useState<ChatMessage[]>([
     { sender: 'bot', text: 'Hello! I\'m your Book Expert AI assistant. I can help you with book recommendations, literary discussions, reading tips, and more. What would you like to know?' }
   ]);
+  const { saveSample } = useGeminiTraining();
 
   const toggleChat = () => setIsOpen((prev) => !prev);
   const closeChat = () => setIsOpen(false);
@@ -75,6 +77,9 @@ export const ChatbotProvider: React.FC<{ children: React.ReactNode }> = ({ child
         'Sorry, I could not process your request at the moment.';
 
       setMessages((prev) => [...prev, { sender: 'bot', text: reply }]);
+      saveSample(text, reply).catch((err) =>
+        console.error('Failed to save training data:', err),
+      );
     } catch (error) {
       console.error('Chatbot error:', error);
       setMessages((prev) => [

--- a/src/hooks/useGeminiTrainingData.ts
+++ b/src/hooks/useGeminiTrainingData.ts
@@ -1,0 +1,23 @@
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+
+/**
+ * Save a prompt/response pair for later Gemini training.
+ */
+export const useGeminiTraining = () => {
+  const { user } = useAuth();
+
+  const saveSample = async (prompt: string, completion: string) => {
+    try {
+      await supabase.from('gemini_training_data').insert({
+        user_id: user?.id ?? null,
+        prompt,
+        completion,
+      });
+    } catch (error) {
+      console.error('Error saving Gemini training data:', error);
+    }
+  };
+
+  return { saveSample };
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -583,6 +583,30 @@ export type Database = {
           },
         ]
       }
+      gemini_training_data: {
+        Row: {
+          id: string
+          user_id: string | null
+          prompt: string
+          completion: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          prompt: string
+          completion: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          prompt?: string
+          completion?: string
+          created_at?: string
+        }
+        Relationships: []
+      }
       user_profile: {
         Row: {
           bio: string | null

--- a/supabase/migrations/20250703120000-add-gemini-training-data.sql
+++ b/supabase/migrations/20250703120000-add-gemini-training-data.sql
@@ -1,0 +1,16 @@
+-- Create table to store Gemini training samples
+create table if not exists public.gemini_training_data (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete set null,
+  prompt text not null,
+  completion text not null,
+  created_at timestamp with time zone not null default now()
+);
+
+alter table public.gemini_training_data enable row level security;
+
+create policy "Allow insert own training data" on public.gemini_training_data
+  for insert with check (auth.uid() = user_id);
+
+create policy "Select own training data" on public.gemini_training_data
+  for select using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add a migration to create `gemini_training_data`
- expose `gemini_training_data` types
- hook to save chat pairs for training
- record chat pairs in `ChatbotContext`
- script to export stored training data
- document Gemini training in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686624720c748320985010fac6f3a7fe