### PR TITLE
Fix author page book count

### DIFF
--- a/src/pages/AuthorDetails.tsx
+++ b/src/pages/AuthorDetails.tsx
@@ -310,7 +310,7 @@ const AuthorDetails = () => {
                     </div>
                     <div className="flex justify-between">
                       <span className="text-gray-600">Total Books</span>
-                      <span className="font-medium">{author.books_count}</span>
+                      <span className="font-medium">{authorBooks.length}</span>
                     </div>
                     <div className="flex justify-between">
                       <span className="text-gray-600">Average Rating</span>


### PR DESCRIPTION
## Summary
- fix `Total Books` statistic on author details page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688351556eec8320acd9ea312e59b359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Total Books" statistic in the Author Stats card now displays a live count based on the currently loaded books, ensuring accurate and up-to-date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->