### PR TITLE
Fix author directory API and error handling

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+https://www.sahadhyayi.com/* https://sahadhyayi.com/:splat 301!

--- a/server.js
+++ b/server.js
@@ -4,11 +4,18 @@ import { Server } from 'socket.io';
 import dotenv from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 import goodreads from 'goodreads-api-node';
+import cors from 'cors';
 
 dotenv.config();
 
 const app = express();
 app.use(express.json());
+app.use(
+  cors({
+    origin: ['https://sahadhyayi.com', 'https://www.sahadhyayi.com'],
+    credentials: true,
+  })
+);
 const httpServer = createServer(app);
 
 const io = new Server(httpServer, {
@@ -86,6 +93,29 @@ app.get('/goodreads/request-token', async (req, res) => {
   }
 });
 
+// Search books by author name
+app.get('/api/books', async (req, res) => {
+  const { author } = req.query;
+
+  try {
+    const { data, error } = await supabase
+      .from('books_library')
+      .select('*')
+      .ilike('author', `%${author}%`)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+
+    res.json(data || []);
+  } catch (err) {
+    if (err.status === 401 || err.code === '401') {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    console.error('Error fetching books by author name:', err);
+    res.status(500).json({ error: 'Failed to load books' });
+  }
+});
+
 app.get('/goodreads/callback', async (req, res) => {
   try {
     await goodreadsClient.getAccessToken();
@@ -121,6 +151,66 @@ app.post('/goodreads/export', async (req, res) => {
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: error.message });
+  }
+});
+
+// Simple slugify helper used in author routes
+const slugify = (text) =>
+  text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+// Fetch paginated authors or a specific author by slug
+app.get('/api/authors', async (req, res) => {
+  const { page = '1', pageSize = '10', slug } = req.query;
+
+  try {
+    if (slug) {
+      const { data, error } = await supabase.rpc('get_authors_data');
+      if (error) throw error;
+      const author = (data || []).find((a) => slugify(a.name) === slug);
+      if (!author) return res.status(404).json({ error: 'Author not found' });
+      return res.json(author);
+    }
+
+    const startIndex = (parseInt(page) - 1) * parseInt(pageSize);
+    const endIndex = parseInt(page) * parseInt(pageSize) - 1;
+
+    const { data, error, count } = await supabase
+      .rpc('get_authors_with_books', {}, { count: 'exact' })
+      .range(startIndex, endIndex)
+      .order('name', { ascending: true });
+
+    if (error) throw error;
+
+    return res.json({ authors: data || [], total: count ?? (data ? data.length : 0) });
+  } catch (err) {
+    if (err.status === 401 || err.code === '401') {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    console.error('Error fetching authors:', err);
+    return res.status(500).json({ error: 'Failed to load authors' });
+  }
+});
+
+// Fetch books for a specific author
+app.get('/api/authors/:id/books', async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const { data, error } = await supabase
+      .from('books_library')
+      .select('*')
+      .eq('author_id', id)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+
+    res.json(data || []);
+  } catch (err) {
+    if (err.status === 401 || err.code === '401') {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    console.error('Error fetching author books:', err);
+    res.status(500).json({ error: 'Failed to load books' });
   }
 });
 

--- a/src/hooks/useAuthorBySlug.ts
+++ b/src/hooks/useAuthorBySlug.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
 import type { Author } from './useAuthors';
 
 const slugify = (text: string) =>
@@ -13,10 +12,16 @@ export const useAuthorBySlug = (slug?: string) => {
     queryKey: ['author', slug],
     enabled: !!slug,
     queryFn: async () => {
-      const { data, error } = await supabase.rpc('get_authors_data');
-      if (error) throw error;
-      const author = (data || []).find((a: any) => slugify(a.name) === slug);
-      return author as Author | null;
+      const res = await fetch(`/api/authors?slug=${slug}`, {
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const err: any = new Error('Failed to fetch author');
+        err.status = res.status;
+        throw err;
+      }
+      const author = (await res.json()) as Author | null;
+      return author;
     },
   });
 };

--- a/src/hooks/useAuthors.ts
+++ b/src/hooks/useAuthors.ts
@@ -1,7 +1,5 @@
 
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-import { mockAuthors } from "@/mockAuthors";
 
 export interface Author {
   id: string;
@@ -23,91 +21,25 @@ export interface Author {
   verification_type?: string;
 }
 
-// Mock fallback data for when API fails
-const fallbackAuthors: Author[] = [
-  {
-    id: '1',
-    name: 'Jane Smith',
-    bio: 'Award-winning fiction writer with over 10 published novels.',
-    profile_image_url: null,
-    location: 'New York, USA',
-    website_url: 'https://janesmith.com',
-    social_links: {},
-    genres: ['Fiction', 'Romance', 'Drama'],
-    books_count: 12,
-    followers_count: 2500,
-    rating: 4.5,
-    upcoming_events: 3,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    availableSlots: ['Monday 10:00 AM', 'Wednesday 2:00 PM']
-  },
-  {
-    id: '2',
-    name: 'Michael Johnson',
-    bio: 'Science fiction author and technology enthusiast.',
-    profile_image_url: null,
-    location: 'San Francisco, USA',
-    website_url: 'https://mjohnson.com',
-    social_links: {},
-    genres: ['Science Fiction', 'Technology', 'Thriller'],
-    books_count: 8,
-    followers_count: 1800,
-    rating: 4.2,
-    upcoming_events: 1,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    availableSlots: ['Tuesday 3:00 PM', 'Friday 11:00 AM']
-  }
-];
 
 export const useAuthors = () => {
   return useQuery({
     queryKey: ['authors'],
     queryFn: async (): Promise<Author[]> => {
-      console.log('Fetching authors with books from database...');
-
       try {
-        // Use the new function that only returns authors with books
-        const { data, error } = await supabase.rpc('get_authors_with_books');
-
-        if (error) {
-          console.error('Failed to fetch authors with books:', error.message || error);
-          console.info('Using fallback author data due to API error');
-          return fallbackAuthors;
+        const res = await fetch('/api/authors?page=1&pageSize=1000', {
+          credentials: 'include',
+        });
+        if (!res.ok) {
+          const err: any = new Error('Failed to fetch authors');
+          err.status = res.status;
+          throw err;
         }
-
-        if (!data || data.length === 0) {
-          console.warn('No authors with books found, using fallback data');
-          return fallbackAuthors;
-        }
-
-        console.log('Authors with books fetched successfully:', data.length);
-        return data.map((author: any) => ({
-          id: author.id,
-          name: author.name,
-          bio: author.bio || 'Bio will be updated by the author.',
-          profile_image_url: author.profile_image_url,
-          location: author.location || 'Unknown',
-          website_url: author.website_url,
-          social_links: author.social_links || {},
-          genres: author.genres || [],
-          books_count: parseInt(author.actual_books_count) || 0, // Use actual count from database
-          followers_count: author.followers_count || 0,
-          rating: parseFloat(author.rating) || 4.0,
-          upcoming_events: author.upcoming_events || 0,
-          created_at: author.created_at,
-          updated_at: author.updated_at,
-          verified: author.verified || false,
-          verification_type: author.verification_type,
-          availableSlots: author.actual_books_count > 0 ? 
-            [`Meet the author of ${author.actual_books_count} book${author.actual_books_count > 1 ? 's' : ''}`] : 
-            ['Available for consultation']
-        })) as Author[];
+        const json = await res.json();
+        return (json.authors || []) as Author[];
       } catch (err) {
         console.error('Exception while fetching authors:', err);
-        console.info('Using fallback author data due to exception');
-        return fallbackAuthors;
+        throw err;
       }
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
@@ -129,53 +61,20 @@ export const usePaginatedAuthors = (page = 1, pageSize = 10) => {
   return useQuery({
     queryKey: ['paginated-authors', page, pageSize],
     queryFn: async (): Promise<PaginatedAuthors> => {
-      const startIndex = (page - 1) * pageSize;
-      const endIndex = page * pageSize - 1;
-
       try {
-        const { data, error, count } = await supabase
-          .rpc('get_authors_with_books', {}, { count: 'exact' })
-          .range(startIndex, endIndex)
-          .order('name', { ascending: true });
-
-        if (error || !data) {
-          console.error('Failed to fetch paginated authors:', error?.message || error);
-          return {
-            authors: fallbackAuthors.slice(startIndex, endIndex + 1),
-            total: fallbackAuthors.length,
-          };
+        const res = await fetch(`/api/authors?page=${page}&pageSize=${pageSize}`, {
+          credentials: 'include',
+        });
+        if (!res.ok) {
+          const err: any = new Error('Failed to fetch authors');
+          err.status = res.status;
+          throw err;
         }
-
-        const authors = data.map((author: any) => ({
-          id: author.id,
-          name: author.name,
-          bio: author.bio || 'Bio will be updated by the author.',
-          profile_image_url: author.profile_image_url,
-          location: author.location || 'Unknown',
-          website_url: author.website_url,
-          social_links: author.social_links || {},
-          genres: author.genres || [],
-          books_count: parseInt(author.actual_books_count) || 0,
-          followers_count: author.followers_count || 0,
-          rating: parseFloat(author.rating) || 4.0,
-          upcoming_events: author.upcoming_events || 0,
-          created_at: author.created_at,
-          updated_at: author.updated_at,
-          verified: author.verified || false,
-          verification_type: author.verification_type,
-          availableSlots:
-            author.actual_books_count > 0
-              ? [`Meet the author of ${author.actual_books_count} book${author.actual_books_count > 1 ? 's' : ''}`]
-              : ['Available for consultation'],
-        })) as Author[];
-
-        return { authors, total: count ?? authors.length };
+        const json = await res.json();
+        return json as PaginatedAuthors;
       } catch (err) {
         console.error('Exception while fetching paginated authors:', err);
-        return {
-          authors: fallbackAuthors.slice(startIndex, endIndex + 1),
-          total: fallbackAuthors.length,
-        };
+        throw err;
       }
     },
     placeholderData: (previousData) => previousData,

--- a/src/pages/Authors.tsx
+++ b/src/pages/Authors.tsx
@@ -1,14 +1,13 @@
 
 import React, { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { Search, User, MapPin, Calendar, MessageSquare, Clock, AlertCircle, RefreshCw, Star, Users, BookOpen } from 'lucide-react';
+import { Search, User, MapPin, Calendar, MessageSquare, Clock, AlertCircle, Star, Users, BookOpen } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Alert, AlertDescription } from '@/components/ui/alert';
 import { ChatWindow } from "@/components/social/ChatWindow";
 import { ScheduleSessionDialog } from "@/components/authors/ScheduleSessionDialog";
 import SEO from '@/components/SEO';
@@ -179,27 +178,29 @@ const Authors = () => {
 
   // Error state with retry option
   if (error) {
+    const status = (error as any).status;
+    const unauthorized = status === 401 || status === 403;
     return (
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50">
         <div className="container mx-auto px-4 py-8">
-          <div className="text-center max-w-md mx-auto">
-            <AlertCircle className="w-16 h-16 text-red-500 mx-auto mb-4" />
-            <h1 className="text-2xl font-bold text-gray-900 mb-4">Unable to Load Authors</h1>
-            <Alert className="mb-6">
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>
-                {error.message || 'There was an error loading the authors data. Please try again.'}
-              </AlertDescription>
-            </Alert>
-            <div className="space-y-4">
-              <Button onClick={handleRetry} className="bg-orange-600 hover:bg-orange-700">
-                <RefreshCw className="w-4 h-4 mr-2" />
-                Try Again
-              </Button>
-              <p className="text-sm text-gray-500">
-                If the problem persists, please refresh the page or contact support.
-              </p>
-            </div>
+          <div className="text-center max-w-md mx-auto space-y-4">
+            <AlertCircle className="w-16 h-16 text-red-500 mx-auto" />
+            {unauthorized ? (
+              <>
+                <h1 className="text-2xl font-bold text-gray-900">Please sign in to view authors.</h1>
+                <Button asChild className="bg-orange-600 hover:bg-orange-700">
+                  <Link to="/signin">Sign In</Link>
+                </Button>
+              </>
+            ) : (
+              <>
+                <h1 className="text-2xl font-bold text-gray-900">Couldn't load authors.</h1>
+                <p className="text-gray-600">Couldn’t load authors. Please check your internet connection or try again later.</p>
+                <Button onClick={handleRetry} className="bg-orange-600 hover:bg-orange-700">
+                  Retry
+                </Button>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/authors/[slug].tsx
+++ b/src/pages/authors/[slug].tsx
@@ -31,7 +31,12 @@ const AuthorSlugPage = () => {
   const { slug } = useParams<{ slug: string }>();
   const { user } = useAuth();
   const { data: author, isLoading } = useAuthorBySlug(slug);
-  const { data: authorBooks, isLoading: booksLoading } = useAuthorBooks(author?.id || '');
+  const {
+    data: authorBooks,
+    isLoading: booksLoading,
+    isError: booksError,
+    refetch: refetchBooks,
+  } = useAuthorBooks(author?.id || '');
   const { data: authorPosts, isLoading: postsLoading } = useAuthorPosts(author?.id);
   const { data: questions, isLoading: questionsLoading } = useAuthorQuestions(author?.id);
   const { data: events, isLoading: eventsLoading } = useAuthorEvents(author?.id);
@@ -168,7 +173,7 @@ const AuthorSlugPage = () => {
                 <CardContent>
                   <div className="prose prose-gray dark:prose-invert max-w-none">
                     <p className="text-muted-foreground leading-relaxed text-base">
-                      {author.bio || `${author.name} is a distinguished author with ${author.books_count} published works. Their writing spans across ${author.genres?.join(', ') || 'various genres'}, captivating readers with compelling narratives and insightful perspectives.`}
+                      {author.bio || 'Bio not yet provided.'}
                     </p>
                   </div>
                   
@@ -178,7 +183,7 @@ const AuthorSlugPage = () => {
                         <div className="font-medium text-foreground">Location</div>
                         <div className="text-muted-foreground flex items-center gap-1">
                           <MapPin className="w-3 h-3" />
-                          {author.location}
+                          {author.location || 'Location not specified'}
                         </div>
                       </div>
                       <div>
@@ -223,6 +228,11 @@ const AuthorSlugPage = () => {
                           <div className="h-3 bg-muted rounded w-3/4"></div>
                         </div>
                       ))}
+                    </div>
+                  ) : booksError ? (
+                    <div className="text-center py-12 space-y-4">
+                      <p className="text-muted-foreground">Couldn't load books. Please try again.</p>
+                      <Button variant="outline" onClick={() => refetchBooks()}>Retry</Button>
                     </div>
                   ) : authorBooks && authorBooks.length > 0 ? (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- add CORS policy and new `/api` routes for authors and books
- redirect `www` subdomain to root domain
- fetch author data through relative API paths
- show helpful error messages on `/authors` page
- handle missing bio/location and book-load errors on author profile pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688331a0713c8320a19fc79f93b28ae2