### PR TITLE
Add infinite scroll for books

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,8 @@
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
+        "react-virtualized-auto-sizer": "^1.0.7",
+        "react-window": "^1.8.11",
         "recharts": "^2.12.7",
         "socket.io": "^4.8.1",
         "sonner": "^1.5.0",
@@ -6247,6 +6249,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -7096,6 +7104,33 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "react-window": "^1.8.11",
+    "react-virtualized-auto-sizer": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/hooks/useInfiniteLibraryBooks.ts
+++ b/src/hooks/useInfiniteLibraryBooks.ts
@@ -1,0 +1,109 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { Book } from './useLibraryBooks';
+import { sampleBooks } from '@/data/sampleBooks';
+
+interface InfiniteParams {
+  genre: string;
+  searchQuery?: string;
+  author?: string;
+  year?: string;
+  language?: string;
+  pageSize?: number;
+}
+
+export interface BooksPage {
+  books: Book[];
+  nextPage: number;
+  total: number;
+}
+
+export const useInfiniteLibraryBooks = ({
+  genre,
+  searchQuery = '',
+  author = 'All',
+  year = '',
+  language = 'All',
+  pageSize = 20,
+}: InfiniteParams) => {
+  return useInfiniteQuery({
+    queryKey: ['infinite-library-books', genre, searchQuery, author, year, language, pageSize],
+    queryFn: async ({ pageParam = 0 }): Promise<BooksPage> => {
+      const start = pageParam * pageSize;
+      const end = start + pageSize - 1;
+
+      let query = supabase
+        .from('books_library')
+        .select('*', { count: 'exact' })
+        .order('created_at', { ascending: true })
+        .range(start, end);
+
+      if (genre !== 'All') {
+        if (genre === 'Hindi') {
+          query = query.eq('language', 'Hindi');
+        } else {
+          query = query.eq('genre', genre);
+        }
+      }
+
+      if (author !== 'All') {
+        query = query.eq('author', author);
+      }
+
+      if (year) {
+        query = query.eq('publication_year', parseInt(year, 10));
+      }
+
+      if (language !== 'All') {
+        query = query.eq('language', language);
+      }
+
+      if (searchQuery && searchQuery.trim()) {
+        query = query.or(
+          `title.ilike.%${searchQuery}%,author.ilike.%${searchQuery}%`
+        );
+      }
+
+      const { data, error, count } = await query;
+
+      if (error || !data) {
+        console.error('Error fetching books:', error);
+        const fallback = sampleBooks.slice(start, end + 1);
+        return {
+          books: fallback,
+          nextPage: pageParam + 1,
+          total: sampleBooks.length,
+        };
+      }
+
+      const books = data.map(book => ({
+        id: book.id,
+        title: book.title,
+        author: book.author || 'Unknown Author',
+        genre: book.genre,
+        cover_image_url: book.cover_image_url,
+        description: book.description,
+        publication_year: book.publication_year,
+        language: book.language || 'English',
+        pdf_url: book.pdf_url,
+        created_at: book.created_at,
+        price: 0,
+        rating: 0,
+        isbn: book.isbn,
+        pages: book.pages,
+        author_bio: book.author_bio,
+      })) as Book[];
+
+      return {
+        books,
+        nextPage: pageParam + 1,
+        total: count ?? books.length,
+      };
+    },
+    getNextPageParam: lastPage => {
+      const nextIndex = lastPage.nextPage * pageSize;
+      if (nextIndex >= lastPage.total) return undefined;
+      return lastPage.nextPage;
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add `useInfiniteLibraryBooks` hook for page-based fetching
- update `BooksCollection` to load books lazily and fetch more when scrolled to the bottom
- show a spinner while loading additional pages
- include new dependencies for virtualization

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882b1edec5c8320ba15a75b68e76c13