### PR TITLE
Fix service worker registration in insecure contexts

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,10 +27,12 @@ root.render(
 
 console.log('App rendered successfully');
 
-if ('serviceWorker' in navigator) {
+if ('serviceWorker' in navigator && window.isSecureContext) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js').catch(err => {
       console.error('Service Worker registration failed:', err);
     });
   });
+} else {
+  console.warn('Service Worker not registered: insecure context or unsupported browser');
 }


### PR DESCRIPTION
## Summary
- check for secure context before registering service worker
- warn when service workers unsupported or insecure

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f0c8dad0483209b72885955df58d5