### PR TITLE
Add search button on authors page

### DIFF
--- a/src/pages/Authors.tsx
+++ b/src/pages/Authors.tsx
@@ -265,15 +265,23 @@ const Authors = () => {
               <div className="lg:col-span-2">
                 <label htmlFor="author-search" className="sr-only">Search authors</label>
                 <div className="relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
                   <Input
                     id="author-search"
                     type="text"
                     placeholder="Search authors by name or bio..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10 h-12 bg-gray-50 border-2 border-gray-200 focus:border-orange-400 rounded-xl"
+                    className="pl-10 pr-10 h-12 bg-gray-50 border-2 border-gray-200 focus:border-orange-400 rounded-xl"
                   />
+                  <button
+                    type="button"
+                    onClick={() => setPage(1)}
+                    aria-label="Search"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                  >
+                    <Search className="w-5 h-5" />
+                  </button>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- add a search button next to the search box on the Authors page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688610a9e6f883209fbdb6c8df3d338d