### PR TITLE
Implement website visit tracking

### DIFF
--- a/src/hooks/useCommunityStats.ts
+++ b/src/hooks/useCommunityStats.ts
@@ -23,16 +23,33 @@ export const useCommunityStats = () => {
   const fetchStats = async () => {
     setIsLoading(true);
     setError(null);
-    
+
     try {
-      const response = await fetch(`${SUPABASE_URL}/functions/v1/community-stats`);
-      
-      if (!response.ok) {
+      const signupsResponse = await fetch(
+        `${SUPABASE_URL}/functions/v1/community-stats`
+      );
+
+      if (!signupsResponse.ok) {
         throw new Error('Failed to fetch community stats');
       }
-      
-      const data: CommunityStats = await response.json();
-      setStats(data);
+
+      const signupsData: CommunityStats = await signupsResponse.json();
+
+      const visitsResponse = await fetch(
+        `${SUPABASE_URL}/functions/v1/website-clicks`
+      );
+
+      if (!visitsResponse.ok) {
+        throw new Error('Failed to record website visit');
+      }
+
+      const visitData = (await visitsResponse.json()) as { totalVisits: number };
+
+      setStats({
+        totalSignups: signupsData.totalSignups,
+        totalVisits: visitData.totalVisits,
+        lastUpdated: new Date().toISOString()
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
       console.error('Failed to fetch community stats:', err);

--- a/supabase/functions/website-clicks/index.ts
+++ b/supabase/functions/website-clicks/index.ts
@@ -1,0 +1,42 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  try {
+    const { error: insertError } = await supabase.from('website_visits').insert({
+      ip: req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip'),
+      user_agent: req.headers.get('user-agent')
+    });
+    if (insertError) throw insertError;
+
+    const { count, error: countError } = await supabase
+      .from('website_visits')
+      .select('*', { count: 'exact', head: true });
+    if (countError) throw countError;
+
+    return new Response(JSON.stringify({ totalVisits: count }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    console.error('Error recording website visit:', error);
+    return new Response(
+      JSON.stringify({ error: 'Failed to record visit' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/migrations/20250712000000-create-website-visits.sql
+++ b/supabase/migrations/20250712000000-create-website-visits.sql
@@ -1,0 +1,18 @@
+-- Track actual website visits
+CREATE TABLE IF NOT EXISTS public.website_visits (
+  id BIGSERIAL PRIMARY KEY,
+  visited_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  ip TEXT,
+  user_agent TEXT
+);
+
+-- Enable row level security so inserts can be limited if needed
+ALTER TABLE public.website_visits ENABLE ROW LEVEL SECURITY;
+
+-- Allow anyone (even anon) to insert visit records
+CREATE POLICY "Public can record visits" ON public.website_visits
+  FOR INSERT WITH CHECK (true);
+
+-- Only admins can view visit details
+CREATE POLICY "Admins can view visits" ON public.website_visits
+  FOR SELECT USING (public.is_admin());


### PR DESCRIPTION
## Summary
- add Supabase table for website visits
- create new edge function `website-clicks`
- update community stats hook to fetch real visit counts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870cf9930ec832083eb419f4c2ff243