### PR TITLE
Enhance SEO scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Set `VITE_COMMUNITY_STATS_URL` to an empty string if the API is unavailable.
 
 ## Previewing the production build
 
-Run `npm run build` to generate the static assets in the `dist` folder. To test the build locally with history fallback, execute:
+Run `npm run build` to generate the static assets in the `dist` folder. The build process automatically runs `generate:sitemap` and `prerender` so the output contains a fresh `sitemap.xml` and HTML snapshots for important pages. To test the build locally with history fallback, execute:
 
 ```sh
 npm run preview
@@ -153,7 +153,7 @@ To clear existing website visit data and restart the auto-incrementing ID counte
 
 ## Generating Sitemap and Pre-rendered Pages
 
-Run `npm run generate:sitemap` to rebuild `public/sitemap.xml` with all important URLs, including author and book pages. To create static HTML pages with meta tags for key routes, execute `npm run prerender`. The generated files are placed under `public/prerender` and copied to the final build so search engines can index them easily.
+Run `npm run generate:sitemap` to rebuild `public/sitemap.xml` with all important URLs. If `VITE_SUPABASE_URL` and a service or anon key are available, the script pulls book and author data directly from Supabase before falling back to sample values. To create static HTML pages with meta tags for key routes, execute `npm run prerender`. It uses the same Supabase credentials to pre-render pages for each book and author under `public/prerender` so search engines can index the content on first load.
 
 ## Open Source Licenses & Compliance
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "npm run generate:licenses && npm run generate:sbom && vite build",
+    "build": "npm run generate:licenses && npm run generate:sbom && npm run generate:sitemap && npm run prerender && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/scripts/generateSitemap.js
+++ b/scripts/generateSitemap.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { createClient } from '@supabase/supabase-js';
 
 const staticPages = [
   '/',
@@ -23,18 +24,46 @@ const staticPages = [
   '/investors'
 ];
 
-const books = [
-  { id: '1', title: 'A Brief History of Time' },
-  { id: '2', title: 'गोदान' },
-  { id: '3', title: 'Pride and Prejudice' },
-  { id: '4', title: 'Sapiens' },
-  { id: '5', title: 'गुनाहों का देवता' }
-];
+let books = [];
+let authors = [];
 
-const authors = [
-  { name: 'Rabindranath Tagore' },
-  { name: 'Haruki Murakami' }
-];
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
+const SUPABASE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+
+if (SUPABASE_URL && SUPABASE_KEY) {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  try {
+    const { data: bookData } = await supabase
+      .from('books_library')
+      .select('id, title');
+    books = bookData || [];
+
+    const { data: authorData } = await supabase
+      .from('authors')
+      .select('name');
+    authors = authorData || [];
+  } catch (error) {
+    console.error('Failed to fetch data from Supabase:', error.message);
+  }
+}
+
+if (books.length === 0) {
+  books = [
+    { id: '1', title: 'A Brief History of Time' },
+    { id: '2', title: 'गोदान' },
+    { id: '3', title: 'Pride and Prejudice' },
+    { id: '4', title: 'Sapiens' },
+    { id: '5', title: 'गुनाहों का देवता' }
+  ];
+}
+
+if (authors.length === 0) {
+  authors = [
+    { name: 'Rabindranath Tagore' },
+    { name: 'Haruki Murakami' }
+  ];
+}
 
 const slugify = text => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { createClient } from '@supabase/supabase-js';
 
 const template = fs.readFileSync('index.html', 'utf8');
 
@@ -10,18 +11,46 @@ const basePages = [
   { path: '/about', title: 'About Sahadhyayi', description: 'Learn about the Sahadhyayi mission and community.' }
 ];
 
-const books = [
-  { id: '1', title: 'A Brief History of Time', description: 'An overview of cosmology and the origins of the universe.' },
-  { id: '2', title: 'गोदान', description: 'A classic Hindi novel depicting rural life in India.' },
-  { id: '3', title: 'Pride and Prejudice', description: 'A romantic novel that critiques the British landed gentry.' },
-  { id: '4', title: 'Sapiens', description: 'A brief history of humankind.' },
-  { id: '5', title: 'गुनाहों का देवता', description: 'A popular Hindi novel exploring a tragic love story.' }
-];
+let books = [];
+let authors = [];
 
-const authors = [
-  { name: 'Rabindranath Tagore', bio: 'Nobel Prize-winning Bengali polymath who reshaped Bengali literature and music.' },
-  { name: 'Haruki Murakami', bio: 'Japanese writer known for works blending surrealism with pop culture and magical realism.' }
-];
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
+const SUPABASE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+
+if (SUPABASE_URL && SUPABASE_KEY) {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+  try {
+    const { data: bookData } = await supabase
+      .from('books_library')
+      .select('id, title, description');
+    books = bookData || [];
+
+    const { data: authorData } = await supabase
+      .from('authors')
+      .select('name, bio');
+    authors = authorData || [];
+  } catch (error) {
+    console.error('Failed to fetch data from Supabase:', error.message);
+  }
+}
+
+if (books.length === 0) {
+  books = [
+    { id: '1', title: 'A Brief History of Time', description: 'An overview of cosmology and the origins of the universe.' },
+    { id: '2', title: 'गोदान', description: 'A classic Hindi novel depicting rural life in India.' },
+    { id: '3', title: 'Pride and Prejudice', description: 'A romantic novel that critiques the British landed gentry.' },
+    { id: '4', title: 'Sapiens', description: 'A brief history of humankind.' },
+    { id: '5', title: 'गुनाहों का देवता', description: 'A popular Hindi novel exploring a tragic love story.' }
+  ];
+}
+
+if (authors.length === 0) {
+  authors = [
+    { name: 'Rabindranath Tagore', bio: 'Nobel Prize-winning Bengali polymath who reshaped Bengali literature and music.' },
+    { name: 'Haruki Murakami', bio: 'Japanese writer known for works blending surrealism with pop culture and magical realism.' }
+  ];
+}
 
 const slugify = text => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 


### PR DESCRIPTION
## Summary
- fetch book and author data from Supabase when generating `sitemap.xml`
- prerender pages for books and authors using Supabase data
- run sitemap and prerender during `npm run build`
- document the new scripts in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882fb56014083208ec93fe3dc541752