### PR TITLE
Fix sign-in links on book details page

### DIFF
--- a/src/components/books/BookIdeasSection.tsx
+++ b/src/components/books/BookIdeasSection.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import SignInLink from '@/components/SignInLink';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -236,7 +237,9 @@ const BookIdeasSection = ({ bookId, bookTitle }: BookIdeasSectionProps) => {
         <Card className="bg-white/80 backdrop-blur-sm border-green-200 shadow-sm">
           <CardContent className="p-6 text-center">
             <p className="text-gray-600 mb-4">Sign in to share your ideas and feedback</p>
-            <Button variant="outline">Sign In</Button>
+            <Button variant="outline" asChild>
+              <SignInLink>Sign In</SignInLink>
+            </Button>
           </CardContent>
         </Card>
       )}

--- a/src/components/books/BookReadersConnection.tsx
+++ b/src/components/books/BookReadersConnection.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import SignInLink from '@/components/SignInLink';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -193,7 +194,9 @@ const BookReadersConnection = ({ bookId, bookTitle }: BookReadersConnectionProps
       ) : (
         <div className="bg-white/80 backdrop-blur-sm rounded-xl p-6 border border-blue-200 shadow-sm text-center">
           <p className="text-gray-600 mb-4">Sign in to connect with fellow readers and share your thoughts</p>
-          <Button variant="outline">Sign In</Button>
+          <Button variant="outline" asChild>
+            <SignInLink>Sign In</SignInLink>
+          </Button>
         </div>
       )}
 

--- a/src/components/books/CreateYourVersionSection.tsx
+++ b/src/components/books/CreateYourVersionSection.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import SignInLink from '@/components/SignInLink';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -221,7 +222,9 @@ const CreateYourVersionSection = ({ bookId, bookTitle }: CreateYourVersionSectio
         <Card className="bg-white/80 backdrop-blur-sm border-purple-200 shadow-sm">
           <CardContent className="p-6 text-center">
             <p className="text-gray-600 mb-4">Sign in to create and share your own versions</p>
-            <Button variant="outline">Sign In</Button>
+            <Button variant="outline" asChild>
+              <SignInLink>Sign In</SignInLink>
+            </Button>
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
## Summary
- add `SignInLink` component to book idea/comment sections
- wire sign-in buttons in reader connection, ideas, and user versions sections

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cc44536748320b2dc1ec2f69e43e0