### PR TITLE
Standardize library pagination options

### DIFF
--- a/src/components/library/BooksCollection.tsx
+++ b/src/components/library/BooksCollection.tsx
@@ -456,7 +456,7 @@ const BooksCollection = ({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent className="bg-white border-2 border-gray-200 shadow-lg z-50">
-                      {[5, 10, 20].map((size) => (
+                      {[10, 20, 40, 100].map((size) => (
                         <SelectItem key={size} value={size.toString()}>{size}</SelectItem>
                       ))}
                     </SelectContent>
@@ -514,7 +514,7 @@ const BooksCollection = ({
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent className="bg-white border-2 border-gray-200 shadow-lg z-50">
-                        {[5, 10, 20].map((size) => (
+                        {[10, 20, 40, 100].map((size) => (
                           <SelectItem key={size} value={size.toString()}>{size}</SelectItem>
                         ))}
                       </SelectContent>

--- a/src/components/library/LibraryPagination.tsx
+++ b/src/components/library/LibraryPagination.tsx
@@ -138,7 +138,7 @@ const LibraryPagination: React.FC<LibraryPaginationProps> = ({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {[10, 20, 30, 50].map((size) => (
+              {[10, 20, 40, 100].map((size) => (
                 <SelectItem key={size} value={size.toString()} className="font-medium">
                   {size}
                 </SelectItem>


### PR DESCRIPTION
## Summary
- unify page size selectors in `BooksCollection` and `LibraryPagination`
- options are now `10, 20, 40, 100` across the library views

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cbfe2d4008320b4ffd9fb6e303a0d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated pagination options to allow users to select from 10, 20, 40, or 100 books per page in both the "All Books" and "My Personal Library" tabs.

* **Enhancements**
  * Increased the minimum page size and added larger options for viewing more books per page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->