### PR TITLE
Fix duplicate book route and add preview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ These values are required for the application to connect to Supabase and for the
 chatbot to fetch responses from the Gemini API. The application will throw an error if any of them are missing.
 Ensure `VITE_SUPABASE_URL` points to the Supabase project hosting the community stats function (e.g. `https://rknxtatvlzunatpyqxro.supabase.co`).
 
+## Previewing the production build
+
+Run `npm run build` to generate the static assets in the `dist` folder. To test the build locally with history fallback, execute:
+
+```sh
+npm run preview
+```
+
+This serves the `dist` directory with routing support so pages like `/book/123` or `/about` load correctly. If you use another HTTP server, ensure it falls back to `index.html` for unmatched routes.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/c31baff7-46f5-4cb4-8fc1-fe1c52fc3fe0) and click on Share -> Publish.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,7 +116,6 @@ function App() {
                         <Route path="/author/:id" element={<AuthorDetails />} />
                         <Route path="/author-profile/:id" element={<AuthorProfile />} />
                         <Route path="/book/:id" element={<BookDetails />} />
-                        <Route path="/book-details/:id" element={<BookDetails />} />
                         <Route 
                           path="/bookshelf" 
                           element={

--- a/src/components/dashboard/CurrentReads.tsx
+++ b/src/components/dashboard/CurrentReads.tsx
@@ -99,7 +99,7 @@ const CurrentReads: React.FC<CurrentReadsProps> = ({ userId }) => {
             {readingProgress.map((book) => {
               const progressPercent = Math.round((book.current_page / book.total_pages) * 100);
               return (
-                <Card key={book.id} className="p-4 cursor-pointer hover:shadow-md transition-shadow" onClick={() => window.location.href = `/book-details/${book.id}`}>
+                <Card key={book.id} className="p-4 cursor-pointer hover:shadow-md transition-shadow" onClick={() => window.location.href = `/book/${book.id}`}>
                   <div className="flex space-x-3">
                     {book.cover_image_url ? (
                       <img
@@ -143,7 +143,7 @@ const CurrentReads: React.FC<CurrentReadsProps> = ({ userId }) => {
                 const progressPercent = Math.round((book.current_page / book.total_pages) * 100);
                 return (
                   <CarouselItem key={book.id} className="md:basis-1/2 lg:basis-1/3">
-                    <Card className="h-full cursor-pointer hover:shadow-md transition-shadow" onClick={() => window.location.href = `/book-details/${book.id}`}>
+                    <Card className="h-full cursor-pointer hover:shadow-md transition-shadow" onClick={() => window.location.href = `/book/${book.id}`}>
                       <CardContent className="p-4">
                         <div className="flex space-x-4">
                           {book.cover_image_url ? (


### PR DESCRIPTION
## Summary
- removed `/book-details/:id` route duplication
- updated reading links to use new `/book/:id` path
- documented how to preview the production build locally

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dd8e40d44832082a9a06c9a0f4a81