### PR TITLE
Fix social feed route

### DIFF
--- a/src/components/books/ReadingStats.tsx
+++ b/src/components/books/ReadingStats.tsx
@@ -104,7 +104,7 @@ const ReadingStats: React.FC<ReadingStatsProps> = ({ bookId, bookTitle }) => {
                 {showAllReaders ? 'Show Less' : `View All ${stats.readers.length} Readers`}
               </Button>
             )}
-            <Link to="/reviews" className="flex-1">
+            <Link to="/social" className="flex-1">
               <Button size="sm" className="bg-orange-600 hover:bg-orange-700 w-full">
                 <Share2 className="w-4 h-4 mr-2" />
                 Connect with Readers

--- a/src/components/dashboard/QuickActionsPanel.tsx
+++ b/src/components/dashboard/QuickActionsPanel.tsx
@@ -20,7 +20,7 @@ const QuickActionsPanel: React.FC = () => {
       title: 'Write Review',
       description: 'Share your thoughts on a book',
       icon: Edit,
-      onClick: () => navigate('/reviews'),
+      onClick: () => navigate('/social'),
       color: 'bg-blue-500 hover:bg-blue-600'
     },
     {

--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -172,7 +172,7 @@ const BookLibrary = () => {
               Available Books
             </h2>
             <Link 
-              to="/reviews" 
+              to="/social"
               className="inline-flex items-center gap-2 px-4 py-2 bg-amber-100 hover:bg-amber-200 text-amber-800 rounded-lg transition-colors font-medium"
             >
               <Users className="w-4 h-4" />
@@ -241,8 +241,8 @@ const BookLibrary = () => {
                   Share your reading journey, discover what others are reading, and join discussions about your favorite books. 
                   <Link to="/authors" className="text-amber-600 hover:text-amber-700 font-medium ml-1">Connect with authors</Link> too!
                 </p>
-                <Link 
-                  to="/reviews" 
+                <Link
+                  to="/social"
                   className="inline-flex items-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg transition-colors font-medium"
                 >
                   <Users className="w-4 h-4" />

--- a/src/utils/chatbotKnowledge.ts
+++ b/src/utils/chatbotKnowledge.ts
@@ -95,7 +95,7 @@ export const PLATFORM_FEATURES: PlatformFeature[] = [
   },
   {
     name: "Social Reading Community",
-    route: "/reviews",
+    route: "/social",
     description: "Join a vibrant community of book lovers and reading enthusiasts",
     keyFunctions: [
       "Connect with fellow readers and book enthusiasts",

--- a/src/utils/enhancedChatbotKnowledge.ts
+++ b/src/utils/enhancedChatbotKnowledge.ts
@@ -93,7 +93,7 @@ PLATFORM NAVIGATION:
 - Library: /library (Browse all books, search, filter)
 - Dashboard: /dashboard (Reading progress, goals, bookshelf)
 - Authors: /authors (Connect with authors, profiles, events)
-- Social: /reviews (Community, reviews, reading groups)
+ - Social: /social (Community, reviews, reading groups)
 - Profile: /profile (User settings, preferences)
 
 USER QUERY: ${userQuery}
@@ -180,7 +180,7 @@ export const populateInitialTrainingData = async (userId: string) => {
           interaction_type: "features"
         }
       }),
-      completion: "Key features include: free PDF downloads, reading progress tracking (/dashboard), author connections (/authors), social reading community (/reviews), book recommendations, and reading goals. All books are completely free to access."
+      completion: "Key features include: free PDF downloads, reading progress tracking (/dashboard), author connections (/authors), social reading community (/social), book recommendations, and reading goals. All books are completely free to access."
     },
     {
       prompt: JSON.stringify({


### PR DESCRIPTION
## Summary
- update `Explore Social Feed` links to `/social`
- fix dashboard quick action to navigate to `/social`
- update reading stats link to `/social`
- update chatbot knowledge references

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a00cad1148320986782239c6a06ba