### PR TITLE
Add color cycle for Book Expert icon and extend timer

### DIFF
--- a/src/components/chatbot/Chatbot.tsx
+++ b/src/components/chatbot/Chatbot.tsx
@@ -14,16 +14,36 @@ const Chatbot = () => {
   const { isOpen, toggleChat, closeChat, messages, sendMessage } = useChatbot();
   const [input, setInput] = useState('');
   const [floating, setFloating] = useState(true);
+  const [colorIndex, setColorIndex] = useState(0);
   const [isMinimized, setIsMinimized] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const colorClasses = [
+    'bg-gradient-to-r from-red-500 to-pink-600',
+    'bg-gradient-to-r from-orange-500 to-yellow-500',
+    'bg-gradient-to-r from-green-500 to-emerald-600',
+    'bg-gradient-to-r from-blue-500 to-indigo-600',
+  ];
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isOpen]);
 
   useEffect(() => {
-    const timer = setTimeout(() => setFloating(false), 10000);
-    return () => clearTimeout(timer);
+    const colorInterval = setInterval(() => {
+      setColorIndex((prev) => (prev + 1) % colorClasses.length);
+    }, 1000);
+
+    const stopColorTimer = setTimeout(() => {
+      clearInterval(colorInterval);
+    }, 10000);
+
+    const timer = setTimeout(() => setFloating(false), 60000);
+
+    return () => {
+      clearInterval(colorInterval);
+      clearTimeout(stopColorTimer);
+      clearTimeout(timer);
+    };
   }, []);
 
   const handleSend = () => {
@@ -53,8 +73,8 @@ const Chatbot = () => {
         onClick={toggleChat}
         className={cn(
           'fixed z-50 flex items-center justify-center rounded-full text-white cursor-pointer shadow-lg hover:shadow-xl transition-all duration-300',
-          floating 
-            ? 'animate-pulse bg-gradient-to-r from-amber-500 to-orange-600' 
+          floating
+            ? `animate-pulse ${colorClasses[colorIndex]}`
             : 'bg-gradient-to-r from-gray-700 to-gray-900 hover:from-amber-500 hover:to-orange-600'
         )}
         style={{ width: '56px', height: '56px', bottom: '24px', right: '24px' }}


### PR DESCRIPTION
## Summary
- cycle Book Expert button colors for 10s
- keep floating animation active for 1 minute

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866d938241083209b716501b5bfb1ed