### PR TITLE
Fix top spacing on AuthorDetails page

### DIFF
--- a/src/pages/AuthorDetails.tsx
+++ b/src/pages/AuthorDetails.tsx
@@ -163,7 +163,7 @@ const AuthorDetails = () => {
         author={author.name}
       />
 
-      <div className="min-h-screen bg-gradient-to-br from-background via-muted/50 to-muted pt-16">
+      <div className="min-h-screen bg-gradient-to-br from-background via-muted/50 to-muted">
         {/* Page Header */}
         <div className="bg-white/80 backdrop-blur-sm border-b border-border sticky top-16 z-10">
           <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">


### PR DESCRIPTION
## Summary
- remove extra padding from AuthorDetails page to avoid double spacing under the navigation bar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688167ec1ac08320ac291c6a97be8caf