### PR TITLE
Fix logout

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -162,6 +162,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         console.error('Error signing out:', error);
         throw error;
       }
+
+      // Explicitly remove persisted session tokens
+      localStorage.removeItem('sb-rknxtatvlzunatpyqxro-auth-token');
+
       // Ensure local auth state is cleared immediately
       setUser(null);
       setSession(null);


### PR DESCRIPTION
## Summary
- explicitly remove persisted auth token when signing out

## Testing
- `npm install`
- `npm run lint`
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68663187587483208d015b1516ac2967