### PR TITLE
Improve ARIA labels and contrast

### DIFF
--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -21,8 +21,9 @@ const BackToTopButton = () => {
   return (
     <Button
       onClick={scrollToTop}
-      className="fixed top-20 left-1/2 -translate-x-1/2 rounded-full shadow-lg z-50"
+      className="fixed top-20 left-1/2 -translate-x-1/2 rounded-full shadow-lg z-50 bg-orange-600 text-white hover:bg-orange-700"
       size="icon"
+      aria-label="Back to top"
     >
       <ArrowUp className="w-4 h-4" />
     </Button>

--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -96,7 +96,7 @@ const GlobalFooter = () => {
               />
               <h3 className="text-xl font-bold">Sahadhyayi</h3>
             </div>
-            <p className="text-orange-100 text-sm mb-4">
+            <p className="text-white text-sm mb-4">
               Rediscover the joy of deep reading through community, technology, and shared knowledge.
             </p>
             
@@ -106,14 +106,14 @@ const GlobalFooter = () => {
               size="sm"
               onClick={handleShowStats}
               disabled={isLoading}
-              className="border-orange-200 text-orange-100 hover:bg-orange-500 hover:text-white transition-all mb-4"
+              className="border-orange-200 text-white hover:bg-orange-500 hover:text-white transition-all mb-4"
             >
               <Users className="w-4 h-4 mr-2" />
               {isLoading ? 'Loading...' : showCount ? 'Hide Community Stats' : 'Show Community Stats'}
             </Button>
             
             {!showCount && (
-              <div className="bg-orange-500/30 p-4 rounded-lg backdrop-blur-sm space-y-3 mb-4 text-orange-100">
+              <div className="bg-orange-500/30 p-4 rounded-lg backdrop-blur-sm space-y-3 mb-4 text-white">
                 <p>Click "Show Community Stats" to see how we're growing.</p>
                 <Button
                   onClick={handleJoinCommunity}
@@ -130,7 +130,7 @@ const GlobalFooter = () => {
           {/* Explore Sahadhyayi */}
           <div>
             <h4 className="font-semibold text-lg mb-4">Explore Sahadhyayi</h4>
-            <ul className="space-y-2 text-orange-100">
+            <ul className="space-y-2 text-white">
               <li>
                 <a href="/library" className="hover:text-white transition-colors">
                   Digital Library
@@ -156,7 +156,7 @@ const GlobalFooter = () => {
 
           <div>
             <h4 className="font-semibold text-lg mb-4">Support</h4>
-            <ul className="space-y-2 text-orange-100">
+            <ul className="space-y-2 text-white">
               <li>
                 <a href="/help" className="hover:text-white transition-colors">
                   Help Center
@@ -181,7 +181,7 @@ const GlobalFooter = () => {
 
           <div>
             <h4 className="font-semibold text-lg mb-4">Company</h4>
-            <ul className="space-y-2 text-orange-100">
+            <ul className="space-y-2 text-white">
               <li>
                 <a href="/about" className="hover:text-white transition-colors">
                   About Us
@@ -213,13 +213,13 @@ const GlobalFooter = () => {
 
         {/* Bottom Section */}
         <div className="border-t border-orange-500 mt-8 pt-6 flex flex-col md:flex-row justify-between items-center">
-          <p className="text-orange-100 text-sm">
+          <p className="text-white text-sm">
             © 2024 Sahadhyayi. All rights reserved. Building a global reading community.
           </p>
           <div className="flex space-x-4 mt-4 md:mt-0">
             <button 
               onClick={() => handleSocialClick('Facebook')}
-              className="text-orange-100 hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
+              className="text-white hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
               title="Facebook"
             >
               <span className="sr-only">Facebook</span>
@@ -227,7 +227,7 @@ const GlobalFooter = () => {
             </button>
             <button 
               onClick={() => handleSocialClick('Twitter')}
-              className="text-orange-100 hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
+              className="text-white hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
               title="Twitter"
             >
               <span className="sr-only">Twitter</span>
@@ -235,7 +235,7 @@ const GlobalFooter = () => {
             </button>
             <button 
               onClick={() => handleSocialClick('Instagram')}
-              className="text-orange-100 hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
+              className="text-white hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
               title="Instagram"
             >
               <span className="sr-only">Instagram</span>
@@ -243,7 +243,7 @@ const GlobalFooter = () => {
             </button>
             <button 
               onClick={() => handleSocialClick('LinkedIn')}
-              className="text-orange-100 hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
+              className="text-white hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
               title="LinkedIn"
             >
               <span className="sr-only">LinkedIn</span>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, ChevronDown, User, LogOut, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,8 @@ const Navigation = () => {
   const { user, signOut } = useAuth();
   const location = useLocation();
   const isMobile = useIsMobile();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -35,6 +37,16 @@ const Navigation = () => {
       window.removeEventListener('scroll', handleScroll);
     };
   }, [scrolled]);
+
+  useEffect(() => {
+    if (isMobile) {
+      if (isOpen) {
+        menuRef.current?.querySelector<HTMLElement>('a, button')?.focus();
+      } else {
+        menuButtonRef.current?.focus();
+      }
+    }
+  }, [isOpen, isMobile]);
 
   // Updated navigation items with Authors tab
   const navItems = user ? [
@@ -61,6 +73,8 @@ const Navigation = () => {
 
   return (
     <nav
+      role="navigation"
+      aria-label="Main"
       className={`fixed top-0 left-0 right-0 z-[100] transition-all duration-300 ${
         scrolled
           ? 'bg-white/95 backdrop-blur-md shadow-lg border-b border-gray-200'
@@ -172,7 +186,8 @@ const Navigation = () => {
                 size="sm"
                 onClick={() => setIsOpen(!isOpen)}
                 className="p-2 border-2 border-orange-500 text-orange-600 hover:bg-orange-50"
-                aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
+                aria-label={isOpen ? 'Close navigation menu' : 'Open navigation menu'}
+                ref={menuButtonRef}
               >
                 {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
               </Button>
@@ -182,7 +197,10 @@ const Navigation = () => {
 
         {/* Mobile Navigation Menu */}
         {isMobile && isOpen && (
-          <div className="md:hidden border-t border-gray-200 bg-white/95 backdrop-blur-md">
+          <div
+            className="md:hidden border-t border-gray-200 bg-white/95 backdrop-blur-md"
+            ref={menuRef}
+          >
             <div className="px-2 pt-2 pb-3 space-y-1">
               {navItems.map((item) => (
                 <Link

--- a/src/components/books/BookReader.tsx
+++ b/src/components/books/BookReader.tsx
@@ -682,6 +682,7 @@ const BookReader = ({ bookId, bookTitle, pdfUrl, epubUrl }: BookReaderProps) => 
                   size="sm"
                   className="absolute left-2 top-1/2 transform -translate-y-1/2 bg-white/90 backdrop-blur-sm shadow-lg hover:bg-white"
                   onClick={navigatePrevious}
+                  aria-label="Previous page"
                 >
                   <ChevronLeft className="w-4 h-4" />
                 </Button>
@@ -690,6 +691,7 @@ const BookReader = ({ bookId, bookTitle, pdfUrl, epubUrl }: BookReaderProps) => 
                   size="sm"
                   className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-white/90 backdrop-blur-sm shadow-lg hover:bg-white"
                   onClick={navigateNext}
+                  aria-label="Next page"
                 >
                   <ChevronRight className="w-4 h-4" />
                 </Button>

--- a/src/components/dashboard/StoriesSection.tsx
+++ b/src/components/dashboard/StoriesSection.tsx
@@ -97,20 +97,26 @@ const StoriesSection: React.FC<StoriesSectionProps> = ({ userId }) => {
               </div>
               <div className="absolute right-4 top-4 flex gap-2 opacity-80 group-hover:opacity-100 transition-opacity">
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button variant="ghost" size="icon" className="rounded-full hover:bg-orange-50">
+                <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="rounded-full hover:bg-orange-50"
+                      aria-label="Edit story"
+                    >
                       <Edit className="w-5 h-5 text-orange-500 hover:scale-110 transition-transform" />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>Edit</TooltipContent>
                 </Tooltip>
                 <Tooltip>
-                  <TooltipTrigger asChild>
+                <TooltipTrigger asChild>
                     <Button
                       variant="ghost"
                       size="icon"
                       className="rounded-full hover:bg-orange-50"
                       onClick={() => handleDelete(story.id)}
+                      aria-label="Delete story"
                     >
                       <Trash2 className="w-5 h-5 text-red-400 hover:scale-110 transition-transform" />
                     </Button>

--- a/src/components/library/BookReader.tsx
+++ b/src/components/library/BookReader.tsx
@@ -101,16 +101,31 @@ const BookReader = ({ book, isOpen, onClose }: BookReaderProps) => {
             </Button>
             
             {/* Zoom Controls */}
-            <Button variant="outline" size="sm" onClick={handleZoomOut}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleZoomOut}
+              aria-label="Zoom out"
+            >
               <ZoomOut className="w-4 h-4" />
             </Button>
             <span className="text-sm min-w-[50px] text-center">{zoom}%</span>
-            <Button variant="outline" size="sm" onClick={handleZoomIn}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleZoomIn}
+              aria-label="Zoom in"
+            >
               <ZoomIn className="w-4 h-4" />
             </Button>
             
             {/* Rotate */}
-            <Button variant="outline" size="sm" onClick={handleRotate}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRotate}
+              aria-label="Rotate page"
+            >
               <RotateCw className="w-4 h-4" />
             </Button>
             
@@ -119,12 +134,22 @@ const BookReader = ({ book, isOpen, onClose }: BookReaderProps) => {
               variant="outline"
               size="sm"
               onClick={() => setIsFullscreen(!isFullscreen)}
+              aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
             >
-              {isFullscreen ? <Minimize className="w-4 h-4" /> : <Maximize className="w-4 h-4" />}
+              {isFullscreen ? (
+                <Minimize className="w-4 h-4" />
+              ) : (
+                <Maximize className="w-4 h-4" />
+              )}
             </Button>
             
             {/* Close */}
-            <Button variant="outline" size="sm" onClick={onClose}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onClose}
+              aria-label="Close reader"
+            >
               <X className="w-4 h-4" />
             </Button>
           </div>
@@ -140,6 +165,7 @@ const BookReader = ({ book, isOpen, onClose }: BookReaderProps) => {
               onClick={handlePrevPage}
               disabled={currentPage <= 1}
               className="h-16"
+              aria-label="Previous page"
             >
               <ChevronLeft className="w-6 h-6" />
             </Button>
@@ -163,6 +189,7 @@ const BookReader = ({ book, isOpen, onClose }: BookReaderProps) => {
               onClick={handleNextPage}
               disabled={currentPage >= totalPages}
               className="h-16"
+              aria-label="Next page"
             >
               <ChevronRight className="w-6 h-6" />
             </Button>

--- a/src/components/notifications/NotificationDropdown.tsx
+++ b/src/components/notifications/NotificationDropdown.tsx
@@ -35,7 +35,12 @@ export const NotificationDropdown = () => {
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="relative">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative"
+          aria-label="Notifications"
+        >
           <Bell className="h-5 w-5" />
           {unreadCount > 0 && (
             <Badge 

--- a/src/components/reading/ChapterSummaryCard.tsx
+++ b/src/components/reading/ChapterSummaryCard.tsx
@@ -80,6 +80,7 @@ const ChapterSummaryCard: React.FC<ChapterSummaryCardProps> = ({
             size="sm"
             onClick={() => setIsExpanded(!isExpanded)}
             className="text-amber-700 hover:text-amber-900"
+            aria-label={isExpanded ? 'Collapse summary' : 'Expand summary'}
           >
             {isExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
           </Button>

--- a/src/pages/AuthorConnect.tsx
+++ b/src/pages/AuthorConnect.tsx
@@ -100,20 +100,20 @@ const AuthorConnect = () => {
                   Meet Our Authors
                 </h1>
               </div>
-              <p className="text-lg sm:text-xl text-orange-100 max-w-3xl mx-auto mb-8 leading-relaxed">
+              <p className="text-lg sm:text-xl text-white max-w-3xl mx-auto mb-8 leading-relaxed">
                 Connect with experienced writers and get personalized guidance for your literary journey.
               </p>
               <div className="flex items-center justify-center space-x-3 mb-6">
                 <div className="p-3 bg-white/20 backdrop-blur-sm rounded-xl shadow-lg">
                   <Calendar className="w-8 h-8 text-white" />
                 </div>
-                <span className="text-lg text-orange-100">Schedule Live Sessions</span>
+                <span className="text-lg text-white">Schedule Live Sessions</span>
               </div>
               <div className="flex items-center justify-center space-x-3 mb-6">
                 <div className="p-3 bg-white/20 backdrop-blur-sm rounded-xl shadow-lg">
                   <Search className="w-8 h-8 text-white" />
                 </div>
-                <span className="text-lg text-orange-100">Search by Genre</span>
+                <span className="text-lg text-white">Search by Genre</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add accessible back-to-top button styling
- label notification bell button
- label edit/delete buttons in stories
- label summary expand button
- label navigation arrows in book reader
- label controls in library book reader
- manage focus for mobile menu & add nav roles
- improve footer and hero text contrast

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882b0fea3888320b84159c53e01603b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added descriptive aria-labels to navigation, reader controls, notification, and story management buttons for improved screen reader support.
  * Enhanced keyboard focus management in the mobile navigation menu.
  * Updated expand/collapse button in chapter summaries with dynamic aria-labels.

* **Style**
  * Updated text colors in the footer and Author Connect page from light orange to white for improved contrast and design consistency.
  * Refined Back to Top button with new orange background and updated hover effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->