### PR TITLE
Add community membership tracking

### DIFF
--- a/src/components/CommunityStats.tsx
+++ b/src/components/CommunityStats.tsx
@@ -39,9 +39,9 @@ const CommunityStats = () => {
         errors: { ...prev.errors, members: null },
       }));
 
-      // Get count of registered users from profiles table
+      // Get count of community members
       const { count, error } = await supabase
-        .from('profiles')
+        .from('community_users')
         .select('*', { count: 'exact', head: true });
 
       if (error) throw error;
@@ -93,11 +93,12 @@ const CommunityStats = () => {
     getCommunityUserCount();
     getTotalPageViews();
 
-    // Set up real-time updates for user registrations
+    // Set up real-time updates for community membership
     const profilesChannel = supabase
-      .channel('profiles-changes')
-      .on('postgres_changes', 
-        { event: 'INSERT', schema: 'public', table: 'profiles' }, 
+      .channel('community-users-changes')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'community_users' },
         () => {
           getCommunityUserCount();
         }

--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -5,12 +5,16 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { useCommunityStats } from "@/hooks/useCommunityStats";
 import CommunityStats from "@/components/CommunityStats";
+import { useAuth } from "@/contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
 
 const GlobalFooter = () => {
   const [showCount, setShowCount] = useState(false);
   const [hasJoined, setHasJoined] = useState(false);
   const { toast } = useToast();
   const { stats, isLoading, fetchStats, joinCommunity } = useCommunityStats(false);
+  const { user } = useAuth();
+  const navigate = useNavigate();
 
   const handleEmailClick = () => {
     window.location.href = 'mailto:gyan@sahadhyayi.com';
@@ -32,20 +36,31 @@ const GlobalFooter = () => {
 
   const handleJoinCommunity = async () => {
     if (hasJoined) return;
-    
+
+    if (!user) {
+      toast({
+        title: 'Sign in required',
+        description: 'Please sign in to join the Sahadhyayi community.'
+      });
+      navigate('/signin');
+      return;
+    }
+
     const success = await joinCommunity();
     if (success) {
       setHasJoined(true);
       toast({
-        title: "Thanks for joining!",
-        description: "Welcome to the Sahadhyayi reading community!",
+        title: 'Thanks for joining!',
+        description: 'Welcome to the Sahadhyayi reading community!'
       });
+      navigate('/social');
     } else {
       toast({
-        title: "Welcome!",
-        description: "Thanks for your interest in joining our community!",
+        title: 'Welcome!',
+        description: 'Thanks for your interest in joining our community!'
       });
       setHasJoined(true);
+      navigate('/social');
     }
   };
 

--- a/supabase/migrations/20250722000000-add-community-users.sql
+++ b/supabase/migrations/20250722000000-add-community-users.sql
@@ -1,0 +1,13 @@
+-- Create community_users table
+CREATE TABLE IF NOT EXISTS public.community_users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id),
+  joined_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  UNIQUE (user_id)
+);
+
+ALTER TABLE public.community_users ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users manage membership" ON public.community_users
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add `community_users` table migration
- track membership via Supabase in `useCommunityStats`
- update stats component to read from new table
- require sign in to join community in footer

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e3a109e248320966cb0e73a8fe9ca