### PR TITLE
Allow homepage for signed in users; clear auth on logout

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -171,15 +171,37 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const signOut = async () => {
     try {
       console.log('[AUTH] Starting sign out process...');
-      
+
       // Sign out from Supabase (this will trigger the auth state change)
       const { error } = await supabase.auth.signOut();
       if (error) {
         console.error('Error signing out from Supabase:', error);
       }
-      
+
+      // Remove any remaining auth tokens from localStorage
+      if (typeof window !== 'undefined') {
+        Object.keys(localStorage).forEach((key) => {
+          if (key.startsWith('sb-')) {
+            localStorage.removeItem(key);
+          }
+        });
+
+        // Clear cookies
+        document.cookie.split(';').forEach((cookie) => {
+          const eqPos = cookie.indexOf('=');
+          const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
+          document.cookie = `${name.trim()}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+        });
+      }
+
+      // Clear local auth state
+      setUser(null);
+      setSession(null);
+
       console.log('[AUTH] Sign out completed successfully');
-      
+
+      // Redirect to home page after sign out
+      window.location.href = '/';
     } catch (error) {
       console.error('Signout error:', error);
       // Ensure local state is cleared even if there's an error

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,43 +1,17 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BookOpen, Users, Map, Calendar, Star, Headphones, LogIn, UserPlus, User, LogOut } from "lucide-react";
+import { BookOpen, Users, Map, Calendar, Star, Headphones, LogIn, UserPlus, User } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { useProfile } from "@/hooks/useProfile";
 import SEO from "@/components/SEO";
 
 const Index = () => {
-  const { user, signOut } = useAuth();
+  const { user } = useAuth();
   const { data: profile } = useProfile();
   const navigate = useNavigate();
 
-  // If user is logged in, redirect to dashboard only after a delay to prevent flash
-  useEffect(() => {
-    if (user) {
-      const timer = setTimeout(() => {
-        navigate('/dashboard');
-      }, 100);
-      return () => clearTimeout(timer);
-    }
-  }, [user, navigate]);
-
-  // Show loading state during redirect
-  if (user) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-orange-600 mx-auto mb-4"></div>
-          <p className="text-lg text-gray-600">Redirecting to your dashboard...</p>
-        </div>
-      </div>
-    );
-  }
-
-  const handleSignOut = async () => {
-    await signOut();
-    navigate('/');
-  };
 
   const features = [
     {


### PR DESCRIPTION
## Summary
- remove automatic redirect to dashboard on `/`
- wipe local storage and cookies on sign out

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687247d074dc832087e8dfff35d0c8f7