### PR TITLE
Fix join community prompt flow

### DIFF
--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -40,6 +40,10 @@ const GlobalFooter = () => {
     if (hasJoined) return;
 
     if (!user) {
+      // Remember intent to join after the user signs in
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('joinCommunityAfterSignIn', 'true');
+      }
       setShowSignIn(true);
       return;
     }

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useAuth } from '@/contexts/AuthContext';
 import { LogIn, Mail, Lock } from 'lucide-react';
+import { useCommunityStats } from '@/hooks/useCommunityStats';
 import SEO from '@/components/SEO';
 
 const SignIn = () => {
@@ -20,15 +21,27 @@ const SignIn = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { user, signIn } = useAuth();
+  const { joinCommunity } = useCommunityStats(false);
 
   // Redirect if already signed in
   useEffect(() => {
+    const joinAfterSignIn = localStorage.getItem('joinCommunityAfterSignIn') === 'true';
+
     if (user) {
+      if (joinAfterSignIn) {
+        // Clear the flag and join the community automatically
+        localStorage.removeItem('joinCommunityAfterSignIn');
+        joinCommunity().then(() => {
+          navigate('/social', { replace: true });
+        });
+        return;
+      }
+
       // Get the intended destination from location state, default to dashboard
       const from = location.state?.from?.pathname || '/dashboard';
       navigate(from, { replace: true });
     }
-  }, [user, navigate, location.state]);
+  }, [user, navigate, location.state, joinCommunity]);
 
   const validateForm = () => {
     if (!formData.email?.trim() || !formData.password) {


### PR DESCRIPTION
## Summary
- remember when a user attempts to join before signing in
- auto-join community after a successful sign in

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68819a795d408320a15597171784bc8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users who attempt to join the community while not signed in will now automatically join the community and be redirected to the social page after signing in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->