### PR TITLE
Fix library book card layout on mobile

### DIFF
--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -84,9 +84,11 @@ const BookCard = ({ book, onDownloadPDF }: BookCardProps) => {
         </div>
 
         {/* Hover Overlay with Download and Details Buttons */}
-        <div className={`absolute inset-0 bg-black/60 flex items-center justify-center gap-3 transition-all duration-300 ${
-          isHovered ? 'opacity-100' : 'opacity-0'
-        }`}>
+        <div
+          className={`absolute inset-0 bg-black/60 flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-3 transition-all duration-300 ${
+            isHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
           {/* Download Button */}
           <button
             onClick={handleDownload}


### PR DESCRIPTION
## Summary
- stack BookCard overlay buttons vertically on small screens for mobile responsiveness

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884fd3774b0832089594e750f650649