### PR TITLE
Add sitemap generation and prerender scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,7 @@ Ensure you set the appropriate `SONAR_TOKEN` and `SONAR_HOST_URL` environment va
 ## Resetting Website Visit IDs
 
 To clear existing website visit data and restart the auto-incrementing ID counter, execute the SQL commands in [docs/ResetWebsiteVisitIDs.md](docs/ResetWebsiteVisitIDs.md).
+
+## Generating Sitemap and Pre-rendered Pages
+
+Run `npm run generate:sitemap` to rebuild `public/sitemap.xml` with all important URLs, including author and book pages. To create static HTML pages with meta tags for key routes, execute `npm run prerender`. The generated files are placed under `public/prerender` and copied to the final build so search engines can index them easily.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start:server": "node server.js"
+    "start:server": "node server.js",
+    "generate:sitemap": "node scripts/generateSitemap.js",
+    "prerender": "node scripts/prerender.js"
   },
   "dependencies": {
     "@google/maps": "^1.1.3",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -144,4 +144,50 @@
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
+
+  <!-- Dynamic Author Pages -->
+  <url>
+    <loc>https://sahadhyayi.com/authors/rabindranath-tagore</loc>
+    <lastmod>2025-07-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/authors/haruki-murakami</loc>
+    <lastmod>2025-07-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Dynamic Book Pages -->
+  <url>
+    <loc>https://sahadhyayi.com/book/1</loc>
+    <lastmod>2025-07-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/book/2</loc>
+    <lastmod>2025-07-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/book/3</loc>
+    <lastmod>2025-07-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/book/4</loc>
+    <lastmod>2025-07-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/book/5</loc>
+    <lastmod>2025-07-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/scripts/generateSitemap.js
+++ b/scripts/generateSitemap.js
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+
+const staticPages = [
+  '/',
+  '/library',
+  '/authors',
+  '/groups',
+  '/map',
+  '/blog',
+  '/community-stories',
+  '/quotes',
+  '/about',
+  '/social',
+  '/help',
+  '/feedback',
+  '/signin',
+  '/signup',
+  '/privacy',
+  '/terms',
+  '/cookies',
+  '/dmca',
+  '/investors'
+];
+
+const books = [
+  { id: '1', title: 'A Brief History of Time' },
+  { id: '2', title: 'गोदान' },
+  { id: '3', title: 'Pride and Prejudice' },
+  { id: '4', title: 'Sapiens' },
+  { id: '5', title: 'गुनाहों का देवता' }
+];
+
+const authors = [
+  { name: 'Rabindranath Tagore' },
+  { name: 'Haruki Murakami' }
+];
+
+const slugify = text => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+const urls = [];
+const today = new Date().toISOString().split('T')[0];
+
+function addUrl(loc, changefreq='weekly', priority='0.6') {
+  urls.push({ loc: `https://sahadhyayi.com${loc}`, lastmod: today, changefreq, priority });
+}
+
+staticPages.forEach(p => addUrl(p, p === '/' ? 'weekly' : 'monthly', p === '/' ? '1.0' : '0.5'));
+books.forEach(b => addUrl(`/book/${b.id}`, 'weekly', '0.5'));
+authors.forEach(a => addUrl(`/authors/${slugify(a.name)}`, 'weekly', '0.6'));
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  urls.map(u => {
+    return `  <url>\n    <loc>${u.loc}</loc>\n    <lastmod>${u.lastmod}</lastmod>\n    <changefreq>${u.changefreq}</changefreq>\n    <priority>${u.priority}</priority>\n  </url>`;}).join('\n') +
+  '\n</urlset>\n';
+
+fs.writeFileSync(path.join('public','sitemap.xml'), xml, 'utf8');
+console.log('sitemap.xml generated with', urls.length, 'urls');

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+
+const template = fs.readFileSync('index.html', 'utf8');
+
+const basePages = [
+  { path: '/', title: 'Sahadhyayi - Digital Reading Community & Book Library | Fellow Readers Platform', description: 'Sahadhyayi means \"fellow reader\" in Sanskrit. Join our vibrant digital reading community and explore thousands of books.' },
+  { path: '/library', title: 'Library - Sahadhyayi', description: 'Browse thousands of free books in our online library.' },
+  { path: '/authors', title: 'Authors - Sahadhyayi', description: 'Discover authors on the Sahadhyayi reading platform.' },
+  { path: '/about', title: 'About Sahadhyayi', description: 'Learn about the Sahadhyayi mission and community.' }
+];
+
+const books = [
+  { id: '1', title: 'A Brief History of Time', description: 'An overview of cosmology and the origins of the universe.' },
+  { id: '2', title: 'गोदान', description: 'A classic Hindi novel depicting rural life in India.' },
+  { id: '3', title: 'Pride and Prejudice', description: 'A romantic novel that critiques the British landed gentry.' },
+  { id: '4', title: 'Sapiens', description: 'A brief history of humankind.' },
+  { id: '5', title: 'गुनाहों का देवता', description: 'A popular Hindi novel exploring a tragic love story.' }
+];
+
+const authors = [
+  { name: 'Rabindranath Tagore', bio: 'Nobel Prize-winning Bengali polymath who reshaped Bengali literature and music.' },
+  { name: 'Haruki Murakami', bio: 'Japanese writer known for works blending surrealism with pop culture and magical realism.' }
+];
+
+const slugify = text => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+function createHtml(title, description) {
+  let html = template.replace(/<title>(.|\n)*?<\/title>/, `<title>${title}</title>`);
+  html = html.replace(/<meta name="description" content=".*?" \/>/, `<meta name="description" content="${description}" />`);
+  return html;
+}
+
+function writePage(filePath, html) {
+  const fullPath = path.join('public', 'prerender', filePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, html);
+}
+
+basePages.forEach(p => {
+  writePage(p.path === '/' ? 'index.html' : p.path.slice(1) + '.html', createHtml(p.title, p.description));
+});
+
+books.forEach(b => {
+  writePage(`book/${b.id}.html`, createHtml(`${b.title} - Sahadhyayi`, b.description));
+});
+
+authors.forEach(a => {
+  writePage(`authors/${slugify(a.name)}.html`, createHtml(`${a.name} - Sahadhyayi`, a.bio));
+});
+
+console.log('Pre-rendered HTML pages created in public/prerender');


### PR DESCRIPTION
## Summary
- add commands to generate sitemap and static pages
- document how to use the new scripts
- include book and author URLs in `public/sitemap.xml`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882b1df256c8320984a7dffab449b3a