### PR TITLE
Fix HTML validation issue

### DIFF
--- a/live-map.html
+++ b/live-map.html
@@ -107,7 +107,7 @@
         el.style.display = 'block';
       }
     </script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap" async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&amp;callback=initMap" async defer></script>
   </head>
   <body>
     <div id="error"></div>


### PR DESCRIPTION
## Summary
- fix unescaped `&` in `live-map.html`
- run HTML tidy checks, lint, and build

## Testing
- `npm run lint`
- `npm run build`
- `tidy -e live-map.html`


------
https://chatgpt.com/codex/tasks/task_e_688cbf336d74832082e4b5f4860ac45c