### PR TITLE
Improve community stats CORS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ VITE_GEMINI_API_KEY=your_key_here
 ```
 These values are required for the application to connect to Supabase and for the
 chatbot to fetch responses from the Gemini API. The application will throw an error if any of them are missing.
+Ensure `VITE_SUPABASE_URL` points to the Supabase project hosting the community stats function (e.g. `https://rknxtatvlzunatpyqxro.supabase.co`).
 
 ## How can I deploy this project?
 

--- a/src/hooks/useCommunityStats.ts
+++ b/src/hooks/useCommunityStats.ts
@@ -1,6 +1,10 @@
 
 import { useState, useEffect } from 'react';
 
+const SUPABASE_URL =
+  (import.meta.env.VITE_SUPABASE_URL as string | undefined) ||
+  'https://rknxtatvlzunatpyqxro.supabase.co';
+
 interface CommunityStats {
   totalSignups: number;
   totalVisits: number;
@@ -21,7 +25,7 @@ export const useCommunityStats = () => {
     setError(null);
     
     try {
-      const response = await fetch('https://c31baff7-46f5-4cb4-8fc1-fe1c52fc3fe0.supabase.co/functions/v1/community-stats');
+      const response = await fetch(`${SUPABASE_URL}/functions/v1/community-stats`);
       
       if (!response.ok) {
         throw new Error('Failed to fetch community stats');
@@ -40,7 +44,7 @@ export const useCommunityStats = () => {
   const joinCommunity = async () => {
     try {
       // Simulate joining the community
-      const response = await fetch('https://c31baff7-46f5-4cb4-8fc1-fe1c52fc3fe0.supabase.co/functions/v1/community-stats', {
+      const response = await fetch(`${SUPABASE_URL}/functions/v1/community-stats`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/supabase/functions/community-stats/index.ts
+++ b/supabase/functions/community-stats/index.ts
@@ -1,17 +1,16 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+}
+
 serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 200,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-      },
-    })
+    return new Response(null, { status: 200, headers: corsHeaders })
   }
 
   try {
@@ -34,24 +33,18 @@ serve(async (req) => {
 
     return new Response(JSON.stringify(stats), {
       status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     })
   } catch (error) {
     console.error('Error fetching community stats:', error);
     
-    return new Response(JSON.stringify({ 
-      error: 'Failed to fetch community statistics',
-      totalSignups: 15847,  // fallback values
-      totalVisits: 125000
-    }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-    })
+    return new Response(
+      JSON.stringify({
+        error: 'Failed to fetch community statistics',
+        totalSignups: 15847, // fallback values
+        totalVisits: 125000
+      }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
   }
 })


### PR DESCRIPTION
## Summary
- add shared `corsHeaders` in community stats function
- document `VITE_SUPABASE_URL` requirement in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68704a22e26483209c2d31407e5b694c