### PR TITLE
Block Supabase functions in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -18,6 +18,7 @@ Disallow: /dashboard/
 Disallow: /profile/
 Disallow: /settings/
 Disallow: /bookshelf/
+Disallow: /functions/v1/”*
 
 # Disallow authentication pages (to prevent indexing of login/signup forms)
 Disallow: /signin


### PR DESCRIPTION
## Summary
- prevent bots from crawling Supabase edge functions

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68710e94ab188320903d6612228f767f