### PR TITLE
Fix fast color cycle on Book Expert

### DIFF
--- a/src/components/chatbot/Chatbot.tsx
+++ b/src/components/chatbot/Chatbot.tsx
@@ -35,7 +35,7 @@ const Chatbot = () => {
   useEffect(() => {
     const colorInterval = setInterval(() => {
       setColorIndex((prev) => (prev + 1) % colorClasses.length);
-    }, 500);
+    }, 2000);
 
     const stopTimeout = setTimeout(() => {
       clearInterval(colorInterval);


### PR DESCRIPTION
## Summary
- slow down color cycling for the Book Expert chatbot so the transition is smoother

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866ebf467688320bb2efada9e9348bb