### PR TITLE
Fix supabase search_path warnings

### DIFF
--- a/supabase/migrations/20250615172119-0225f804-d0b3-47cb-a7d8-22f087942675.sql
+++ b/supabase/migrations/20250615172119-0225f804-d0b3-47cb-a7d8-22f087942675.sql
@@ -19,7 +19,8 @@ BEGIN
   NEW.updated_at = now();
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 DROP TRIGGER IF EXISTS set_profile_updated_at ON public.profiles;
 

--- a/supabase/migrations/20250615205347-294cbf5a-3411-4e04-a6e3-093943aef439.sql
+++ b/supabase/migrations/20250615205347-294cbf5a-3411-4e04-a6e3-093943aef439.sql
@@ -35,7 +35,8 @@ BEGIN
   NEW.last_updated = now();
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 DROP TRIGGER IF EXISTS set_last_updated_user_profile ON public.user_profile;
 

--- a/supabase/migrations/20250620004329-c53c95a9-716c-4616-b791-039eedb4d72b.sql
+++ b/supabase/migrations/20250620004329-c53c95a9-716c-4616-b791-039eedb4d72b.sql
@@ -203,7 +203,8 @@ BEGIN
   NEW.updated_at = now();
   RETURN NEW;
 END;
-$$ language 'plpgsql';
+$$ language 'plpgsql'
+  SET search_path = 'public, pg_catalog';
 
 -- Create triggers for updated_at columns
 CREATE TRIGGER handle_reading_summaries_updated_at


### PR DESCRIPTION
## Summary
- set `search_path` for `update_profile_updated_at`
- set `search_path` for `set_last_updated_user_profile`
- set `search_path` for `handle_updated_at`

These changes fix the linter warning about functions using a mutable search path. To address the remaining warnings (`auth_otp_long_expiry` and `auth_leaked_password_protection`), set the OTP expiry to less than an hour and enable Supabase leaked password protection in the project settings.

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868588921348320986577268463601f