### PR TITLE
Enable interactive genre filtering

### DIFF
--- a/src/components/library/BooksCollection.tsx
+++ b/src/components/library/BooksCollection.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useEffect, useState, useRef } from 'react';
 import { Library, Search, Plus, Trash2 } from 'lucide-react';
 import { usePersonalLibrary, useCleanupUnusedBooks } from '@/hooks/usePersonalLibrary';
 import { useBookSearch } from '@/hooks/useBookSearch';
-import { useAllLibraryBooks } from '@/hooks/useLibraryBooks';
+import { useBooksByGenre } from '@/hooks/useLibraryBooks';
 import type { Book } from '@/hooks/useLibraryBooks';
 import BooksGrid from './BooksGrid';
 import LoadingGrid from './LoadingGrid';
@@ -44,7 +44,7 @@ const BooksCollection = ({
   const { user } = useAuth();
   
   // All library books (global)
-  const { data: allLibraryBooks = [], isLoading: isLoadingAll, refetch: refetchAll } = useAllLibraryBooks();
+  const { data: allLibraryBooks = [], isLoading: isLoadingAll, refetch: refetchAll } = useBooksByGenre(selectedGenre);
   
   // Personal library (user-specific)
   const { data: personalLibrary = [], isLoading: isLoadingPersonal, refetch: refetchPersonal } = usePersonalLibrary();

--- a/src/components/library/GenreSelector.tsx
+++ b/src/components/library/GenreSelector.tsx
@@ -16,7 +16,8 @@ const GenreSelector = ({ genres, selected, onSelect }: GenreSelectorProps) => {
           variant={selected === genre ? 'default' : 'outline'}
           size="sm"
           onClick={() => onSelect(genre)}
-          className={selected === genre ? 'bg-blue-600 hover:bg-blue-700 text-white' : ''}
+          aria-pressed={selected === genre}
+          className={selected === genre ? 'bg-orange-600 hover:bg-orange-700 text-white' : ''}
         >
           {genre}
         </Button>

--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -139,6 +139,8 @@ const BookLibrary = () => {
                     'All',
                     'Science',
                     'Fiction',
+                    'Fantasy',
+                    'Mystery',
                     'Hindi',
                     'Devotional',
                     'Biography',

--- a/src/utils/securityConfig.ts
+++ b/src/utils/securityConfig.ts
@@ -124,7 +124,7 @@ export class SecurityMiddleware {
     if (!userAgent || typeof userAgent !== 'string') return 'Unknown';
     
     return userAgent
-      .replace(/[<>'\"&]/g, '')
+      .replace(/[<>'"&]/g, '')
       .substring(0, 200);
   }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -14,7 +14,7 @@ export const encodeHTML = (str: string): string => {
     '=': '&#x3D;'
   };
   
-  return String(str).replace(/[&<>"'`=\/]/g, (s) => entityMap[s]);
+  return String(str).replace(/[&<>"'`=/]/g, (s) => entityMap[s]);
 };
 
 // Advanced XSS sanitization using DOMPurify-like approach


### PR DESCRIPTION
## Summary
- highlight GenreSelector buttons and add `aria-pressed`
- fetch books per genre in BooksCollection using `useBooksByGenre`
- extend BookLibrary genre list with Fantasy and Mystery
- fix linter warnings in utility regexes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882acbdae4c83209804bbb4ced757ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Fantasy" and "Mystery" as selectable genres in the book library.

* **Improvements**
  * Book listings are now filtered by the selected genre for a more focused browsing experience.
  * Genre selection buttons now use orange styling for the selected state.
  * Improved accessibility with the addition of an aria-pressed attribute to genre buttons.

* **Other**
  * Minor simplifications to internal regular expressions without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->