### PR TITLE
Integrate Libgen open access search

### DIFF
--- a/src/components/books/BookSearchBar.tsx
+++ b/src/components/books/BookSearchBar.tsx
@@ -8,10 +8,12 @@ import { useToast } from '@/hooks/use-toast';
 interface BookSearchBarProps {
   onSearch: (searchTerm: string) => void;
   loading: boolean;
+  onToggleExternal?: (value: boolean) => void;
 }
 
-const BookSearchBar: React.FC<BookSearchBarProps> = ({ onSearch, loading }) => {
+const BookSearchBar: React.FC<BookSearchBarProps> = ({ onSearch, loading, onToggleExternal }) => {
   const [searchTerm, setSearchTerm] = useState('');
+  const [useExternal, setUseExternal] = useState(true);
   const { toast } = useToast();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -56,8 +58,14 @@ const BookSearchBar: React.FC<BookSearchBarProps> = ({ onSearch, loading }) => {
     setSearchTerm(value);
   };
 
+  const handleToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.checked;
+    setUseExternal(val);
+    onToggleExternal?.(val);
+  };
+
   return (
-    <form onSubmit={handleSubmit} className="flex gap-3 w-full max-w-2xl">
+    <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-3 w-full max-w-2xl">
       <div className="relative flex-1">
         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
         <Input
@@ -86,6 +94,12 @@ const BookSearchBar: React.FC<BookSearchBarProps> = ({ onSearch, loading }) => {
           </>
         )}
       </Button>
+      {onToggleExternal && (
+        <label className="flex items-center text-xs gap-2 pl-1">
+          <input type="checkbox" checked={useExternal} onChange={handleToggle} />
+          Search External Sources
+        </label>
+      )}
     </form>
   );
 };

--- a/src/components/books/OpenAccessBookCard.tsx
+++ b/src/components/books/OpenAccessBookCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ExternalBook } from '@/utils/searchExternalSources';
+
+interface Props {
+  book: ExternalBook;
+}
+
+const OpenAccessBookCard: React.FC<Props> = ({ book }) => {
+  return (
+    <Card className="bg-white/70 backdrop-blur-sm hover:shadow-lg transition">
+      <CardContent className="p-4 space-y-2">
+        <h3 className="font-semibold leading-snug">{book.title}</h3>
+        {book.author && (
+          <p className="text-sm text-muted-foreground">{book.author}</p>
+        )}
+        <div className="text-xs text-muted-foreground flex flex-wrap gap-2">
+          {book.year && <span>{book.year}</span>}
+          {book.language && <span>{book.language}</span>}
+          {book.extension && <span>{book.extension.toUpperCase()}</span>}
+          {book.size && <span>{book.size}</span>}
+        </div>
+        <Button asChild size="sm" className="mt-2">
+          <a href={book.downloadUrl} target="_blank" rel="noopener noreferrer">
+            Download
+          </a>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default OpenAccessBookCard;

--- a/src/components/library/BookSelectionModal.tsx
+++ b/src/components/library/BookSelectionModal.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { BookOpen, Download, Plus, Check, User } from 'lucide-react';
+import OpenAccessBookCard from '@/components/books/OpenAccessBookCard';
+import type { ExternalBook } from '@/utils/searchExternalSources';
 import { Link } from 'react-router-dom';
 import { slugify } from '@/utils/slugify';
 import { useAddToPersonalLibrary } from '@/hooks/usePersonalLibrary';
@@ -30,11 +32,12 @@ interface BookSelectionModalProps {
   isOpen: boolean;
   onClose: () => void;
   books: BookSearchResult[];
+  externalBooks?: ExternalBook[];
   searchTerm: string;
   onBooksAdded?: () => void;
 }
 
-const BookSelectionModal = ({ isOpen, onClose, books, searchTerm, onBooksAdded }: BookSelectionModalProps) => {
+const BookSelectionModal = ({ isOpen, onClose, books, externalBooks = [], searchTerm, onBooksAdded }: BookSelectionModalProps) => {
   const { user } = useAuth();
   const addToLibraryMutation = useAddToPersonalLibrary();
   const { saveSelectedBooks, loading: isSaving } = useBookSearch();
@@ -318,6 +321,20 @@ const BookSelectionModal = ({ isOpen, onClose, books, searchTerm, onBooksAdded }
             );
           })}
         </div>
+
+        {externalBooks.length > 0 && (
+          <div className="mt-6 space-y-4">
+            <h3 className="text-lg font-semibold flex items-center gap-2">
+              <BookOpen className="w-4 h-4" />
+              <span>\ud83d\udcda Found on Open Access Sources</span>
+            </h3>
+            <div className="grid gap-4">
+              {externalBooks.map(book => (
+                <OpenAccessBookCard key={book.id} book={book} />
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="flex justify-between items-center gap-2 mt-6 pt-4 border-t">
           <div className="text-sm text-muted-foreground">

--- a/src/utils/searchExternalSources.ts
+++ b/src/utils/searchExternalSources.ts
@@ -1,0 +1,47 @@
+export interface ExternalBook {
+  id: string;
+  title: string;
+  author?: string;
+  year?: string;
+  language?: string;
+  extension?: string;
+  size?: string;
+  md5: string;
+  downloadUrl: string;
+}
+
+/**
+ * Search Libgen for books matching the query and construct
+ * direct download links via library.lol.
+ * Returns an array of ExternalBook objects.
+ */
+export async function searchExternalSources(query: string): Promise<ExternalBook[]> {
+  const encoded = encodeURIComponent(query);
+  const url = `https://libgen.gs/search.php?req=${encoded}&res=20&format=json`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Libgen request failed');
+    const data = await res.json();
+
+    if (!Array.isArray(data)) return [];
+
+    return data.map((item: any) => {
+      const md5: string = item.md5;
+      return {
+        id: md5,
+        md5,
+        title: item.title || 'Unknown Title',
+        author: item.author,
+        year: item.year,
+        language: item.language,
+        extension: item.extension,
+        size: item.filesize || item.filesize_size || item.size,
+        downloadUrl: `http://library.lol/main/${md5}`
+      } as ExternalBook;
+    });
+  } catch (err) {
+    console.error('searchExternalSources error:', err);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add `searchExternalSources` helper to query Libgen
- add `OpenAccessBookCard` component
- show external results in `BookSelectionModal`
- wire new search flow and toggle in `BooksCollection`
- add optional external search toggle to `BookSearchBar`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b054204b48320af6b3de70ec38abf