### PR TITLE
Add SEO sitemap generation and prerender script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .env
+public/prerender

--- a/README.md
+++ b/README.md
@@ -149,3 +149,4 @@ To clear existing website visit data and restart the auto-incrementing ID counte
 ## Generating Sitemap and Pre-rendered Pages
 
 Run `npm run generate:sitemap` to rebuild `public/sitemap.xml` with all important URLs, including author and book pages. To create static HTML pages with meta tags for key routes, execute `npm run prerender`. The generated files are placed under `public/prerender` and copied to the final build so search engines can index them easily.
+These steps run automatically when you execute `npm run build`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "npm run generate:sitemap && npm run prerender && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,193 +1,165 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-  <!-- Homepage -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://sahadhyayi.com/</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-    <image:image>
-      <image:loc>https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png</image:loc>
-      <image:title>Sahadhyayi - Digital Reading Community</image:title>
-      <image:caption>Join Sahadhyayi's vibrant reading community and discover thousands of books online</image:caption>
-    </image:image>
   </url>
-
-  <!-- Main Navigation Pages -->
   <url>
     <loc>https://sahadhyayi.com/library</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/authors</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
-  <url>
-    <loc>https://sahadhyayi.com/groups</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  
-  <url>
-    <loc>https://sahadhyayi.com/map</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <!-- New Content Pages -->
-  <url>
-    <loc>https://sahadhyayi.com/blog</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://sahadhyayi.com/community-stories</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://sahadhyayi.com/quotes</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <!-- About and Information Pages -->
   <url>
     <loc>https://sahadhyayi.com/about</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.5</priority>
   </url>
-  
+  <url>
+    <loc>https://sahadhyayi.com/groups</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/map</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/blog</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/community-stories</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/quotes</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/about</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
   <url>
     <loc>https://sahadhyayi.com/social</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/help</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/feedback</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
-
-  <!-- Authentication Pages -->
   <url>
     <loc>https://sahadhyayi.com/signin</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/signup</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
+    <priority>0.5</priority>
   </url>
-
-  <!-- Legal Pages -->
   <url>
     <loc>https://sahadhyayi.com/privacy</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/terms</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/cookies</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/dmca</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/investors</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
+    <priority>0.5</priority>
   </url>
-
-  <!-- Dynamic Author Pages -->
-  <url>
-    <loc>https://sahadhyayi.com/authors/rabindranath-tagore</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://sahadhyayi.com/authors/haruki-murakami</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <!-- Dynamic Book Pages -->
   <url>
     <loc>https://sahadhyayi.com/book/1</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://sahadhyayi.com/book/2</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://sahadhyayi.com/book/3</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://sahadhyayi.com/book/4</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://sahadhyayi.com/book/5</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/authors/rabindranath-tagore</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/authors/haruki-murakami</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>
 </urlset>

--- a/scripts/generateSitemap.js
+++ b/scripts/generateSitemap.js
@@ -1,40 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const staticPages = [
-  '/',
-  '/library',
-  '/authors',
-  '/groups',
-  '/map',
-  '/blog',
-  '/community-stories',
-  '/quotes',
-  '/about',
-  '/social',
-  '/help',
-  '/feedback',
-  '/signin',
-  '/signup',
-  '/privacy',
-  '/terms',
-  '/cookies',
-  '/dmca',
-  '/investors'
-];
-
-const books = [
-  { id: '1', title: 'A Brief History of Time' },
-  { id: '2', title: 'गोदान' },
-  { id: '3', title: 'Pride and Prejudice' },
-  { id: '4', title: 'Sapiens' },
-  { id: '5', title: 'गुनाहों का देवता' }
-];
-
-const authors = [
-  { name: 'Rabindranath Tagore' },
-  { name: 'Haruki Murakami' }
-];
+import { staticPages, books, authors } from './seoData.js';
 
 const slugify = text => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -1,27 +1,10 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
+
+import { basePages, books, authors } from "./seoData.js";
 
 const template = fs.readFileSync('index.html', 'utf8');
 
-const basePages = [
-  { path: '/', title: 'Sahadhyayi - Digital Reading Community & Book Library | Fellow Readers Platform', description: 'Sahadhyayi means \"fellow reader\" in Sanskrit. Join our vibrant digital reading community and explore thousands of books.' },
-  { path: '/library', title: 'Library - Sahadhyayi', description: 'Browse thousands of free books in our online library.' },
-  { path: '/authors', title: 'Authors - Sahadhyayi', description: 'Discover authors on the Sahadhyayi reading platform.' },
-  { path: '/about', title: 'About Sahadhyayi', description: 'Learn about the Sahadhyayi mission and community.' }
-];
-
-const books = [
-  { id: '1', title: 'A Brief History of Time', description: 'An overview of cosmology and the origins of the universe.' },
-  { id: '2', title: 'गोदान', description: 'A classic Hindi novel depicting rural life in India.' },
-  { id: '3', title: 'Pride and Prejudice', description: 'A romantic novel that critiques the British landed gentry.' },
-  { id: '4', title: 'Sapiens', description: 'A brief history of humankind.' },
-  { id: '5', title: 'गुनाहों का देवता', description: 'A popular Hindi novel exploring a tragic love story.' }
-];
-
-const authors = [
-  { name: 'Rabindranath Tagore', bio: 'Nobel Prize-winning Bengali polymath who reshaped Bengali literature and music.' },
-  { name: 'Haruki Murakami', bio: 'Japanese writer known for works blending surrealism with pop culture and magical realism.' }
-];
 
 const slugify = text => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 

--- a/scripts/seoData.js
+++ b/scripts/seoData.js
@@ -1,0 +1,55 @@
+export const basePages = [
+  {
+    path: '/',
+    title: 'Sahadhyayi - Digital Reading Community & Book Library | Fellow Readers Platform',
+    description: 'Sahadhyayi means "fellow reader" in Sanskrit. Join our vibrant digital reading community and explore thousands of books.'
+  },
+  {
+    path: '/library',
+    title: 'Library - Sahadhyayi',
+    description: 'Browse thousands of free books in our online library.'
+  },
+  {
+    path: '/authors',
+    title: 'Authors - Sahadhyayi',
+    description: 'Discover authors on the Sahadhyayi reading platform.'
+  },
+  {
+    path: '/about',
+    title: 'About Sahadhyayi',
+    description: 'Learn about the Sahadhyayi mission and community.'
+  }
+];
+
+export const staticPages = [
+  ...basePages.map(p => p.path),
+  '/groups',
+  '/map',
+  '/blog',
+  '/community-stories',
+  '/quotes',
+  '/about',
+  '/social',
+  '/help',
+  '/feedback',
+  '/signin',
+  '/signup',
+  '/privacy',
+  '/terms',
+  '/cookies',
+  '/dmca',
+  '/investors'
+];
+
+export const books = [
+  { id: '1', title: 'A Brief History of Time', description: 'An overview of cosmology and the origins of the universe.' },
+  { id: '2', title: 'गोदान', description: 'A classic Hindi novel depicting rural life in India.' },
+  { id: '3', title: 'Pride and Prejudice', description: 'A romantic novel that critiques the British landed gentry.' },
+  { id: '4', title: 'Sapiens', description: 'A brief history of humankind.' },
+  { id: '5', title: 'गुनाहों का देवता', description: 'A popular Hindi novel exploring a tragic love story.' }
+];
+
+export const authors = [
+  { name: 'Rabindranath Tagore', bio: 'Nobel Prize-winning Bengali polymath who reshaped Bengali literature and music.' },
+  { name: 'Haruki Murakami', bio: 'Japanese writer known for works blending surrealism with pop culture and magical realism.' }
+];


### PR DESCRIPTION
## Summary
- share SEO data for scripts
- update sitemap and prerender scripts to use shared data
- run sitemap and prerender as part of the build
- document SEO build steps
- ignore generated prerender files

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882b838b7388320b8d64667310b6aed