### PR TITLE
Configure SonarQube

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,13 @@ node scripts/exportGeminiTrainingData.js
 ```
 
 The script creates a `gemini_training_data.json` file that can be used with Google's tuning tools or any other model training pipeline.
+
+## SonarQube Analysis
+
+This project includes a `sonar-project.properties` configuration file so the code can be analyzed with SonarQube or SonarCloud. Run the scanner locally with:
+
+```sh
+npx sonar-scanner
+```
+
+Ensure you set the appropriate `SONAR_TOKEN` and `SONAR_HOST_URL` environment variables before running the command.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.projectKey=sahadhyayi
+sonar.projectName=Sahadhyayi
+sonar.projectVersion=1.0
+sonar.sourceEncoding=UTF-8
+sonar.sources=src
+sonar.exclusions=node_modules/**,dist/**,public/**
+sonar.tests=src
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.tsconfigPath=tsconfig.json


### PR DESCRIPTION
## Summary
- add `sonar-project.properties` for SonarQube scanning
- document how to run SonarQube scanner

## Testing
- `npm run lint`
- `npm run build`
- `npx --yes sonar-scanner` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6870c36ccad08320a72828e2faf9e1d6