### PR TITLE
Implement scroll position restoration for library

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,11 +1,16 @@
-import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const ScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+    if ('scrollRestoration' in window.history) {
+      window.history.scrollRestoration = 'manual';
+    }
+    const stored = sessionStorage.getItem(`scroll-${pathname}`);
+    const y = stored ? parseInt(stored, 10) : 0;
+    window.scrollTo({ top: y, left: 0, behavior: 'auto' });
   }, [pathname]);
 
   return null;

--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { BookOpen, Users } from 'lucide-react';
 import { SearchBar } from '@/components/ui/search-bar';
 import FilterPopup from '@/components/library/FilterPopup';
@@ -14,6 +14,17 @@ const BookLibrary = () => {
   const [selectedYear, setSelectedYear] = useState<string>('');
   const [selectedLanguage, setSelectedLanguage] = useState<string>('All');
   const [priceRange, setPriceRange] = useState<[number, number]>([0, 100]);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem('scroll-/library');
+    if (stored) {
+      const y = parseInt(stored, 10);
+      window.scrollTo(0, y);
+    }
+    return () => {
+      sessionStorage.setItem('scroll-/library', String(window.scrollY));
+    };
+  }, []);
 
   const handleClearFilters = () => {
     setSelectedGenre('All');


### PR DESCRIPTION
## Summary
- store & restore library scroll position via sessionStorage
- update ScrollToTop to use manual restoration and saved state

## Testing
- `npm run lint` *(fails: no-useless-escape errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882ac93871483208b2ad1510c00f319