### PR TITLE
Fix Google Maps API env variable

### DIFF
--- a/src/components/social/ModernGoogleMap.tsx
+++ b/src/components/social/ModernGoogleMap.tsx
@@ -39,7 +39,9 @@ export const ModernGoogleMap: React.FC = () => {
   const [currentBook, setCurrentBook] = useState('');
   const [userLocation, setUserLocation] = useState<{lat: number, lng: number} | null>(null);
 
-  const GOOGLE_MAPS_API_KEY = 'AIzaSyDPBJ3hdp-aILWTyyAJQtDku30yiLA4P2Y';
+  const GOOGLE_MAPS_API_KEY =
+    (import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined) ||
+    'AIzaSyDPBJ3hdp-aILWTyyAJQtDku30yiLA4P2Y';
 
   // Load readers from Supabase with real-time updates
   useEffect(() => {


### PR DESCRIPTION
## Summary
- load GOOGLE_MAPS_API_KEY from environment in `ModernGoogleMap`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d58dc1a0c8320a9101e2c767da3df