### PR TITLE
Fix page visit hook usage in non-browser environments

### DIFF
--- a/src/hooks/usePageVisitTracker.ts
+++ b/src/hooks/usePageVisitTracker.ts
@@ -1,9 +1,10 @@
 
-import * as React from 'react';
+import { useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 
 export const usePageVisitTracker = () => {
-  React.useEffect(() => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
     const recordVisit = async () => {
       try {
         // Get basic visitor info


### PR DESCRIPTION
## Summary
- avoid `React.useEffect` null errors by using the hook from `react`
- skip page visit tracking when no `window` is available

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bd821310c832089cbfb312331b54c