### PR TITLE
Fix Book Expert placeholder

### DIFF
--- a/src/components/chatbot/Chatbot.tsx
+++ b/src/components/chatbot/Chatbot.tsx
@@ -240,7 +240,7 @@ const Chatbot = () => {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyPress={handleKeyPress}
-                placeholder="Ask about books, authors, reading tips..."
+                placeholder="Ask me about books!"
                 className="w-full resize-none rounded-lg border border-gray-300 pl-4 pr-20 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-transparent"
                 rows={1}
                 disabled={isLoading || isRecording || isProcessing}


### PR DESCRIPTION
## Summary
- shrink the Book Expert chat input placeholder text so the text area doesn't show a scrollbar when idle

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686adff48764832090b86d16e8668808