### PR TITLE
Fix spacing above digital library header

### DIFF
--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -65,8 +65,8 @@ const BookLibrary = () => {
         {JSON.stringify(structuredData)}
       </script>
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-orange-50">
-      {/* Fixed SEO-optimized header with proper spacing - increased margins */}
-      <div className="bg-white/80 backdrop-blur-sm border-b border-amber-200 mt-20 md:mt-24" style={{marginTop: '100px'}}>
+      {/* Fixed SEO-optimized header with proper spacing */}
+      <div className="bg-white/80 backdrop-blur-sm border-b border-amber-200 mt-20 md:mt-24">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 pb-20" style={{paddingTop: '40px', paddingBottom: '40px'}}>
           <div className="text-center">
             <div className="flex items-center justify-center space-x-3 mb-8" style={{marginBottom: '30px', marginTop: '20px'}}>


### PR DESCRIPTION
## Summary
- remove hard-coded margin from digital library page header

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68723f9037508320acdc4a1792ac503c