### PR TITLE
feat: rename header link to Sahadhyayi

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -97,7 +97,7 @@ const Navigation = () => {
               alt="Sahadhyayi navigation logo"
               className="w-8 h-8 flex-shrink-0"
             />
-            <span className="whitespace-nowrap leading-none">Digital Library</span>
+            <span className="whitespace-nowrap leading-none">Sahadhyayi</span>
           </Link>
 
           {/* Desktop Navigation */}


### PR DESCRIPTION
## Summary
- update navigation header text to display "Sahadhyayi" instead of "Digital Library"

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e8ae99238832099d3a70750bc86eb