### PR TITLE
Add website visit ID reset guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,7 @@ npx sonar-scanner
 ```
 
 Ensure you set the appropriate `SONAR_TOKEN` and `SONAR_HOST_URL` environment variables before running the command.
+
+## Resetting Website Visit IDs
+
+To clear existing website visit data and restart the auto-incrementing ID counter, execute the SQL commands in [docs/ResetWebsiteVisitIDs.md](docs/ResetWebsiteVisitIDs.md).

--- a/docs/ResetWebsiteVisitIDs.md
+++ b/docs/ResetWebsiteVisitIDs.md
@@ -1,0 +1,10 @@
+# Resetting Website Visit IDs
+
+If you need to clear out the visit history and start the `id` numbering from 1 again, run the following SQL commands against your Supabase database:
+
+```sql
+DELETE FROM public.website_visits;
+ALTER SEQUENCE public.website_visits_id_seq RESTART WITH 1;
+```
+
+The first statement removes all existing rows. The second resets the `BIGSERIAL` sequence used by the `id` column so the next inserted visit will be assigned `id = 1`.


### PR DESCRIPTION
## Summary
- document how to reset the `website_visits` sequence
- reference the new guide from the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e6fd055048320b0fdf993c66331e9