### PR TITLE
Fix header overlap with top menu

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -110,7 +110,7 @@
 
   body {
     @apply bg-background text-foreground;
-    padding-top: 0 !important;
+    padding-top: 4rem;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
   


### PR DESCRIPTION
## Summary
- adjust global body padding to prevent header overlap with the fixed navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687db7008f3883208c2080ae59e76382