### PR TITLE
Fix community stats button background

### DIFF
--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -108,7 +108,7 @@ const GlobalFooter = () => {
               size="sm"
               onClick={handleShowStats}
               disabled={isLoading}
-              className="border-white text-white hover:bg-white hover:text-orange-600 transition-all mb-4 font-medium"
+              className="border-white text-white bg-transparent hover:bg-white hover:text-orange-600 transition-all mb-4 font-medium"
             >
               <Users className="w-4 h-4 mr-2" />
               {isLoading ? 'Loading...' : showCount ? 'Hide Community Stats' : 'Show Community Stats'}


### PR DESCRIPTION
## Summary
- make the "Show Community Stats" button background transparent so it blends better with the footer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68830fd444688320a45b94d4df86b2ea