### PR TITLE
Improve accessibility with skip link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,7 @@ function App() {
               <div className="min-h-screen bg-background flex flex-col">
                 <Navigation />
                 <ScrollToTop />
-                <main className="flex-1 pt-16">
+                <main id="main-content" className="flex-1 pt-16">
                   <Routes>
                     <Route path="/" element={<Index />} />
                     <Route path="/library" element={<BookLibrary />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -60,11 +60,20 @@ const Navigation = () => {
   };
 
   return (
-    <nav className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-      scrolled 
-        ? 'bg-white/95 backdrop-blur-md shadow-lg border-b border-gray-200' 
-        : 'bg-white/90 backdrop-blur-sm'
-    }`}>
+    <nav
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
+        scrolled
+          ? 'bg-white/95 backdrop-blur-md shadow-lg border-b border-gray-200'
+          : 'bg-white/90 backdrop-blur-sm'
+      }`}
+    >
+      {/* Skip to Content accessibility link */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only absolute left-2 top-2 bg-white text-gray-800 p-2 rounded"
+      >
+        Skip to main content
+      </a>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}


### PR DESCRIPTION
## Summary
- add `id="main-content"` to main element
- include a skip-to-content link in the navigation for keyboard users

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870d095724c8320ac6f3bf0d5f0a709