### PR TITLE
Fix header spacing after sign in

### DIFF
--- a/src/pages/AuthorDetails.tsx
+++ b/src/pages/AuthorDetails.tsx
@@ -76,7 +76,7 @@ const AuthorDetails = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 flex items-center justify-center pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 flex items-center justify-center pt-16">
         <div className="animate-pulse text-center">
           <div className="w-16 h-16 bg-orange-200 rounded-full mx-auto mb-4"></div>
           <p className="text-gray-600">Loading author profile...</p>
@@ -87,7 +87,7 @@ const AuthorDetails = () => {
 
   if (!author) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 flex items-center justify-center pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 flex items-center justify-center pt-16">
         <div className="text-center max-w-md mx-auto">
           <div className="w-16 h-16 bg-red-200 rounded-full mx-auto mb-4 flex items-center justify-center">
             <User className="w-8 h-8 text-red-600" />
@@ -122,7 +122,7 @@ const AuthorDetails = () => {
         author={author.name}
       />
 
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-16">
         {/* Header */}
         <div className="bg-white/80 backdrop-blur-sm border-b border-orange-200 sticky top-16 z-10">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">

--- a/src/pages/AuthorProfile.tsx
+++ b/src/pages/AuthorProfile.tsx
@@ -79,7 +79,7 @@ const AuthorProfile = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center pt-16">
         <div className="animate-pulse text-center">
           <div className="w-16 h-16 bg-blue-200 rounded-full mx-auto mb-4"></div>
           <p className="text-gray-600">Loading author profile...</p>
@@ -90,7 +90,7 @@ const AuthorProfile = () => {
 
   if (!author) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center pt-16">
         <div className="text-center">
           <div className="w-16 h-16 bg-red-200 rounded-full mx-auto mb-4 flex items-center justify-center">
             <Users className="w-8 h-8 text-red-600" />
@@ -125,7 +125,7 @@ const AuthorProfile = () => {
         author={author.name}
       />
 
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 pt-16">
         {/* Header */}
         <div className="bg-white/80 backdrop-blur-sm border-b border-blue-200 sticky top-16 z-10">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">

--- a/src/pages/Authors.tsx
+++ b/src/pages/Authors.tsx
@@ -134,7 +134,7 @@ const Authors = () => {
   // Loading state
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-16">
         <div className="container mx-auto px-4 py-8">
           <div className="text-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-600 mx-auto mb-4"></div>
@@ -148,7 +148,7 @@ const Authors = () => {
   // Error state with retry option
   if (error) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-16">
         <div className="container mx-auto px-4 py-8">
           <div className="text-center max-w-md mx-auto">
             <AlertCircle className="w-16 h-16 text-red-500 mx-auto mb-4" />
@@ -192,7 +192,7 @@ const Authors = () => {
         type="website"
       />
 
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-16">
         <div className="container mx-auto px-4 py-8">
           {/* Breadcrumb Navigation */}
           <Breadcrumb items={breadcrumbItems} className="mb-6" />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -33,7 +33,7 @@ const NotFound = () => {
         url="https://sahadhyayi.com/404"
         noIndex={true}
       />
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-20">
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 pt-16">
         <div className="text-center max-w-md mx-auto p-8">
           <div className="mb-8">
             <div className="w-20 h-20 bg-gradient-to-br from-orange-500 to-amber-500 rounded-full flex items-center justify-center mx-auto mb-6 shadow-lg">

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -113,7 +113,7 @@ const SignIn = () => {
         canonical="https://sahadhyayi.com/signin"
         url="https://sahadhyayi.com/signin"
       />
-      <div className="min-h-screen flex items-center justify-center p-4 pt-20">
+      <div className="min-h-screen flex items-center justify-center p-4 pt-16">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
             <CardTitle className="flex items-center justify-center gap-2 text-2xl">

--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -76,7 +76,7 @@ const SocialMedia = () => {
         url="https://sahadhyayi.com/social"
       />
       
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-orange-50 pt-20">
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-orange-50 pt-16">
         {/* Header */}
         <div className="bg-white shadow-sm border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">


### PR DESCRIPTION
## Summary
- trim excessive top padding across pages after login

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870c391fcc88320856f65e70320cf97