### PR TITLE
Enhance library pagination UX

### DIFF
--- a/src/components/library/BooksCollection.tsx
+++ b/src/components/library/BooksCollection.tsx
@@ -1,5 +1,5 @@
 
-import React, { useMemo, useEffect, useState } from 'react';
+import React, { useMemo, useEffect, useState, useRef } from 'react';
 import { Library, Search, Plus, Trash2 } from 'lucide-react';
 import { usePersonalLibrary, useCleanupUnusedBooks } from '@/hooks/usePersonalLibrary';
 import { useBookSearch } from '@/hooks/useBookSearch';
@@ -59,6 +59,8 @@ const BooksCollection = ({
   const [pageSize, setPageSize] = useState(10);
   const [currentPageAll, setCurrentPageAll] = useState(1);
   const [currentPagePersonal, setCurrentPagePersonal] = useState(1);
+  const allGridRef = useRef<HTMLDivElement>(null);
+  const personalGridRef = useRef<HTMLDivElement>(null);
 
   // Convert personal library to Book format for compatibility
   const personalBooks: Book[] = useMemo(() => {
@@ -325,14 +327,17 @@ const BooksCollection = ({
               </span>
             )}
           </div>
-          <BooksGrid books={paginatedAllBooks} onDownloadPDF={handleDownloadPDF} />
-          <LibraryPagination
-            totalCount={filteredAllBooks.length}
-            currentPage={currentPageAll}
-            pageSize={pageSize}
-            onPageChange={setCurrentPageAll}
-            onPageSizeChange={setPageSize}
-          />
+          <div ref={allGridRef} className="space-y-6">
+            <BooksGrid books={paginatedAllBooks} onDownloadPDF={handleDownloadPDF} />
+            <LibraryPagination
+              totalCount={filteredAllBooks.length}
+              currentPage={currentPageAll}
+              pageSize={pageSize}
+              onPageChange={setCurrentPageAll}
+              onPageSizeChange={setPageSize}
+              scrollTargetRef={allGridRef}
+            />
+          </div>
         </TabsContent>
 
         {user && (
@@ -354,7 +359,7 @@ const BooksCollection = ({
             {isLoadingPersonal ? (
               <LoadingGrid />
             ) : (
-              <div className="space-y-6">
+              <div ref={personalGridRef} className="space-y-6">
                 <BooksGrid
                   books={paginatedPersonalBooks}
                   onDownloadPDF={handleDownloadPDF}
@@ -365,6 +370,7 @@ const BooksCollection = ({
                   pageSize={pageSize}
                   onPageChange={setCurrentPagePersonal}
                   onPageSizeChange={setPageSize}
+                  scrollTargetRef={personalGridRef}
                 />
               </div>
             )}

--- a/src/components/library/LibraryContent.tsx
+++ b/src/components/library/LibraryContent.tsx
@@ -107,7 +107,13 @@ const LibraryContent = ({
 
       {/* Pagination */}
       {filteredBooks.length > 0 && (
-        <LibraryPagination currentPage={1} totalPages={1} />
+        <LibraryPagination
+          totalCount={filteredBooks.length}
+          currentPage={1}
+          pageSize={filteredBooks.length}
+          onPageChange={() => {}}
+          onPageSizeChange={() => {}}
+        />
       )}
     </div>
   );

--- a/src/components/library/LibraryPagination.tsx
+++ b/src/components/library/LibraryPagination.tsx
@@ -22,6 +22,7 @@ interface LibraryPaginationProps {
   pageSize: number;
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number) => void;
+  scrollTargetRef?: React.RefObject<HTMLElement>;
 }
 
 const LibraryPagination: React.FC<LibraryPaginationProps> = ({
@@ -30,6 +31,7 @@ const LibraryPagination: React.FC<LibraryPaginationProps> = ({
   pageSize,
   onPageChange,
   onPageSizeChange,
+  scrollTargetRef,
 }) => {
   const totalPages = Math.ceil(totalCount / pageSize) || 1;
   const [goInput, setGoInput] = useState('');
@@ -39,8 +41,12 @@ const LibraryPagination: React.FC<LibraryPaginationProps> = ({
   const end = Math.min(currentPage * pageSize, totalCount);
 
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  }, [currentPage, pageSize]);
+    if (scrollTargetRef?.current) {
+      scrollTargetRef.current.scrollIntoView({ behavior: 'smooth' });
+    } else {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [currentPage, pageSize, scrollTargetRef]);
 
   const handlePageSizeChange = (value: string) => {
     const size = parseInt(value, 10);
@@ -124,6 +130,7 @@ const LibraryPagination: React.FC<LibraryPaginationProps> = ({
                   <PaginationLink
                     href="#"
                     isActive={page === currentPage}
+                    className={page === currentPage ? 'font-bold' : undefined}
                     onClick={(e) => {
                       e.preventDefault();
                       onPageChange(page);


### PR DESCRIPTION
## Summary
- tweak `LibraryPagination` to scroll to the grid and bold the active page
- use pagination refs in `BooksCollection`
- update `LibraryContent` to match new pagination API

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ae848477083209af918f0c3a4af19