### PR TITLE
Fix login redirect flow

### DIFF
--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -3,11 +3,12 @@ import { useEffect, useState } from "react";
 import { Users, Mail, LogIn } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
 import { useCommunityStats } from "@/hooks/useCommunityStats";
 import { useAuth } from "@/contexts/AuthContext";
 import CommunityStats from "@/components/CommunityStats";
+import SignInLink from '@/components/SignInLink';
 
 const GlobalFooter = () => {
   const [showCount, setShowCount] = useState(false);
@@ -17,6 +18,7 @@ const GlobalFooter = () => {
   const { stats, isLoading, fetchStats, joinCommunity } = useCommunityStats(false);
   const { user } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     if (user && showSignIn) {
@@ -265,7 +267,11 @@ const GlobalFooter = () => {
           <Button
             onClick={() => {
               setShowSignIn(false);
-              navigate('/signin');
+              if (typeof window !== 'undefined') {
+                sessionStorage.setItem('redirectScrollY', String(window.scrollY));
+              }
+              const redirect = `${location.pathname}${location.search}${location.hash}`;
+              navigate(`/signin?redirect=${encodeURIComponent(redirect)}`, { state: { from: redirect } });
             }}
             className="w-full bg-orange-600 hover:bg-orange-700"
           >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,7 @@
 
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
+import SignInLink from '@/components/SignInLink';
 import { Menu, X, ChevronDown, User, LogOut, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
@@ -147,11 +148,11 @@ const Navigation = () => {
                   </>
                 ) : (
                   <div className="flex items-center space-x-4">
-                    <Link to="/signin">
+                    <SignInLink>
                       <Button variant="ghost" size="sm" className="border-2 border-orange-500 text-orange-600 hover:bg-orange-50">
                         Sign In
                       </Button>
-                    </Link>
+                    </SignInLink>
                     <Link to="/signup">
                       <Button size="sm" className="bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-700 hover:to-orange-700 text-white">
                         Sign Up
@@ -242,11 +243,11 @@ const Navigation = () => {
                 </div>
               ) : (
                 <div className="pt-4 space-y-3 border-t border-gray-200">
-                  <Link to="/signin" onClick={() => setIsOpen(false)} className="block">
+                  <SignInLink onClick={() => setIsOpen(false)} className="block">
                     <Button variant="ghost" size="sm" className="w-full justify-center border-2 border-orange-500 text-orange-600 hover:bg-orange-50">
                       Sign In
                     </Button>
-                  </Link>
+                  </SignInLink>
                   <Link to="/signup" onClick={() => setIsOpen(false)} className="block">
                     <Button size="sm" className="w-full bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-700 hover:to-orange-700 text-white">
                       Sign Up

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { Skeleton } from '@/components/ui/skeleton';
 
 interface ProtectedRouteProps {
@@ -10,6 +10,7 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -27,7 +28,17 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   }
 
   if (!user) {
-    return <Navigate to="/signin" replace />;
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('redirectScrollY', String(window.scrollY));
+    }
+    const redirect = `${location.pathname}${location.search}${location.hash}`;
+    return (
+      <Navigate
+        to={`/signin?redirect=${encodeURIComponent(redirect)}`}
+        state={{ from: redirect }}
+        replace
+      />
+    );
   }
 
   return <>{children}</>;

--- a/src/components/SignInLink.tsx
+++ b/src/components/SignInLink.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link, useLocation, type LinkProps } from 'react-router-dom';
+
+const SignInLink: React.FC<Omit<LinkProps, 'to'>> = ({ children, onClick, ...props }) => {
+  const location = useLocation();
+  const redirect = `${location.pathname}${location.search}${location.hash}`;
+
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('redirectScrollY', String(window.scrollY));
+    }
+    if (onClick) {
+      onClick(e);
+    }
+  };
+
+  return (
+    <Link
+      {...props}
+      to={`/signin?redirect=${encodeURIComponent(redirect)}`}
+      state={{ from: redirect }}
+      onClick={handleClick}
+    >
+      {children}
+    </Link>
+  );
+};
+
+export default SignInLink;

--- a/src/components/books/BookContinuationSection.tsx
+++ b/src/components/books/BookContinuationSection.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { BookOpen, PenTool, Vote, Users, LogIn } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 interface BookContinuationSectionProps {
   bookId: string;
@@ -19,6 +19,7 @@ const BookContinuationSection = ({ bookId, bookTitle, genre }: BookContinuationS
   const { user } = useAuth();
   const { toast } = useToast();
   const navigate = useNavigate();
+  const location = useLocation();
   const [continuationSummary, setContinuationSummary] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [voteForSequel, setVoteForSequel] = useState<'yes' | 'no' | null>(null);
@@ -32,7 +33,11 @@ const BookContinuationSection = ({ bookId, bookTitle, genre }: BookContinuationS
                    genre?.toLowerCase().includes('mystery');
 
   const handleSignInPrompt = () => {
-    navigate('/signin');
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('redirectScrollY', String(window.scrollY));
+    }
+    const redirect = `${location.pathname}${location.search}${location.hash}`;
+    navigate(`/signin?redirect=${encodeURIComponent(redirect)}`, { state: { from: redirect } });
   };
 
   const handleSubmitContinuation = async () => {

--- a/src/components/library/AuthenticatedActions.tsx
+++ b/src/components/library/AuthenticatedActions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Plus, Check, Download } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import SignInLink from '@/components/SignInLink';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAddToBookshelf, useUserBookshelf } from '@/hooks/useUserBookshelf';
 import type { Book } from '@/hooks/useLibraryBooks';
@@ -26,11 +27,11 @@ const AuthenticatedActions: React.FC<AuthenticatedActionsProps> = ({ book, onDow
   if (!user) {
     return (
       <div className="flex gap-2 mt-3">
-        <Link to="/signin" className="flex-1">
+        <SignInLink className="flex-1">
           <Button variant="outline" size="sm" className="w-full">
             Sign in to Add to Shelf
           </Button>
-        </Link>
+        </SignInLink>
         {book.pdf_url && onDownloadPDF && (
           <Button 
             variant="outline" 

--- a/src/components/navigation/AuthSection.tsx
+++ b/src/components/navigation/AuthSection.tsx
@@ -1,5 +1,5 @@
 
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import UserDropdownMenu from "./UserDropdownMenu";
 import { useAuth } from "@/contexts/AuthContext";
 import { NotificationDropdown } from '@/components/notifications/NotificationDropdown';
@@ -9,9 +9,14 @@ import { LogIn, UserPlus } from "lucide-react";
 const AuthSection = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleSignInClick = () => {
-    navigate('/signin');
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('redirectScrollY', String(window.scrollY));
+    }
+    const redirect = `${location.pathname}${location.search}${location.hash}`;
+    navigate(`/signin?redirect=${encodeURIComponent(redirect)}`, { state: { from: redirect } });
   };
 
   const handleSignUpClick = () => {

--- a/src/components/navigation/MobileNavMenu.tsx
+++ b/src/components/navigation/MobileNavMenu.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/sheet";
 import { Menu } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import SignInLink from '@/components/SignInLink';
 import { useAuth } from "@/contexts/AuthContext";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -99,9 +100,9 @@ const MobileNavMenu = ({ isOpen, onClose }: MobileNavMenuProps) => {
             </>
           ) : (
             <>
-              <Link to="/signin" className="block px-4 py-2 rounded-md hover:bg-gray-100">
+              <SignInLink className="block px-4 py-2 rounded-md hover:bg-gray-100">
                 Sign In
-              </Link>
+              </SignInLink>
               <Link to="/signup" className="block px-4 py-2 rounded-md hover:bg-gray-100">
                 Sign Up
               </Link>

--- a/src/hooks/useAutoLogout.ts
+++ b/src/hooks/useAutoLogout.ts
@@ -51,8 +51,12 @@ export const useAutoLogout = () => {
         duration: 5000,
       });
       
-      // Redirect to signin page
-      navigate('/signin', { replace: true });
+      // Redirect to signin page with original location
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('redirectScrollY', String(window.scrollY));
+      }
+      const redirect = `${location.pathname}${location.search}${location.hash}`;
+      navigate(`/signin?redirect=${encodeURIComponent(redirect)}`, { replace: true, state: { from: redirect } });
     } catch (error) {
       console.error('[AUTO-LOGOUT] Error during auto logout:', error);
     }
@@ -76,8 +80,12 @@ export const useAutoLogout = () => {
         duration: 5000,
       });
       
-      // Redirect to signin page
-      navigate('/signin', { replace: true });
+      // Redirect to signin page with original location
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('redirectScrollY', String(window.scrollY));
+      }
+      const redirect2 = `${location.pathname}${location.search}${location.hash}`;
+      navigate(`/signin?redirect=${encodeURIComponent(redirect2)}`, { replace: true, state: { from: redirect2 } });
     } catch (error) {
       console.error('[AUTO-LOGOUT] Error during session timeout:', error);
     }

--- a/src/pages/CommunityStories.tsx
+++ b/src/pages/CommunityStories.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { BookOpen, PenTool, Heart } from 'lucide-react';
 import SEO from '@/components/SEO';
 import { Link } from 'react-router-dom';
+import SignInLink from '@/components/SignInLink';
 import { Button } from '@/components/ui/button';
 
 const CommunityStories = () => {
@@ -51,11 +52,11 @@ const CommunityStories = () => {
                     Sign in to share your own stories and connect with fellow creative readers.
                   </p>
                   <div className="flex gap-4 justify-center">
-                    <Link to="/signin">
+                    <SignInLink>
                       <Button className="bg-purple-600 hover:bg-purple-700 shadow-lg">
                         Sign In
                       </Button>
-                    </Link>
+                    </SignInLink>
                     <Link to="/signup">
                       <Button variant="outline" className="border-purple-200 text-purple-600 hover:bg-purple-50">
                         Sign Up

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BookOpen, Users, Map, Calendar, Star, Headphones, LogIn, UserPlus, User } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
+import SignInLink from '@/components/SignInLink';
 import { useAuth } from "@/contexts/AuthContext";
 import { useProfile } from "@/hooks/useProfile";
 import SEO from "@/components/SEO";
@@ -115,12 +116,12 @@ const Index = () => {
                   Join Our Reading Community (Free!)
                 </Button>
               </Link>
-              <Link to="/signin" className="w-full sm:w-auto">
+              <SignInLink className="w-full sm:w-auto">
                 <Button variant="outline" size="lg" className="w-full sm:w-auto border-orange-400 text-orange-600 hover:bg-orange-50 px-6 sm:px-8 py-3 text-base sm:text-lg shadow-lg">
                   <LogIn className="w-4 h-4 sm:w-5 sm:h-5 mr-2" />
                   Sign In
                 </Button>
-              </Link>
+              </SignInLink>
             </div>
           </div>
         </section>

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { Link, useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -23,6 +23,7 @@ const SignIn = () => {
   const [error, setError] = useState('');
   const navigate = useNavigate();
   const location = useLocation();
+  const [searchParams] = useSearchParams();
   const { user, signIn } = useAuth();
   const { joinCommunity } = useCommunityStats(false);
   const { toast } = useToast();
@@ -41,11 +42,21 @@ const SignIn = () => {
         return;
       }
 
-      // Get the intended destination from location state, default to dashboard
-      const from = location.state?.from?.pathname || '/dashboard';
-      navigate(from, { replace: true });
+      // Determine intended destination from state or query parameter
+      const fromState = location.state?.from as string | undefined;
+      const fromQuery = searchParams.get('redirect');
+      const destination = fromState || fromQuery || '/dashboard';
+      navigate(destination, { replace: true });
+
+      const scrollY = sessionStorage.getItem('redirectScrollY');
+      if (scrollY) {
+        setTimeout(() => {
+          window.scrollTo(0, parseInt(scrollY, 10));
+          sessionStorage.removeItem('redirectScrollY');
+        }, 0);
+      }
     }
-  }, [user, navigate, location.state, joinCommunity]);
+  }, [user, navigate, location.state, joinCommunity, searchParams]);
 
   const validateForm = () => {
     if (!formData.email?.trim() || !formData.password) {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import SignInLink from '@/components/SignInLink';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -338,9 +339,9 @@ const SignUp = () => {
             <div className="mt-6 text-center">
               <p className="text-sm text-gray-600">
                 Already have an account?{' '}
-                <Link to="/signin" className="text-amber-600 hover:text-amber-700 font-medium">
+                <SignInLink className="text-amber-600 hover:text-amber-700 font-medium">
                   Sign in here
-                </Link>
+                </SignInLink>
               </p>
             </div>
           </CardContent>

--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { MessageCircle, MapPin, UsersIcon, Users } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
+import SignInLink from '@/components/SignInLink';
 import SEO from '@/components/SEO';
 import { SocialFeed } from '@/components/social/SocialFeed';
 import { EnhancedReadingMap } from '@/components/social/EnhancedReadingMap';
@@ -49,11 +50,11 @@ const SocialMedia = () => {
                 Please sign in to access Sahadhyayi's Social Reading Community!
               </p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                <Link to="/signin">
+                <SignInLink>
                   <Button className="w-full sm:w-auto bg-orange-600 hover:bg-orange-700">
                     Sign In
                   </Button>
-                </Link>
+                </SignInLink>
                 <Link to="/signup">
                   <Button variant="outline" className="w-full sm:w-auto border-orange-300 text-orange-700 hover:bg-orange-50">
                     Sign Up


### PR DESCRIPTION
## Summary
- create `SignInLink` component to keep the original URL
- redirect unauthenticated users with query string in `ProtectedRoute`
- return to previous URL after sign in
- preserve scroll position when redirected
- update navigation and various pages to use `SignInLink`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882b180ee44832089cca689e981b0e3