### PR TITLE
Add reading challenges with badges

### DIFF
--- a/src/components/dashboard/ReadingChallengesSection.tsx
+++ b/src/components/dashboard/ReadingChallengesSection.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Button } from '@/components/ui/button';
+import { Target } from 'lucide-react';
+import { useChallenges, useUserChallenges, useJoinChallenge } from '@/hooks/useReadingChallenges';
+
+const ReadingChallengesSection: React.FC = () => {
+  const { data: challenges = [] } = useChallenges();
+  const { data: userChallenges = [] } = useUserChallenges();
+  const join = useJoinChallenge();
+
+  const joinedIds = new Set(userChallenges.map((uc) => uc.challenge_id));
+
+  const getProgress = (id: string) =>
+    userChallenges.find((uc) => uc.challenge_id === id)?.progress || 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center text-base sm:text-lg">
+          <Target className="w-5 h-5 mr-2 text-amber-600" />
+          Reading Challenges
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {challenges.length === 0 ? (
+          <div className="text-center py-6 text-gray-500 text-sm">
+            No challenges available.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {challenges.map((ch) => {
+              const progress = getProgress(ch.id);
+              const percent = Math.min(100, Math.round((progress / ch.goal) * 100));
+              const joined = joinedIds.has(ch.id);
+              return (
+                <div key={ch.id} className="border border-gray-200 rounded-lg p-3">
+                  <div className="flex items-center justify-between mb-2">
+                    <div>
+                      <h4 className="font-medium text-gray-900">{ch.name}</h4>
+                      <p className="text-sm text-gray-500">{ch.description}</p>
+                    </div>
+                    {joined ? (
+                      <span className="text-green-600 text-sm font-semibold">Joined</span>
+                    ) : (
+                      <Button size="sm" onClick={() => join.mutate(ch.id)} disabled={join.isPending}>
+                        Join
+                      </Button>
+                    )}
+                  </div>
+                  {joined && (
+                    <div>
+                      <Progress value={percent} className="h-2 bg-gray-200" />
+                      <div className="text-xs text-gray-500 mt-1">
+                        {progress} / {ch.goal} books
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ReadingChallengesSection;

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -20,6 +20,7 @@ import ProfileAvatar from "./ProfileAvatar";
 import ProfileInfo from "./ProfileInfo";
 import ProfileTags from "./ProfileTags";
 import ProfileSocialLinks from "./ProfileSocialLinks";
+import UserBadges from "./UserBadges";
 import EditProfileDialog from "./EditProfileDialog";
 import DeleteProfileDialog from "./DeleteProfileDialog";
 import { openPopupWindow } from "./openPopupWindow";
@@ -193,6 +194,8 @@ export const ProfileView: React.FC = () => {
             </div>
             {/* Tags/Life phases */}
             <ProfileTags life_tags={profile?.life_tags ?? []} />
+            {/* Earned Badges */}
+            <UserBadges />
             {/* Social Links */}
             <ProfileSocialLinks social_links={profile?.social_links} />
             {/* Action Buttons */}

--- a/src/components/profile/UserBadges.tsx
+++ b/src/components/profile/UserBadges.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { useUserBadges } from '@/hooks/useReadingChallenges';
+
+const UserBadges: React.FC = () => {
+  const { data: badges = [] } = useUserBadges();
+
+  if (badges.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 justify-center mt-2">
+      {badges.map((b) => (
+        <Badge key={b.id} variant="secondary">
+          {b.badges?.name}
+        </Badge>
+      ))}
+    </div>
+  );
+};
+
+export default UserBadges;

--- a/src/hooks/useReadingChallenges.ts
+++ b/src/hooks/useReadingChallenges.ts
@@ -1,0 +1,116 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+
+export interface ReadingChallenge {
+  id: string;
+  name: string;
+  description?: string;
+  start_date?: string;
+  end_date?: string;
+  goal: number;
+  challenge_type?: string;
+}
+
+export interface UserChallenge {
+  id: string;
+  user_id: string;
+  challenge_id: string;
+  progress?: number;
+  completed?: boolean;
+  reading_challenges?: ReadingChallenge;
+}
+
+export interface UserBadge {
+  id: string;
+  badge_id: string;
+  user_id: string;
+  badges?: { name: string; icon_url?: string };
+}
+
+export const useChallenges = () =>
+  useQuery({
+    queryKey: ['challenges'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('reading_challenges')
+        .select('*')
+        .order('start_date', { ascending: false });
+      if (error) throw error;
+      return data as ReadingChallenge[];
+    },
+  });
+
+export const useUserChallenges = () => {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ['user-challenges', user?.id],
+    queryFn: async () => {
+      if (!user) return [];
+      const { data, error } = await supabase
+        .from('user_challenges')
+        .select('*, reading_challenges(*)')
+        .eq('user_id', user.id);
+      if (error) throw error;
+
+      const challenges = (data as UserChallenge[]) || [];
+
+      // Calculate progress based on books in user's bookshelf
+      await Promise.all(
+        challenges.map(async (uc) => {
+          const rc = uc.reading_challenges;
+          if (!rc) return;
+          const { count } = await supabase
+            .from('user_bookshelf')
+            .select('id', { count: 'exact', head: true })
+            .eq('user_id', user.id)
+            .in('status', ['reading', 'completed'])
+            .gte('added_at', rc.start_date ?? '1970-01-01')
+            .lte('added_at', rc.end_date ?? '2999-12-31');
+          uc.progress = count ?? 0;
+          uc.completed = uc.progress >= rc.goal;
+        })
+      );
+
+      return challenges;
+    },
+    enabled: !!user,
+  });
+};
+
+export const useJoinChallenge = () => {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  return useMutation({
+    mutationFn: async (challengeId: string) => {
+      if (!user) throw new Error('Not authenticated');
+      const { data, error } = await supabase
+        .from('user_challenges')
+        .insert({ user_id: user.id, challenge_id: challengeId })
+        .select()
+        .single();
+      if (error) throw error;
+      return data as UserChallenge;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-challenges'] });
+    },
+  });
+};
+
+export const useUserBadges = () => {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ['user-badges', user?.id],
+    queryFn: async () => {
+      if (!user) return [];
+      const { data, error } = await supabase
+        .from('user_badges')
+        .select('*, badges(name, icon_url)')
+        .eq('user_id', user.id);
+      if (error) throw error;
+      return data as UserBadge[];
+    },
+    enabled: !!user,
+  });
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import DashboardStats from '@/components/dashboard/DashboardStats';
 import EnhancedBookshelf from '@/components/dashboard/EnhancedBookshelf';
 import CurrentReads from '@/components/dashboard/CurrentReads';
 import ReadingTracker from '@/components/dashboard/ReadingTracker';
+import ReadingChallengesSection from '@/components/dashboard/ReadingChallengesSection';
 import ReadingGoalDialog from '@/components/dashboard/ReadingGoalDialog';
 import ReadingGoalModal from '@/components/dashboard/ReadingGoalModal';
 
@@ -146,7 +147,10 @@ const Dashboard = () => {
               
               {/* Reading Progress Tracker */}
               {user?.id && <ReadingTracker userId={user.id} />}
-              
+
+              {/* Reading Challenges */}
+              <ReadingChallengesSection />
+
               {/* My Library Section */}
               <EnhancedBookshelf />
               

--- a/supabase/migrations/20250725120000-add-reading-challenges.sql
+++ b/supabase/migrations/20250725120000-add-reading-challenges.sql
@@ -1,0 +1,63 @@
+-- Create reading challenges and badges tables
+
+-- Reading challenges table
+CREATE TABLE IF NOT EXISTS public.reading_challenges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  description TEXT,
+  start_date DATE,
+  end_date DATE,
+  goal INTEGER NOT NULL,
+  challenge_type TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- User challenges table
+CREATE TABLE IF NOT EXISTS public.user_challenges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  challenge_id UUID NOT NULL REFERENCES public.reading_challenges(id) ON DELETE CASCADE,
+  progress INTEGER NOT NULL DEFAULT 0,
+  completed BOOLEAN NOT NULL DEFAULT FALSE,
+  joined_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  UNIQUE(user_id, challenge_id)
+);
+
+-- Badges table
+CREATE TABLE IF NOT EXISTS public.badges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  description TEXT,
+  icon_url TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- User badges table
+CREATE TABLE IF NOT EXISTS public.user_badges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  badge_id UUID NOT NULL REFERENCES public.badges(id) ON DELETE CASCADE,
+  awarded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  UNIQUE(user_id, badge_id)
+);
+
+-- Enable RLS
+ALTER TABLE public.reading_challenges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_challenges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.badges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_badges ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Public can view reading challenges" ON public.reading_challenges
+  FOR SELECT USING (true);
+
+CREATE POLICY "Users can manage own challenges" ON public.user_challenges
+  FOR ALL USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Public can view badges" ON public.badges
+  FOR SELECT USING (true);
+
+CREATE POLICY "Users manage own badges" ON public.user_badges
+  FOR ALL USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- introduce database tables for reading challenges and badges
- add hooks for reading challenge queries and joins
- display challenges on the dashboard
- show earned badges on profile pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882b7872bf083208774ad8a9cd42737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Reading Challenges section on the dashboard, allowing users to view, join, and track progress on reading challenges.
  * Added badge functionality, enabling users to earn and display badges on their profile.
  * Users can now see earned badges in their profile view.

* **Database**
  * Added new tables to support reading challenges, user participation, badges, and user badges, with appropriate access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->