### PR TITLE
Fix community stats crash in mobile

### DIFF
--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -50,7 +50,11 @@ const GlobalFooter = () => {
     if (!user) {
       // Remember intent to join after the user signs in
       if (typeof window !== 'undefined') {
-        localStorage.setItem('joinCommunityAfterSignIn', 'true');
+        try {
+          localStorage.setItem('joinCommunityAfterSignIn', 'true');
+        } catch {
+          // ignore storage errors
+        }
       }
       setShowSignIn(true);
       return;

--- a/src/hooks/useCommunityStats.ts
+++ b/src/hooks/useCommunityStats.ts
@@ -12,9 +12,26 @@ interface CommunityStats {
 }
 
 export const useCommunityStats = (autoFetch: boolean = true) => {
+  const safeGetItem = (key: string): string | null => {
+    try {
+      return typeof window !== 'undefined' ? localStorage.getItem(key) : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const safeSetItem = (key: string, value: string) => {
+    try {
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(key, value);
+      }
+    } catch {
+      // Ignore write errors (e.g. private mode)
+    }
+  };
+
   const getCachedStats = (): CommunityStats | null => {
-    if (typeof window === 'undefined') return null;
-    const cached = localStorage.getItem(LOCAL_STORAGE_KEY);
+    const cached = safeGetItem(LOCAL_STORAGE_KEY);
     if (!cached) return null;
     try {
       return JSON.parse(cached) as CommunityStats;
@@ -65,9 +82,7 @@ export const useCommunityStats = (autoFetch: boolean = true) => {
       };
 
       setStats(updated);
-      if (typeof window !== 'undefined') {
-        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
-      }
+      safeSetItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
     } catch (err) {
       console.error('Failed to fetch community stats:', err);
       const fallback = {
@@ -76,9 +91,7 @@ export const useCommunityStats = (autoFetch: boolean = true) => {
         lastUpdated: new Date().toISOString(),
       };
       setStats(fallback);
-      if (typeof window !== 'undefined') {
-        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(fallback));
-      }
+      safeSetItem(LOCAL_STORAGE_KEY, JSON.stringify(fallback));
       setError('Failed to load community stats');
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- handle `localStorage` failures in `useCommunityStats`
- guard `joinCommunityAfterSignIn` flag with try/catch

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884fa0b9a648320a620e902cd49935e