### PR TITLE
Fix book details link by adding /books route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,6 +136,7 @@ function App() {
                         <Route path="/author/:id" element={<AuthorDetails />} />
                         <Route path="/author-profile/:id" element={<AuthorProfile />} />
                         <Route path="/book/:id" element={<BookDetails />} />
+                        <Route path="/books/:bookId" element={<BookDetails />} />
                         <Route 
                           path="/bookshelf" 
                           element={


### PR DESCRIPTION
## Summary
- update router to accept `/books/:bookId` in addition to `/book/:id`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68893abcbdd883209e8fdd7792bac56d