### PR TITLE
Fix supabase config fallback

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,7 +20,8 @@ const io = new Server(httpServer, {
 });
 
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
-const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
 
 if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
   throw new Error('Missing Supabase configuration');


### PR DESCRIPTION
## Summary
- allow server to start if SUPABASE_SERVICE_ROLE_KEY is missing by falling back to the anon key

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bda0d7b688320bff37a6a56e1ab59