### PR TITLE
Optimize author list rendering

### DIFF
--- a/src/pages/Authors.tsx
+++ b/src/pages/Authors.tsx
@@ -496,7 +496,13 @@ const AuthorCard: React.FC<AuthorCardProps> = ({ author, books, featured }) => {
               <MessageSquare className="w-3 h-3 mr-1" />
               Message
             </Button>
-            <ChatWindow friendId={author.id} isOpen={showChat} onClose={() => setShowChat(false)} />
+            {showChat && (
+              <ChatWindow
+                friendId={author.id}
+                isOpen={showChat}
+                onClose={() => setShowChat(false)}
+              />
+            )}
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary
- lazy load `ChatWindow` component so each author's chat only loads when needed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e72e1c7c8832083f2c5d71fc1512a