### PR TITLE
Add missing SEO meta tags

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,8 +13,8 @@
     </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sahadhyayi</title>
-    <meta name="description" content="Sahadhyayi - Reviving Deep Reading Culture" />
+    <title>Page Not Found - Sahadhyayi</title>
+    <meta name="description" content="Sorry, the page you requested could not be found. Explore Sahadhyayi's digital reading community for books and discussions." />
     <meta name="author" content="Sahadhyayi" />
 
     <meta property="og:title" content="Sahadhyayi" />

--- a/live-map.html
+++ b/live-map.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Live Location Map</title>
+    <title>Live Location Map - Sahadhyayi</title>
+    <meta name="description" content="Experimental page displaying your live location on a map using browser geolocation and Google Maps." />
     <style>
       html, body {
         height: 100%;

--- a/lovable-website.html
+++ b/lovable-website.html
@@ -14,7 +14,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="color-scheme" content="light">
-    <title>Lovable - Where Reading Becomes an Affair of the Heart</title>
+    <title>Lovable Demo - Sahadhyayi</title>
+    <meta name="description" content="Prototype design for the Lovable reading community experience on Sahadhyayi." />
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {

--- a/search-demo.html
+++ b/search-demo.html
@@ -13,7 +13,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light">
-  <title>Search Highlight Demo</title>
+  <title>Search Highlight Demo - Sahadhyayi</title>
+  <meta name="description" content="Demo page showcasing search term highlighting within text for the Sahadhyayi platform." />
   <style>
     body {
       font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
- add descriptive title and meta description for 404 page
- add descriptive meta tags to search-demo, live-map and lovable demo pages
- run npm lint and npm build

## Testing
- `npm run lint` *(fails: no-useless-escape errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882ad47658483209e8b955b406a6b51