### PR TITLE
Improve mobile menu visibility

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -171,7 +171,8 @@ const Navigation = () => {
                 variant="ghost"
                 size="sm"
                 onClick={() => setIsOpen(!isOpen)}
-                className="p-2"
+                className="p-2 border-2 border-orange-500 text-orange-600 hover:bg-orange-50"
+                aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
               >
                 {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
               </Button>


### PR DESCRIPTION
## Summary
- highlight the mobile menu button with an orange border and text color
- add aria-label for better accessibility

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68819ad64b308320b53bb56c534d9e77