### PR TITLE
Remove extra margin above Digital Library header

### DIFF
--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -70,7 +70,7 @@ const BookLibrary = () => {
       </script>
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-orange-50">
       {/* Fixed SEO-optimized header with proper spacing */}
-      <div className="bg-white/80 backdrop-blur-sm border-b border-amber-200 mt-16 md:mt-20" style={{scrollMarginTop: '80px'}}>
+      <div className="bg-white/80 backdrop-blur-sm border-b border-amber-200" style={{scrollMarginTop: '80px'}}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
             <div className="flex items-center justify-center space-x-3 mb-8" style={{marginBottom: '30px', marginTop: '20px'}}>


### PR DESCRIPTION
## Summary
- remove top margin from `Digital Library` header container

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872be8012e883209ab0787f3d4b22e3