### PR TITLE
Fix client-side routing on direct page loads

### DIFF
--- a/404.html
+++ b/404.html
@@ -19,7 +19,9 @@
     <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
     
     <script>
-      // Redirect all 404s to the main app for client-side routing
+      // Preserve the requested path for client-side routing on GitHub Pages
+      sessionStorage.redirectPath =
+        window.location.pathname + window.location.search + window.location.hash;
       window.location.href = '/';
     </script>
   </head>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,13 @@
 
   <body>
     <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
     <!-- Google Search Console verification (replace with your actual verification code) -->
     <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
## Summary
- persist requested path in `404.html` for GitHub Pages
- restore preserved path in `index.html` before loading the app

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870d06a42c08320a79ea7353f5d6a80