### PR TITLE
Add prerender and sitemap generation to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ To clear existing website visit data and restart the auto-incrementing ID counte
 
 Run `npm run generate:sitemap` to rebuild `public/sitemap.xml` with all important URLs, including author and book pages. To create static HTML pages with meta tags for key routes, execute `npm run prerender`. The generated files are placed under `public/prerender` and copied to the final build so search engines can index them easily.
 
+The `npm run build` command automatically runs these scripts via `prebuild`, ensuring the sitemap and pre-rendered pages are regenerated for every production build.
+
 ## External Integrations
 
 Sahadhyayi can connect to Goodreads so you can import your existing bookshelf and export your reading history back to Goodreads. See [docs/ExternalIntegrations.md](docs/ExternalIntegrations.md) for details.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "npm run prerender && npm run generate:sitemap",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",

--- a/public/prerender/about.html
+++ b/public/prerender/about.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Sahadhyayi</title>
+    <meta name="description" content="Learn about the Sahadhyayi mission and community." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/authors.html
+++ b/public/prerender/authors.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Authors - Sahadhyayi</title>
+    <meta name="description" content="Discover authors on the Sahadhyayi reading platform." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/authors/haruki-murakami.html
+++ b/public/prerender/authors/haruki-murakami.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Haruki Murakami - Sahadhyayi</title>
+    <meta name="description" content="Japanese writer known for works blending surrealism with pop culture and magical realism." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/authors/rabindranath-tagore.html
+++ b/public/prerender/authors/rabindranath-tagore.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rabindranath Tagore - Sahadhyayi</title>
+    <meta name="description" content="Nobel Prize-winning Bengali polymath who reshaped Bengali literature and music." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/book/1.html
+++ b/public/prerender/book/1.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A Brief History of Time - Sahadhyayi</title>
+    <meta name="description" content="An overview of cosmology and the origins of the universe." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/book/2.html
+++ b/public/prerender/book/2.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>गोदान - Sahadhyayi</title>
+    <meta name="description" content="A classic Hindi novel depicting rural life in India." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/book/3.html
+++ b/public/prerender/book/3.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pride and Prejudice - Sahadhyayi</title>
+    <meta name="description" content="A romantic novel that critiques the British landed gentry." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/book/4.html
+++ b/public/prerender/book/4.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sapiens - Sahadhyayi</title>
+    <meta name="description" content="A brief history of humankind." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/book/5.html
+++ b/public/prerender/book/5.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>गुनाहों का देवता - Sahadhyayi</title>
+    <meta name="description" content="A popular Hindi novel exploring a tragic love story." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/index.html
+++ b/public/prerender/index.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sahadhyayi - Digital Reading Community & Book Library | Fellow Readers Platform</title>
+    <meta name="description" content="Sahadhyayi means "fellow reader" in Sanskrit. Join our vibrant digital reading community and explore thousands of books." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/prerender/library.html
+++ b/public/prerender/library.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-82BF21X121"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-82BF21X121');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Library - Sahadhyayi</title>
+    <meta name="description" content="Browse thousands of free books in our online library." />
+    <meta name="keywords" content="sahadhyayi, online books, digital library, reading community, ebooks, read online, book discussions, reading tracker, AI reading assistant, deep reading, book recommendations, reading groups, literature, fiction, non-fiction, Hindi books, English books, book lovers, reading social network, author connect, digital reading platform, free books, book reviews, online library, book club, reading challenge, literary community" />
+    <meta name="author" content="Sahadhyayi Team" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="bingbot" content="index, follow" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#f59e0b" />
+    <link rel="canonical" href="https://sahadhyayi.com/" />
+
+    <!-- Preconnect to improve performance -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://sahadhyayi.com" />
+    <meta property="og:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta property="og:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta property="og:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Sahadhyayi reading community platform" />
+    <meta property="og:site_name" content="Sahadhyayi" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sahadhyayi" />
+    <meta name="twitter:creator" content="@sahadhyayi" />
+    <meta name="twitter:url" content="https://sahadhyayi.com" />
+    <meta name="twitter:title" content="Sahadhyayi - Digital Reading Community & Online Book Library" />
+    <meta name="twitter:description" content="Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library." />
+    <meta name="twitter:image" content="https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <meta name="twitter:image:alt" content="Sahadhyayi reading community platform" />
+
+    <!-- Additional SEO Meta Tags -->
+    <meta name="application-name" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-title" content="Sahadhyayi" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="format-detection" content="telephone=no" />
+    
+    <!-- Geographic targeting -->
+    <meta name="geo.region" content="IN" />
+    <meta name="geo.country" content="India" />
+    
+    <!-- Content language -->
+    <meta http-equiv="content-language" content="en-IN" />
+    
+    <!-- Referrer policy for security -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
+    <!-- Enhanced Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://sahadhyayi.com/#website",
+          "name": "Sahadhyayi",
+          "alternateName": ["Sahadhyayi Reading Community", "Sahadhyayi Digital Library"],
+          "url": "https://sahadhyayi.com",
+          "description": "Join Sahadhyayi's vibrant reading community and discover thousands of books online. Connect with fellow readers, track your progress, and explore our comprehensive digital library.",
+          "inLanguage": "en-IN",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://sahadhyayi.com/library?search={search_term_string}",
+            "query-input": "required name=search_term_string"
+          },
+          "publisher": {
+            "@type": "Organization",
+            "@id": "https://sahadhyayi.com/#organization"
+          }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://sahadhyayi.com/#organization",
+          "name": "Sahadhyayi",
+          "url": "https://sahadhyayi.com",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png",
+            "width": 512,
+            "height": 512,
+            "caption": "Sahadhyayi Logo"
+          },
+          "foundingDate": "2024",
+          "description": "Digital reading community platform connecting readers and authors worldwide",
+          "mission": "To revive deep reading culture and connect readers worldwide",
+          "sameAs": [
+            "https://sahadhyayi.com/about",
+            "https://twitter.com/sahadhyayi"
+          ],
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "contactType": "customer service",
+            "url": "https://sahadhyayi.com/feedback"
+          }
+        },
+        {
+          "@type": "WebApplication",
+          "name": "Sahadhyayi Reading Platform",
+          "url": "https://sahadhyayi.com",
+          "applicationCategory": "Entertainment",
+          "applicationSubCategory": "Reading",
+          "operatingSystem": "Web Browser",
+          "browserRequirements": "HTML5, JavaScript enabled",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+            "availability": "https://schema.org/InStock"
+          },
+          "featureList": [
+            "Digital Library Access",
+            "Reading Progress Tracking",
+            "Community Discussions",
+            "Author Connections",
+            "Reading Groups",
+            "Book Recommendations"
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <!-- Favicon and Icons with Sahadhyayi logo -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="shortcut icon" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" />
+    <link rel="manifest" href="/manifest.json" />
+    
+    <!-- Preload critical resources -->
+    <link rel="preload" href="/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png" as="image" type="image/png" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script>
+      const redirectPath = sessionStorage.redirectPath;
+      if (redirectPath) {
+        sessionStorage.removeItem('redirectPath');
+        history.replaceState(null, '', redirectPath);
+      }
+    </script>
+    <!-- Google Search Console verification -->
+    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,193 +1,159 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-  <!-- Homepage -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://sahadhyayi.com/</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-    <image:image>
-      <image:loc>https://sahadhyayi.com/lovable-uploads/fff3e49f-a95f-4fcf-ad47-da2dc6626f29.png</image:loc>
-      <image:title>Sahadhyayi - Digital Reading Community</image:title>
-      <image:caption>Join Sahadhyayi's vibrant reading community and discover thousands of books online</image:caption>
-    </image:image>
   </url>
-
-  <!-- Main Navigation Pages -->
   <url>
     <loc>https://sahadhyayi.com/library</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/authors</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/groups</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/map</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-
-  <!-- New Content Pages -->
   <url>
     <loc>https://sahadhyayi.com/blog</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-
   <url>
     <loc>https://sahadhyayi.com/community-stories</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.7</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-
   <url>
     <loc>https://sahadhyayi.com/quotes</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-
-  <!-- About and Information Pages -->
   <url>
     <loc>https://sahadhyayi.com/about</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/social</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/help</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/feedback</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
-
-  <!-- Authentication Pages -->
   <url>
     <loc>https://sahadhyayi.com/signin</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/signup</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
+    <priority>0.5</priority>
   </url>
-
-  <!-- Legal Pages -->
   <url>
     <loc>https://sahadhyayi.com/privacy</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/terms</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/cookies</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/dmca</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
-  
   <url>
     <loc>https://sahadhyayi.com/investors</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
+    <priority>0.5</priority>
   </url>
-
-  <!-- Dynamic Author Pages -->
-  <url>
-    <loc>https://sahadhyayi.com/authors/rabindranath-tagore</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://sahadhyayi.com/authors/haruki-murakami</loc>
-    <lastmod>2025-07-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <!-- Dynamic Book Pages -->
   <url>
     <loc>https://sahadhyayi.com/book/1</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://sahadhyayi.com/book/2</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://sahadhyayi.com/book/3</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://sahadhyayi.com/book/4</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://sahadhyayi.com/book/5</loc>
-    <lastmod>2025-07-12</lastmod>
+    <lastmod>2025-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/authors/rabindranath-tagore</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://sahadhyayi.com/authors/haruki-murakami</loc>
+    <lastmod>2025-07-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add `prebuild` npm script that prerenders pages and generates sitemap before the production build
- document build automation in README
- include generated `public/prerender` HTML and updated `sitemap.xml`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882bc888b84832096423e64538771b9