### PR TITLE
Fix search bar Enter key

### DIFF
--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -19,12 +19,16 @@ const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
       onError: (error) => console.error('Speech recognition error:', error)
     })
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        e.preventDefault()
-        onSearch?.()
-      }
-    }
+    // Trigger search when user presses Enter
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          onSearch?.()
+        }
+      },
+      [onSearch]
+    )
 
     return (
       <div className={cn('relative w-full', className)}>


### PR DESCRIPTION
## Summary
- trigger search when pressing Enter in the search bar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a01aa3e4c8320af512d226c0ccc86