### PR TITLE
Add apply and clear buttons for library filters

### DIFF
--- a/src/components/library/FilterPopup.tsx
+++ b/src/components/library/FilterPopup.tsx
@@ -5,7 +5,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Input } from '@/components/ui/input';
 import { Slider } from '@/components/ui/slider';
 import { Button } from '@/components/ui/button';
-import { Filter, X } from 'lucide-react';
+import { Filter } from 'lucide-react';
 
 interface FilterPopupProps {
   selectedGenre: string;
@@ -19,6 +19,8 @@ interface FilterPopupProps {
   priceRange: [number, number];
   onPriceRangeChange: (range: [number, number]) => void;
   onClearFilters: () => void;
+  onApplyFilters: () => void;
+  hasActiveFilters: boolean;
 }
 
 const FilterPopup = ({
@@ -32,22 +34,20 @@ const FilterPopup = ({
   onLanguageChange,
   priceRange,
   onPriceRangeChange,
-  onClearFilters
+  onClearFilters,
+  onApplyFilters,
+  hasActiveFilters
 }: FilterPopupProps) => {
   const genres = ['All', 'Fiction', 'Science', 'History', 'Biography', 'Philosophy', 'Technology', 'Self-Help'];
   const authors = ['All', 'J.K. Rowling', 'Stephen King', 'Agatha Christie', 'Isaac Asimov', 'Maya Angelou', 'Stephen Hawking'];
   const languages = ['All', 'English', 'Spanish', 'French', 'German', 'Italian', 'Portuguese'];
 
-  const hasActiveFilters = selectedGenre !== 'All' || selectedAuthor !== 'All' || 
-    selectedYear !== '' || selectedLanguage !== 'All' || 
-    priceRange[0] !== 0 || priceRange[1] !== 100;
-
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <Button 
-          variant="outline" 
-          size="sm" 
+        <Button
+          variant="outline"
+          size="sm"
           className="flex items-center gap-2 bg-white border-2 border-blue-200 hover:border-blue-400 transition-colors"
         >
           <Filter className="w-4 h-4" />
@@ -74,13 +74,12 @@ const FilterPopup = ({
                 onClick={onClearFilters}
                 className="text-sm"
               >
-                <X className="w-4 h-4 mr-1" />
                 Clear All
               </Button>
             )}
           </SheetTitle>
         </SheetHeader>
-        
+
         <div className="space-y-6">
           {/* Genre Filter */}
           <div className="space-y-3">
@@ -160,6 +159,13 @@ const FilterPopup = ({
                 className="w-full"
               />
             </div>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-4">
+            <Button variant="outline" onClick={onClearFilters}>
+              Clear Filters
+            </Button>
+            <Button onClick={onApplyFilters}>Apply Filters</Button>
           </div>
         </div>
       </SheetContent>

--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -15,6 +15,12 @@ const BookLibrary = () => {
   const [selectedLanguage, setSelectedLanguage] = useState<string>('All');
   const [priceRange, setPriceRange] = useState<[number, number]>([0, 100]);
 
+  const [draftGenre, setDraftGenre] = useState<string>('All');
+  const [draftAuthor, setDraftAuthor] = useState<string>('All');
+  const [draftYear, setDraftYear] = useState<string>('');
+  const [draftLanguage, setDraftLanguage] = useState<string>('All');
+  const [draftPriceRange, setDraftPriceRange] = useState<[number, number]>([0, 100]);
+
   useEffect(() => {
     const stored = sessionStorage.getItem('scroll-/library');
     if (stored) {
@@ -27,11 +33,24 @@ const BookLibrary = () => {
   }, []);
 
   const handleClearFilters = () => {
+    setDraftGenre('All');
+    setDraftAuthor('All');
+    setDraftYear('');
+    setDraftLanguage('All');
+    setDraftPriceRange([0, 100]);
     setSelectedGenre('All');
     setSelectedAuthor('All');
     setSelectedYear('');
     setSelectedLanguage('All');
     setPriceRange([0, 100]);
+  };
+
+  const handleApplyFilters = () => {
+    setSelectedGenre(draftGenre);
+    setSelectedAuthor(draftAuthor);
+    setSelectedYear(draftYear);
+    setSelectedLanguage(draftLanguage);
+    setPriceRange(draftPriceRange);
   };
 
   const handleSearch = () => {
@@ -128,17 +147,26 @@ const BookLibrary = () => {
                   />
                 </div>
                 <FilterPopup
-                  selectedGenre={selectedGenre}
-                  onGenreChange={setSelectedGenre}
-                  selectedAuthor={selectedAuthor}
-                  onAuthorChange={setSelectedAuthor}
-                  selectedYear={selectedYear}
-                  onYearChange={setSelectedYear}
-                  selectedLanguage={selectedLanguage}
-                  onLanguageChange={setSelectedLanguage}
-                  priceRange={priceRange}
-                  onPriceRangeChange={setPriceRange}
+                  selectedGenre={draftGenre}
+                  onGenreChange={setDraftGenre}
+                  selectedAuthor={draftAuthor}
+                  onAuthorChange={setDraftAuthor}
+                  selectedYear={draftYear}
+                  onYearChange={setDraftYear}
+                  selectedLanguage={draftLanguage}
+                  onLanguageChange={setDraftLanguage}
+                  priceRange={draftPriceRange}
+                  onPriceRangeChange={setDraftPriceRange}
                   onClearFilters={handleClearFilters}
+                  onApplyFilters={handleApplyFilters}
+                  hasActiveFilters={
+                    selectedGenre !== 'All' ||
+                    selectedAuthor !== 'All' ||
+                    selectedYear !== '' ||
+                    selectedLanguage !== 'All' ||
+                    priceRange[0] !== 0 ||
+                    priceRange[1] !== 100
+                  }
                 />
               </div>
 
@@ -158,7 +186,10 @@ const BookLibrary = () => {
                     'History'
                   ]}
                   selected={selectedGenre}
-                  onSelect={setSelectedGenre}
+                  onSelect={(g) => {
+                    setSelectedGenre(g);
+                    setDraftGenre(g);
+                  }}
                 />
               </div>
             </div>
@@ -198,8 +229,11 @@ const BookLibrary = () => {
             <div className="bg-white/80 backdrop-blur-sm p-6 rounded-xl border border-gray-200 hover:shadow-lg transition-all">
               <h3 className="text-lg font-semibold text-gray-900 mb-2">Fiction & Literature</h3>
               <p className="text-gray-600 mb-4">Explore classic and contemporary fiction from renowned authors worldwide.</p>
-              <button 
-                onClick={() => setSelectedGenre('Fiction')}
+              <button
+                onClick={() => {
+                  setSelectedGenre('Fiction');
+                  setDraftGenre('Fiction');
+                }}
                 className="text-amber-600 hover:text-amber-700 font-medium"
               >
                 Browse Fiction →
@@ -208,8 +242,11 @@ const BookLibrary = () => {
             <div className="bg-white/80 backdrop-blur-sm p-6 rounded-xl border border-gray-200 hover:shadow-lg transition-all">
               <h3 className="text-lg font-semibold text-gray-900 mb-2">Hindi Literature</h3>
               <p className="text-gray-600 mb-4">Discover the rich tradition of Hindi literature and contemporary works.</p>
-              <button 
-                onClick={() => setSelectedLanguage('Hindi')}
+              <button
+                onClick={() => {
+                  setSelectedLanguage('Hindi');
+                  setDraftLanguage('Hindi');
+                }}
                 className="text-amber-600 hover:text-amber-700 font-medium"
               >
                 Browse Hindi Books →
@@ -218,8 +255,11 @@ const BookLibrary = () => {
             <div className="bg-white/80 backdrop-blur-sm p-6 rounded-xl border border-gray-200 hover:shadow-lg transition-all">
               <h3 className="text-lg font-semibold text-gray-900 mb-2">Science & Technology</h3>
               <p className="text-gray-600 mb-4">Stay updated with the latest scientific discoveries and technological advances.</p>
-              <button 
-                onClick={() => setSelectedGenre('Science')}
+              <button
+                onClick={() => {
+                  setSelectedGenre('Science');
+                  setDraftGenre('Science');
+                }}
                 className="text-amber-600 hover:text-amber-700 font-medium"
               >
                 Browse Science Books →


### PR DESCRIPTION
## Summary
- introduce temporary filter state in `BookLibrary`
- add `Apply Filters` and `Clear Filters` actions in `FilterPopup`
- apply filters only when user clicks Apply

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a01627e6c832098e243eba81c3a25