### PR TITLE
Fix message button login check

### DIFF
--- a/src/components/social/ChatWindow.tsx
+++ b/src/components/social/ChatWindow.tsx
@@ -9,6 +9,7 @@ import { usePrivateMessages, useSendPrivateMessage } from '@/hooks/useMessages';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import SignInLink from '@/components/SignInLink';
 import { formatDistanceToNow } from 'date-fns';
 
 interface ChatWindowProps {
@@ -68,6 +69,19 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ friendId, isOpen, onClos
   const getInitials = (name: string) => {
     return name?.split(' ').map(n => n[0]).join('').toUpperCase() || 'U';
   };
+
+  if (!user) {
+    return (
+      <Dialog open={isOpen} onOpenChange={onClose}>
+        <DialogContent className="sm:max-w-md p-6 text-center space-y-4">
+          <p className="text-sm text-gray-600">Please sign in to send messages.</p>
+          <SignInLink>
+            <Button className="bg-orange-600 hover:bg-orange-700">Sign In</Button>
+          </SignInLink>
+        </DialogContent>
+      </Dialog>
+    );
+  }
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>

--- a/src/pages/Authors.tsx
+++ b/src/pages/Authors.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { ChatWindow } from "@/components/social/ChatWindow";
 import { ScheduleSessionDialog } from "@/components/authors/ScheduleSessionDialog";
+import { useAuth } from '@/contexts/AuthContext';
 import SEO from '@/components/SEO';
 import Breadcrumb from '@/components/ui/breadcrumb';
 import { usePaginatedAuthors, type Author } from '@/hooks/useAuthors';
@@ -415,6 +416,19 @@ interface AuthorCardProps {
 
 const AuthorCard: React.FC<AuthorCardProps> = ({ author, books, featured }) => {
   const [showChat, setShowChat] = useState(false);
+  const { user } = useAuth();
+
+  const handleMessageClick = () => {
+    if (!user) {
+      toast({
+        title: 'Authentication Required',
+        description: 'Please sign in to message authors.',
+        variant: 'destructive'
+      });
+      return;
+    }
+    setShowChat(true);
+  };
   const getAuthorInitials = (name: string) => {
     return name.split(' ').map(n => n.charAt(0)).join('').toUpperCase().slice(0, 2);
   };
@@ -530,7 +544,7 @@ const AuthorCard: React.FC<AuthorCardProps> = ({ author, books, featured }) => {
               variant="outline"
               size="sm"
               className="text-xs border-green-300 text-green-700 hover:bg-green-50"
-              onClick={() => setShowChat(true)}
+              onClick={handleMessageClick}
             >
               <MessageSquare className="w-3 h-3 mr-1" />
               Message


### PR DESCRIPTION
## Summary
- require authentication before opening chat on authors page
- prompt login in `ChatWindow` dialog if not signed in

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68835e4ae3e483208fa0add499ed0647