### PR TITLE
Fix author Q&A submission

### DIFF
--- a/src/components/authors/QuestionAnswerCard.tsx
+++ b/src/components/authors/QuestionAnswerCard.tsx
@@ -19,7 +19,9 @@ export const QuestionAnswerCard = ({ qa }: QuestionAnswerCardProps) => {
           </div>
           <div className="flex items-center gap-1 text-xs text-muted-foreground">
             <Clock className="w-3 h-3" />
-            {formatDistanceToNow(new Date(qa.answered_at!), { addSuffix: true })}
+            {qa.answered_at
+              ? formatDistanceToNow(new Date(qa.answered_at), { addSuffix: true })
+              : 'Pending'}
           </div>
         </div>
       </CardHeader>
@@ -31,7 +33,11 @@ export const QuestionAnswerCard = ({ qa }: QuestionAnswerCardProps) => {
         <div className="border-t pt-4">
           <h4 className="font-medium text-foreground mb-2">Author's Answer:</h4>
           <div className="prose prose-sm dark:prose-invert max-w-none">
-            <p className="text-foreground leading-relaxed whitespace-pre-wrap">{qa.answer}</p>
+            {qa.answer ? (
+              <p className="text-foreground leading-relaxed whitespace-pre-wrap">{qa.answer}</p>
+            ) : (
+              <p className="text-muted-foreground italic">Awaiting response...</p>
+            )}
           </div>
         </div>
       </CardContent>

--- a/src/pages/authors/[slug].tsx
+++ b/src/pages/authors/[slug].tsx
@@ -32,7 +32,7 @@ const AuthorSlugPage = () => {
   const { data: author, isLoading } = useAuthorBySlug(slug);
   const { data: authorBooks, isLoading: booksLoading } = useAuthorBooks(author?.id || '');
   const { data: authorPosts, isLoading: postsLoading } = useAuthorPosts(author?.id);
-  const { data: questions, isLoading: questionsLoading } = useAuthorQuestions(author?.id);
+  const { data: questions, isLoading: questionsLoading } = useAuthorQuestions(author?.id, user?.id);
   const { data: events, isLoading: eventsLoading } = useAuthorEvents(author?.id);
 
   // Check if current user is the author


### PR DESCRIPTION
## Summary
- include pending questions for current user
- refresh Q&A list after submission
- show pending state in question cards
- pass user id when querying Q&A

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688351e8b8688320bd7e3c6ed8b6d795