### PR TITLE
Fix social page heading overlap

### DIFF
--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -75,7 +75,7 @@ const SocialMedia = () => {
         url="https://sahadhyayi.com/social"
       />
       
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-orange-50">
+      <div className="min-h-screen pt-20 bg-gradient-to-br from-amber-50 via-white to-orange-50">
         {/* Header */}
         <div className="bg-white shadow-sm border-b border-gray-200">
           <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6">


### PR DESCRIPTION
## Summary
- add top padding to SocialMedia page so header doesn't cover the title

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d5b0f0e748320b114432837827155