### PR TITLE
Improve library search UI

### DIFF
--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -1,6 +1,6 @@
 
 import * as React from "react"
-import { Search, X, Mic, MicOff } from "lucide-react"
+import { Search, Send, Mic, MicOff } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
@@ -9,42 +9,60 @@ import { useSpeechToText } from "@/hooks/useSpeechToText"
 export interface SearchBarProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
   value: string
   onValueChange: (value: string) => void
+  onSearch?: () => void
 }
 
 const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
-  ({ className, value, onValueChange, ...props }, ref) => {
+  ({ className, value, onValueChange, onSearch, ...props }, ref) => {
     const { isRecording, toggleRecording } = useSpeechToText({
       onTranscript: (text) => onValueChange(text),
       onError: (error) => console.error('Speech recognition error:', error)
     })
 
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        onSearch?.()
+      }
+    }
+
     return (
-      <div className={cn("relative w-full", className)}>
-        <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
-        {value && (
-          <button
-            type="button"
-            onClick={() => onValueChange("")}
-            className="absolute right-10 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        )}
-        <button
-          type="button"
-          onClick={toggleRecording}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
-        >
-          {isRecording ? <MicOff className="h-5 w-5" /> : <Mic className="h-5 w-5" />}
-        </button>
+      <div className={cn('relative w-full', className)}>
         <Input
           ref={ref}
           type="text"
           value={value}
           onChange={(e) => onValueChange(e.target.value)}
-          className={cn("pl-10 pr-16", className)}
+          onKeyDown={handleKeyDown}
+          className="pl-4 pr-24 h-12 text-base rounded-xl shadow-sm"
           {...props}
         />
+        <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onSearch}
+            aria-label="Search"
+            className="p-1 text-gray-500 hover:text-gray-700"
+          >
+            <Search className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={toggleRecording}
+            aria-label="Voice search"
+            className="p-1 text-gray-500 hover:text-gray-700"
+          >
+            {isRecording ? <MicOff className="h-5 w-5" /> : <Mic className="h-5 w-5" />}
+          </button>
+          <button
+            type="button"
+            onClick={onSearch}
+            aria-label="Submit"
+            className="p-1 text-gray-500 hover:text-gray-700"
+          >
+            <Send className="h-5 w-5" />
+          </button>
+        </div>
       </div>
     )
   }

--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -23,6 +23,10 @@ const BookLibrary = () => {
     setPriceRange([0, 100]);
   };
 
+  const handleSearch = () => {
+    setSearchQuery((q) => q.trim());
+  };
+
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -107,8 +111,9 @@ const BookLibrary = () => {
                   <SearchBar
                     value={searchQuery}
                     onValueChange={setSearchQuery}
-                    placeholder="Search books by title, author, or genre..."
-                    className="h-12 text-base bg-white/90 backdrop-blur-sm border-2 border-amber-200 focus-within:border-amber-400 rounded-xl shadow-sm"
+                    onSearch={handleSearch}
+                    placeholder="Search books, authors, genres..."
+                    className="bg-white/90 backdrop-blur-sm border-2 border-amber-200 focus-within:border-amber-400 rounded-xl shadow-sm"
                   />
                 </div>
                 <FilterPopup


### PR DESCRIPTION
## Summary
- add search, voice, and submit icons for library search
- style search input like Book Expert chat
- trim search input when triggered

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872bc94e2e08320943dd39e935ec0d4