### PR TITLE
Fix social media tab UI

### DIFF
--- a/src/components/social/EnhancedFriendsManager.tsx
+++ b/src/components/social/EnhancedFriendsManager.tsx
@@ -223,15 +223,16 @@ const UserCard: React.FC<UserCardProps> = ({ user, onSendRequest, getInitials })
       </div>
     </div>
     <div className="flex gap-2">
-      <Button 
-        size="sm" 
+      <Button
+        size="sm"
         variant="outline"
+        aria-label="Add friend"
         onClick={() => onSendRequest(user.id, user.full_name || 'User')}
       >
         <UserPlus className="w-4 h-4 mr-1" />
         Add
       </Button>
-      <Button size="sm" variant="ghost">
+      <Button size="sm" variant="ghost" aria-label="Message user">
         <MessageCircle className="w-4 h-4" />
       </Button>
     </div>

--- a/src/components/social/FriendsLocationMap.tsx
+++ b/src/components/social/FriendsLocationMap.tsx
@@ -142,7 +142,11 @@ export const FriendsLocationMap: React.FC = () => {
           className="rounded-lg border"
         />
         <div className="flex justify-center mt-4">
-          <Button onClick={shareLocation} className="bg-green-600 hover:bg-green-700">
+          <Button
+            onClick={shareLocation}
+            className="bg-green-600 hover:bg-green-700"
+            aria-label="Share my location"
+          >
             Share My Location
           </Button>
         </div>

--- a/src/components/social/ReadingGroups.tsx
+++ b/src/components/social/ReadingGroups.tsx
@@ -236,7 +236,11 @@ export const ReadingGroups = () => {
             <CardContent className="p-4">
               <div className="flex gap-4">
                 {/* Group Image */}
-                <div className="w-20 h-12 bg-gradient-to-br from-orange-400 to-amber-500 rounded-lg flex-shrink-0"></div>
+                <img
+                  src={group.coverImage}
+                  alt={`${group.name} cover`}
+                  className="w-20 h-12 rounded-lg object-cover flex-shrink-0"
+                />
                 
                 {/* Group Info */}
                 <div className="flex-1">

--- a/src/components/social/SocialFeed.tsx
+++ b/src/components/social/SocialFeed.tsx
@@ -165,7 +165,12 @@ export const SocialFeed = () => {
                   <p className="text-sm text-gray-500">@{post.user.username} • {post.timestamp}</p>
                 </div>
               </div>
-              <Button variant="ghost" size="sm" className="text-gray-400 hover:text-gray-600">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-gray-400 hover:text-gray-600"
+                aria-label="More options"
+              >
                 •••
               </Button>
             </div>

--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -91,19 +91,19 @@ const SocialMedia = () => {
             <TabsList className="grid w-full grid-cols-4 mb-4 sm:mb-6 bg-white shadow-sm">
               <TabsTrigger value="feed" className="flex items-center gap-1 sm:gap-2 py-2 sm:py-3 text-xs sm:text-sm">
                 <MessageCircle className="w-3 h-3 sm:w-4 sm:h-4" />
-                <span className="hidden xs:inline">Feed</span>
+                <span className="hidden sm:inline">Feed</span>
               </TabsTrigger>
               <TabsTrigger value="friends" className="flex items-center gap-1 sm:gap-2 py-2 sm:py-3 text-xs sm:text-sm">
                 <Users className="w-3 h-3 sm:w-4 sm:h-4" />
-                <span className="hidden xs:inline">Friends</span>
+                <span className="hidden sm:inline">Friends</span>
               </TabsTrigger>
               <TabsTrigger value="map" className="flex items-center gap-1 sm:gap-2 py-2 sm:py-3 text-xs sm:text-sm">
                 <MapPin className="w-3 h-3 sm:w-4 sm:h-4" />
-                <span className="hidden xs:inline">Map</span>
+                <span className="hidden sm:inline">Map</span>
               </TabsTrigger>
               <TabsTrigger value="groups" className="flex items-center gap-1 sm:gap-2 py-2 sm:py-3 text-xs sm:text-sm">
                 <UsersIcon className="w-3 h-3 sm:w-4 sm:h-4" />
-                <span className="hidden xs:inline">Groups</span>
+                <span className="hidden sm:inline">Groups</span>
               </TabsTrigger>
             </TabsList>
 


### PR DESCRIPTION
## Summary
- show tab labels on small screens by using `sm:` prefix
- add accessibility labels for post options and friend actions
- use actual cover images in reading groups
- label map sharing button for screen readers

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687df56924288320b707b7690ddb0744