### PR TITLE
Add about-us route and fix lint errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ function App() {
                       <Routes>
                         <Route path="/" element={<Index />} />
                         <Route path="/about" element={<About />} />
+                        <Route path="/about-us" element={<About />} />
                         <Route path="/blog" element={<Blog />} />
                         <Route path="/blog/:slug" element={<BlogPost />} />
                         <Route path="/signin" element={<SignIn />} />

--- a/src/utils/securityConfig.ts
+++ b/src/utils/securityConfig.ts
@@ -124,7 +124,7 @@ export class SecurityMiddleware {
     if (!userAgent || typeof userAgent !== 'string') return 'Unknown';
     
     return userAgent
-      .replace(/[<>'\"&]/g, '')
+      .replace(/[<>'"&]/g, '')
       .substring(0, 200);
   }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -14,7 +14,7 @@ export const encodeHTML = (str: string): string => {
     '=': '&#x3D;'
   };
   
-  return String(str).replace(/[&<>"'`=\/]/g, (s) => entityMap[s]);
+  return String(str).replace(/[&<>"'`=/]/g, (s) => entityMap[s]);
 };
 
 // Advanced XSS sanitization using DOMPurify-like approach


### PR DESCRIPTION
## Summary
- add `/about-us` route that renders the same About page
- fix linter complaints about unnecessary escapes in `securityConfig.ts` and `validation.ts`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882ad57ffb48320867e19f6a924f612