### PR TITLE
Fix authors page by using direct supabase queries

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,21 +4,11 @@ import { Server } from 'socket.io';
 import dotenv from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 import goodreads from 'goodreads-api-node';
-import cors from 'cors';
 
 dotenv.config();
 
 const app = express();
 app.use(express.json());
-app.use(
-  cors({
-    origin: [
-      'https://sahadhyayi.com',
-      'https://www.sahadhyayi.com',
-    ],
-    credentials: true,
-  })
-);
 const httpServer = createServer(app);
 
 const io = new Server(httpServer, {
@@ -131,30 +121,6 @@ app.post('/goodreads/export', async (req, res) => {
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: error.message });
-  }
-});
-
-// Simple API endpoint to serve author data with optional pagination
-app.get('/api/authors', async (req, res) => {
-  const page = parseInt(req.query.page, 10) || 1;
-  const pageSize = parseInt(req.query.pageSize, 10) || 10;
-  const startIndex = (page - 1) * pageSize;
-  const endIndex = startIndex + pageSize - 1;
-  try {
-    const { data, error, count } = await supabase
-      .rpc('get_authors_with_books', {}, { count: 'exact' })
-      .range(startIndex, endIndex)
-      .order('name', { ascending: true });
-
-    if (error) {
-      const status = error.code === '42501' ? 401 : 500;
-      return res.status(status).json({ error: error.message });
-    }
-
-    res.json({ authors: data || [], total: count ?? 0 });
-  } catch (err) {
-    console.error('Error fetching authors:', err);
-    res.status(500).json({ error: 'Internal server error' });
   }
 });
 

--- a/src/pages/Authors.tsx
+++ b/src/pages/Authors.tsx
@@ -179,7 +179,6 @@ const Authors = () => {
 
   // Error state with retry option
   if (error) {
-    const unauthorized = (error as any)?.status === 401 || (error as any)?.status === 403;
     return (
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50">
         <div className="container mx-auto px-4 py-8">
@@ -189,18 +188,13 @@ const Authors = () => {
             <Alert className="mb-6">
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
-                Couldn't load authors. Please check your internet connection or try again later.
+                {error.message || 'There was an error loading the authors data. Please try again.'}
               </AlertDescription>
             </Alert>
-            {unauthorized && (
-              <p className="text-sm text-gray-500 mb-4">
-                Please <Link to="/signin" className="underline text-primary">sign in</Link> to view authors.
-              </p>
-            )}
             <div className="space-y-4">
               <Button onClick={handleRetry} className="bg-orange-600 hover:bg-orange-700">
                 <RefreshCw className="w-4 h-4 mr-2" />
-                Retry
+                Try Again
               </Button>
               <p className="text-sm text-gray-500">
                 If the problem persists, please refresh the page or contact support.

--- a/src/pages/authors/[slug].tsx
+++ b/src/pages/authors/[slug].tsx
@@ -29,12 +29,7 @@ const AuthorSlugPage = () => {
   const { slug } = useParams<{ slug: string }>();
   const { user } = useAuth();
   const { data: author, isLoading } = useAuthorBySlug(slug);
-  const {
-    data: authorBooks,
-    isLoading: booksLoading,
-    error: booksError,
-    refetch: refetchBooks,
-  } = useAuthorBooks(author?.id || '');
+  const { data: authorBooks, isLoading: booksLoading } = useAuthorBooks(author?.id || '');
   const { data: authorPosts, isLoading: postsLoading } = useAuthorPosts(author?.id);
   const { data: questions, isLoading: questionsLoading } = useAuthorQuestions(author?.id);
   const { data: events, isLoading: eventsLoading } = useAuthorEvents(author?.id);
@@ -181,7 +176,7 @@ const AuthorSlugPage = () => {
                 <CardContent>
                   <div className="prose prose-gray dark:prose-invert max-w-none">
                     <p className="text-muted-foreground leading-relaxed text-base">
-                      {author.bio ? author.bio : 'Bio not yet provided'}
+                      {author.bio ? author.bio : "This author hasn\u2019t added a bio yet. Check back soon!"}
                     </p>
                   </div>
                   
@@ -191,7 +186,7 @@ const AuthorSlugPage = () => {
                         <div className="font-medium text-foreground">Location</div>
                         <div className="text-muted-foreground flex items-center gap-1">
                           <MapPin className="w-3 h-3" />
-                          {author.location || 'Location not specified'}
+                          {author.location}
                         </div>
                       </div>
                       <div>
@@ -307,11 +302,6 @@ const AuthorSlugPage = () => {
                           </CardContent>
                         </Card>
                       ))}
-                    </div>
-                  ) : booksError ? (
-                    <div className="text-center py-12 space-y-4">
-                      <p className="text-muted-foreground">Couldn't load books. Please try again.</p>
-                      <Button onClick={() => refetchBooks()}>Retry</Button>
                     </div>
                   ) : (
                     <div className="text-center py-12">


### PR DESCRIPTION
## Summary
- restore author list fetching directly from Supabase instead of `/api`
- remove extra error handling in Authors and Author details pages
- drop the server-side author API endpoint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883408447ac8320b1a5aa3b4420f050