### PR TITLE
Improve library with lazy loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-tooltip": "^1.1.4",
         "@supabase/supabase-js": "^2.50.0",
         "@tanstack/react-query": "^5.56.2",
+        "@tanstack/react-virtual": "^3.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -2884,6 +2885,33 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/d3-array": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "terser": "^5.43.1",
     "vaul": "^0.9.3",
     "vite-plugin-compression": "^0.5.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@tanstack/react-virtual": "^3.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/components/library/VirtualizedBooksGrid.tsx
+++ b/src/components/library/VirtualizedBooksGrid.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import BookCard from './BookCard';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import type { Book } from '@/hooks/useLibraryBooks';
+
+interface VirtualizedBooksGridProps {
+  books: Book[];
+  fetchMore: () => void;
+  hasMore: boolean;
+  isFetching: boolean;
+  onDownloadPDF: (book: Book) => void;
+}
+
+const ROW_HEIGHT = 340; // approximate height of a row of cards
+const COLUMNS = 4;
+
+const VirtualizedBooksGrid: React.FC<VirtualizedBooksGridProps> = ({
+  books,
+  fetchMore,
+  hasMore,
+  isFetching,
+  onDownloadPDF,
+}) => {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const rowCount = Math.ceil(books.length / COLUMNS);
+
+  const rowVirtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 5,
+  });
+
+  useEffect(() => {
+    const virtualRows = rowVirtualizer.getVirtualItems();
+    if (!virtualRows.length) return;
+    const last = virtualRows[virtualRows.length - 1];
+    if (last.index >= rowCount - 1 && hasMore && !isFetching) {
+      fetchMore();
+    }
+  }, [rowVirtualizer.getVirtualItems(), rowCount, hasMore, isFetching, fetchMore]);
+
+  return (
+    <div ref={parentRef} className="h-[80vh] overflow-auto">
+      <div
+        style={{
+          height: rowVirtualizer.getTotalSize(),
+          position: 'relative',
+        }}
+      >
+        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+          const startIndex = virtualRow.index * COLUMNS;
+          const items = books.slice(startIndex, startIndex + COLUMNS);
+          return (
+            <div
+              key={virtualRow.key}
+              className="absolute left-0 right-0 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+              style={{ transform: `translateY(${virtualRow.start}px)` }}
+            >
+              {items.map((book) => (
+                <BookCard
+                  key={book.id}
+                  book={book}
+                  onDownloadPDF={onDownloadPDF}
+                />
+              ))}
+            </div>
+          );
+        })}
+      </div>
+      {isFetching && (
+        <div className="py-4 flex justify-center">
+          <LoadingSpinner />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VirtualizedBooksGrid;

--- a/src/hooks/useInfiniteLibraryBooks.ts
+++ b/src/hooks/useInfiniteLibraryBooks.ts
@@ -1,0 +1,28 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { Book } from './useLibraryBooks';
+
+const PAGE_SIZE = 20;
+
+const fetchBooksPage = async (from: number): Promise<Book[]> => {
+  const to = from + PAGE_SIZE - 1;
+  const { data, error } = await supabase
+    .from('books_library')
+    .select('*')
+    .order('created_at', { ascending: true })
+    .range(from, to);
+  if (error) {
+    throw error;
+  }
+  return (data || []) as Book[];
+};
+
+export const useInfiniteLibraryBooks = () => {
+  return useInfiniteQuery({
+    queryKey: ['infinite-library-books'],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => fetchBooksPage(pageParam),
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.length * PAGE_SIZE : undefined,
+  });
+};


### PR DESCRIPTION
## Summary
- use `useInfiniteLibraryBooks` hook for paged fetches
- add `VirtualizedBooksGrid` component with react-virtual
- wire up infinite scroll in `BooksCollection`
- install `@tanstack/react-virtual`

## Testing
- `npm run lint` *(fails: no-useless-escape)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882acd08c2c8320a8f9ed883a9fe821