### PR TITLE
Add messaging and scheduling dialogs

### DIFF
--- a/src/pages/AuthorDetails.tsx
+++ b/src/pages/AuthorDetails.tsx
@@ -8,6 +8,8 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import SEO from '@/components/SEO';
+import { ChatWindow } from "@/components/social/ChatWindow";
+import { ScheduleSessionDialog } from "@/components/authors/ScheduleSessionDialog";
 import Breadcrumb from '@/components/Breadcrumb';
 import { useAllLibraryBooks } from '@/hooks/useLibraryBooks';
 import { useAuthors } from '@/hooks/useAuthors';
@@ -17,6 +19,7 @@ const AuthorDetails = () => {
   const { data: books, isLoading: booksLoading } = useAllLibraryBooks();
   const { data: authors = [], isLoading: authorsLoading } = useAuthors();
   const [showFullBio, setShowFullBio] = useState(false);
+  const [showChat, setShowChat] = useState(false);
 
   const isLoading = booksLoading || authorsLoading;
 
@@ -199,14 +202,23 @@ const AuthorDetails = () => {
                           <Heart className="w-4 h-4 mr-2" />
                           Follow Author
                         </Button>
-                        <Button variant="outline" className="border-green-300 text-green-700 hover:bg-green-50">
+                        <Button
+                          variant="outline"
+                          className="border-green-300 text-green-700 hover:bg-green-50"
+                          onClick={() => setShowChat(true)}
+                        >
                           <MessageSquare className="w-4 h-4 mr-2" />
                           Message
                         </Button>
-                        <Button variant="outline" className="border-purple-300 text-purple-700 hover:bg-purple-50">
-                          <Calendar className="w-4 h-4 mr-2" />
-                          Schedule Session
-                        </Button>
+                        <ScheduleSessionDialog
+                          author={author}
+                          trigger={
+                            <Button variant="outline" className="border-purple-300 text-purple-700 hover:bg-purple-50">
+                              <Calendar className="w-4 h-4 mr-2" />
+                              Schedule Session
+                            </Button>
+                          }
+                        />
                       </div>
                     </div>
                   </div>
@@ -369,6 +381,7 @@ const AuthorDetails = () => {
           </Tabs>
         </div>
       </div>
+      <ChatWindow friendId={author.id} isOpen={showChat} onClose={() => setShowChat(false)} />
     </>
   );
 };

--- a/src/pages/AuthorProfile.tsx
+++ b/src/pages/AuthorProfile.tsx
@@ -8,6 +8,8 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ChatWindow } from "@/components/social/ChatWindow";
+import { ScheduleSessionDialog } from "@/components/authors/ScheduleSessionDialog";
 import SEO from '@/components/SEO';
 import { useAllLibraryBooks } from '@/hooks/useLibraryBooks';
 
@@ -15,6 +17,8 @@ const AuthorProfile = () => {
   const { authorName } = useParams<{ authorName: string }>();
   const { data: books, isLoading } = useAllLibraryBooks();
   const [showFullBio, setShowFullBio] = useState(false);
+  const [showChat, setShowChat] = useState(false);
+  const chatId = authorName || 'author-profile';
 
   // Find author and their books
   const { author, authorBooks } = useMemo(() => {
@@ -192,14 +196,23 @@ const AuthorProfile = () => {
                           <Users className="w-4 h-4 mr-2" />
                           Follow Author
                         </Button>
-                        <Button variant="outline" className="border-green-300 text-green-700 hover:bg-green-50">
+                        <Button
+                          variant="outline"
+                          className="border-green-300 text-green-700 hover:bg-green-50"
+                          onClick={() => setShowChat(true)}
+                        >
                           <MessageSquare className="w-4 h-4 mr-2" />
                           Message
                         </Button>
-                        <Button variant="outline" className="border-purple-300 text-purple-700 hover:bg-purple-50">
-                          <Calendar className="w-4 h-4 mr-2" />
-                          Schedule Session
-                        </Button>
+                        <ScheduleSessionDialog
+                          author={{ id: chatId, name: author.name, availableSlots: [] }}
+                          trigger={
+                            <Button variant="outline" className="border-purple-300 text-purple-700 hover:bg-purple-50">
+                              <Calendar className="w-4 h-4 mr-2" />
+                              Schedule Session
+                            </Button>
+                          }
+                        />
                       </div>
                     </div>
                   </div>
@@ -387,17 +400,26 @@ const AuthorProfile = () => {
                       <p className="text-gray-700 mb-4">
                         Available for writing consultations, manuscript reviews, and literary guidance sessions.
                       </p>
-                      <Button className="w-full bg-orange-600 hover:bg-orange-700">
-                        <Calendar className="w-4 h-4 mr-2" />
-                        Schedule Consultation
-                      </Button>
+                      <ScheduleSessionDialog
+                        author={{ id: chatId, name: author.name, availableSlots: [] }}
+                        trigger={
+                          <Button className="w-full bg-orange-600 hover:bg-orange-700">
+                            <Calendar className="w-4 h-4 mr-2" />
+                            Schedule Consultation
+                          </Button>
+                        }
+                      />
                     </div>
                     <div>
                       <h4 className="text-lg font-semibold mb-4">Direct Messaging</h4>
                       <p className="text-gray-700 mb-4">
                         Send a message for collaboration opportunities, interviews, or general inquiries.
                       </p>
-                      <Button variant="outline" className="w-full border-green-300 text-green-700 hover:bg-green-50">
+                      <Button
+                        variant="outline"
+                        className="w-full border-green-300 text-green-700 hover:bg-green-50"
+                        onClick={() => setShowChat(true)}
+                      >
                         <MessageSquare className="w-4 h-4 mr-2" />
                         Send Message
                       </Button>
@@ -409,6 +431,7 @@ const AuthorProfile = () => {
           </Tabs>
         </div>
       </div>
+  <ChatWindow friendId={chatId} isOpen={showChat} onClose={() => setShowChat(false)} />
     </>
   );
 };

--- a/src/pages/Authors.tsx
+++ b/src/pages/Authors.tsx
@@ -9,6 +9,8 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { ChatWindow } from "@/components/social/ChatWindow";
+import { ScheduleSessionDialog } from "@/components/authors/ScheduleSessionDialog";
 import SEO from '@/components/SEO';
 import Breadcrumb from '@/components/ui/breadcrumb';
 import { useAuthors, type Author } from '@/hooks/useAuthors';
@@ -22,6 +24,7 @@ const Authors = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedGenre, setSelectedGenre] = useState('all');
   const [bookCountFilter, setBookCountFilter] = useState('all');
+  const [chatAuthor, setChatAuthor] = useState<string | null>(null);
 
   console.log('Authors page state:', { 
     authorsCount: authors.length, 
@@ -339,6 +342,7 @@ interface AuthorCardProps {
 }
 
 const AuthorCard: React.FC<AuthorCardProps> = ({ author, featured }) => {
+  const [showChat, setShowChat] = useState(false);
   const getAuthorInitials = (name: string) => {
     return name.split(' ').map(n => n.charAt(0)).join('').toUpperCase().slice(0, 2);
   };
@@ -428,14 +432,25 @@ const AuthorCard: React.FC<AuthorCardProps> = ({ author, featured }) => {
             </Button>
           </Link>
           <div className="grid grid-cols-2 gap-1">
-            <Button variant="outline" size="sm" className="text-xs border-blue-300 text-blue-700 hover:bg-blue-50">
-              <Clock className="w-3 h-3 mr-1" />
-              Schedule
-            </Button>
-            <Button variant="outline" size="sm" className="text-xs border-green-300 text-green-700 hover:bg-green-50">
+            <ScheduleSessionDialog
+              author={author}
+              trigger={
+                <Button variant="outline" size="sm" className="text-xs border-blue-300 text-blue-700 hover:bg-blue-50">
+                  <Clock className="w-3 h-3 mr-1" />
+                  Schedule
+                </Button>
+              }
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-xs border-green-300 text-green-700 hover:bg-green-50"
+              onClick={() => setShowChat(true)}
+            >
               <MessageSquare className="w-3 h-3 mr-1" />
               Message
             </Button>
+            <ChatWindow friendId={author.id} isOpen={showChat} onClose={() => setShowChat(false)} />
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary
- wire up chat and schedule dialogs in author pages
- add buttons to trigger dialogs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877a6409f908320a89ef45d92a2224d