### PR TITLE
Preserve return url after login

### DIFF
--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -265,7 +265,9 @@ const GlobalFooter = () => {
           <Button
             onClick={() => {
               setShowSignIn(false);
-              navigate('/signin');
+              const nextUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+              sessionStorage.setItem('authRedirectScroll', String(window.scrollY));
+              navigate(`/signin?next=${encodeURIComponent(nextUrl)}`);
             }}
             className="w-full bg-orange-600 hover:bg-orange-700"
           >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -59,6 +59,10 @@ const Navigation = () => {
     return email.charAt(0).toUpperCase();
   };
 
+  const signInUrl = `/signin?next=${encodeURIComponent(
+    location.pathname + location.search + location.hash
+  )}`;
+
   return (
     <nav
       className={`fixed top-0 left-0 right-0 z-[100] transition-all duration-300 ${
@@ -147,7 +151,10 @@ const Navigation = () => {
                   </>
                 ) : (
                   <div className="flex items-center space-x-4">
-                    <Link to="/signin">
+                    <Link
+                      to={signInUrl}
+                      onClick={() => sessionStorage.setItem('authRedirectScroll', String(window.scrollY))}
+                    >
                       <Button variant="ghost" size="sm" className="border-2 border-orange-500 text-orange-600 hover:bg-orange-50">
                         Sign In
                       </Button>
@@ -242,7 +249,14 @@ const Navigation = () => {
                 </div>
               ) : (
                 <div className="pt-4 space-y-3 border-t border-gray-200">
-                  <Link to="/signin" onClick={() => setIsOpen(false)} className="block">
+                  <Link
+                    to={signInUrl}
+                    onClick={() => {
+                      sessionStorage.setItem('authRedirectScroll', String(window.scrollY));
+                      setIsOpen(false);
+                    }}
+                    className="block"
+                  >
                     <Button variant="ghost" size="sm" className="w-full justify-center border-2 border-orange-500 text-orange-600 hover:bg-orange-50">
                       Sign In
                     </Button>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { Skeleton } from '@/components/ui/skeleton';
 
 interface ProtectedRouteProps {
@@ -10,6 +10,7 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -27,7 +28,20 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   }
 
   if (!user) {
-    return <Navigate to="/signin" replace />;
+    const nextUrl = `${location.pathname}${location.search}${location.hash}`;
+
+    // store current scroll position so it can be restored after login
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('authRedirectScroll', String(window.scrollY));
+    }
+
+    return (
+      <Navigate
+        to={`/signin?next=${encodeURIComponent(nextUrl)}`}
+        state={{ from: location }}
+        replace
+      />
+    );
   }
 
   return <>{children}</>;

--- a/src/components/books/BookContinuationSection.tsx
+++ b/src/components/books/BookContinuationSection.tsx
@@ -32,7 +32,9 @@ const BookContinuationSection = ({ bookId, bookTitle, genre }: BookContinuationS
                    genre?.toLowerCase().includes('mystery');
 
   const handleSignInPrompt = () => {
-    navigate('/signin');
+    const nextUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    sessionStorage.setItem('authRedirectScroll', String(window.scrollY));
+    navigate(`/signin?next=${encodeURIComponent(nextUrl)}`);
   };
 
   const handleSubmitContinuation = async () => {

--- a/src/components/library/AuthenticatedActions.tsx
+++ b/src/components/library/AuthenticatedActions.tsx
@@ -24,9 +24,16 @@ const AuthenticatedActions: React.FC<AuthenticatedActionsProps> = ({ book, onDow
   };
 
   if (!user) {
+    const signInUrl = `/signin?next=${encodeURIComponent(
+      window.location.pathname + window.location.search + window.location.hash
+    )}`;
     return (
       <div className="flex gap-2 mt-3">
-        <Link to="/signin" className="flex-1">
+        <Link
+          to={signInUrl}
+          className="flex-1"
+          onClick={() => sessionStorage.setItem('authRedirectScroll', String(window.scrollY))}
+        >
           <Button variant="outline" size="sm" className="w-full">
             Sign in to Add to Shelf
           </Button>

--- a/src/components/navigation/AuthSection.tsx
+++ b/src/components/navigation/AuthSection.tsx
@@ -11,7 +11,9 @@ const AuthSection = () => {
   const navigate = useNavigate();
 
   const handleSignInClick = () => {
-    navigate('/signin');
+    const nextUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    sessionStorage.setItem('authRedirectScroll', String(window.scrollY));
+    navigate(`/signin?next=${encodeURIComponent(nextUrl)}`);
   };
 
   const handleSignUpClick = () => {

--- a/src/components/navigation/MobileNavMenu.tsx
+++ b/src/components/navigation/MobileNavMenu.tsx
@@ -33,6 +33,10 @@ const MobileNavMenu = ({ isOpen, onClose }: MobileNavMenuProps) => {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const signInUrl = `/signin?next=${encodeURIComponent(
+    location.pathname + location.search + location.hash
+  )}`;
+
   const handleSignOut = async () => {
     await signOut();
     navigate("/");
@@ -99,7 +103,7 @@ const MobileNavMenu = ({ isOpen, onClose }: MobileNavMenuProps) => {
             </>
           ) : (
             <>
-              <Link to="/signin" className="block px-4 py-2 rounded-md hover:bg-gray-100">
+              <Link to={signInUrl} className="block px-4 py-2 rounded-md hover:bg-gray-100">
                 Sign In
               </Link>
               <Link to="/signup" className="block px-4 py-2 rounded-md hover:bg-gray-100">

--- a/src/hooks/useAutoLogout.ts
+++ b/src/hooks/useAutoLogout.ts
@@ -51,8 +51,12 @@ export const useAutoLogout = () => {
         duration: 5000,
       });
       
-      // Redirect to signin page
-      navigate('/signin', { replace: true });
+      // Redirect to signin page with return URL and scroll position
+      const nextUrl = `${location.pathname}${location.search}${location.hash}`;
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('authRedirectScroll', String(window.scrollY));
+      }
+      navigate(`/signin?next=${encodeURIComponent(nextUrl)}`, { replace: true });
     } catch (error) {
       console.error('[AUTO-LOGOUT] Error during auto logout:', error);
     }
@@ -77,7 +81,11 @@ export const useAutoLogout = () => {
       });
       
       // Redirect to signin page
-      navigate('/signin', { replace: true });
+      const nextUrl = `${location.pathname}${location.search}${location.hash}`;
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('authRedirectScroll', String(window.scrollY));
+      }
+      navigate(`/signin?next=${encodeURIComponent(nextUrl)}`, { replace: true });
     } catch (error) {
       console.error('[AUTO-LOGOUT] Error during session timeout:', error);
     }

--- a/src/pages/CommunityStories.tsx
+++ b/src/pages/CommunityStories.tsx
@@ -51,7 +51,10 @@ const CommunityStories = () => {
                     Sign in to share your own stories and connect with fellow creative readers.
                   </p>
                   <div className="flex gap-4 justify-center">
-                    <Link to="/signin">
+                    <Link
+                      to={`/signin?next=${encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)}`}
+                      onClick={() => sessionStorage.setItem('authRedirectScroll', String(window.scrollY))}
+                    >
                       <Button className="bg-purple-600 hover:bg-purple-700 shadow-lg">
                         Sign In
                       </Button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -115,7 +115,11 @@ const Index = () => {
                   Join Our Reading Community (Free!)
                 </Button>
               </Link>
-              <Link to="/signin" className="w-full sm:w-auto">
+              <Link
+                to={`/signin?next=${encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)}`}
+                className="w-full sm:w-auto"
+                onClick={() => sessionStorage.setItem('authRedirectScroll', String(window.scrollY))}
+              >
                 <Button variant="outline" size="lg" className="w-full sm:w-auto border-orange-400 text-orange-600 hover:bg-orange-50 px-6 sm:px-8 py-3 text-base sm:text-lg shadow-lg">
                   <LogIn className="w-4 h-4 sm:w-5 sm:h-5 mr-2" />
                   Sign In

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -41,9 +41,21 @@ const SignIn = () => {
         return;
       }
 
-      // Get the intended destination from location state, default to dashboard
-      const from = location.state?.from?.pathname || '/dashboard';
+      // Determine the intended destination
+      const searchParams = new URLSearchParams(location.search);
+      const fromQuery = searchParams.get('next');
+      const fromState = location.state?.from?.pathname
+        ? `${location.state.from.pathname}${location.state.from.search}${location.state.from.hash}`
+        : null;
+      const from = fromQuery || fromState || '/dashboard';
+
       navigate(from, { replace: true });
+
+      const scroll = sessionStorage.getItem('authRedirectScroll');
+      if (scroll) {
+        sessionStorage.removeItem('authRedirectScroll');
+        window.scrollTo(0, parseInt(scroll, 10));
+      }
     }
   }, [user, navigate, location.state, joinCommunity]);
 

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -338,7 +338,11 @@ const SignUp = () => {
             <div className="mt-6 text-center">
               <p className="text-sm text-gray-600">
                 Already have an account?{' '}
-                <Link to="/signin" className="text-amber-600 hover:text-amber-700 font-medium">
+                <Link
+                  to={`/signin?next=${encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)}`}
+                  className="text-amber-600 hover:text-amber-700 font-medium"
+                  onClick={() => sessionStorage.setItem('authRedirectScroll', String(window.scrollY))}
+                >
                   Sign in here
                 </Link>
               </p>

--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -49,7 +49,10 @@ const SocialMedia = () => {
                 Please sign in to access Sahadhyayi's Social Reading Community!
               </p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                <Link to="/signin">
+                <Link
+                  to={`/signin?next=${encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)}`}
+                  onClick={() => sessionStorage.setItem('authRedirectScroll', String(window.scrollY))}
+                >
                   <Button className="w-full sm:w-auto bg-orange-600 hover:bg-orange-700">
                     Sign In
                   </Button>

--- a/src/utils/securityConfig.ts
+++ b/src/utils/securityConfig.ts
@@ -123,9 +123,9 @@ export class SecurityMiddleware {
   static sanitizeUserAgent(userAgent: string): string {
     if (!userAgent || typeof userAgent !== 'string') return 'Unknown';
     
-    return userAgent
-      .replace(/[<>'\"&]/g, '')
-      .substring(0, 200);
+      return userAgent
+        .replace(/[<>'"&]/g, '')
+        .substring(0, 200);
   }
 
   static validateReferer(referer: string): boolean {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -14,7 +14,7 @@ export const encodeHTML = (str: string): string => {
     '=': '&#x3D;'
   };
   
-  return String(str).replace(/[&<>"'`=\/]/g, (s) => entityMap[s]);
+  return String(str).replace(/[&<>"'`=/]/g, (s) => entityMap[s]);
 };
 
 // Advanced XSS sanitization using DOMPurify-like approach


### PR DESCRIPTION
## Summary
- capture previous page and scroll position in `ProtectedRoute`
- restore location after sign in using query param
- update auto logout handler to keep return URL
- propagate login return URL through navigation and other links
- clean up regex escapes in utils

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882ad6bacc0832094e2c9df128086c5