### PR TITLE
Improve sign up validation

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -103,20 +103,31 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (!email || !password) {
         return { error: { message: 'Email and password are required' } as AuthError };
       }
-      
+
       if (password.length < 8) {
         return { error: { message: 'Password must be at least 8 characters long' } as AuthError };
       }
-      
+
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!emailRegex.test(email)) {
         return { error: { message: 'Please enter a valid email address' } as AuthError };
       }
 
-      const redirectUrl = `${window.location.origin}/dashboard`;
-      
+      const emailLower = email.trim().toLowerCase();
+
+      // Check if a user already exists with this email using the admin API
+      const { data: existingUser, error: checkError } = await supabase.auth.admin.getUserByEmail(emailLower);
+      if (checkError) {
+        return { error: checkError };
+      }
+      if (existingUser) {
+        return { error: { message: 'An account with this email already exists. Please sign in.' } as AuthError };
+      }
+
+      const redirectUrl = 'https://www.sahadhyayi.com/signin';
+
       const { error } = await supabase.auth.signUp({
-        email: email.trim().toLowerCase(),
+        email: emailLower,
         password,
         options: {
           emailRedirectTo: redirectUrl,

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -95,8 +95,8 @@ const SignUp = () => {
         // Enhanced error handling with user-friendly messages
         let errorMessage = error.message;
         
-        if (error.message.includes('User already registered')) {
-          errorMessage = 'An account with this email already exists. Please try signing in instead.';
+        if (error.message.includes('User already registered') || error.message.includes('already exists')) {
+          errorMessage = 'An account with this email already exists. Please sign in.';
         } else if (error.message.includes('Invalid email')) {
           errorMessage = 'Please enter a valid email address.';
         } else if (error.message.includes('Password')) {
@@ -104,7 +104,7 @@ const SignUp = () => {
         } else if (error.message.includes('rate limit')) {
           errorMessage = 'Too many attempts. Please wait a moment before trying again.';
         } else if (error.message.includes('email') && error.message.includes('confirm')) {
-          errorMessage = 'Account created successfully! You can now sign in directly - email confirmation is optional.';
+          errorMessage = 'A verification email has been sent to your email.';
           setSuccess(errorMessage);
           
           // Clear form on success
@@ -129,7 +129,7 @@ const SignUp = () => {
         return;
       }
 
-      setSuccess('Account created successfully! You can now sign in.');
+      setSuccess('A verification email has been sent to your email.');
       
       // Clear form on success
       setFormData({


### PR DESCRIPTION
## Summary
- check for existing accounts before signing up
- use Sign Up redirect url to Sahadhyayi sign-in page
- show verification email notice after successful sign up

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686aa184686c8320be3c69398adf5a38