### PR TITLE
Fix atom orbit alignment and display labels

### DIFF
--- a/src/components/AnimatedHero.tsx
+++ b/src/components/AnimatedHero.tsx
@@ -150,10 +150,11 @@ const AnimatedHero: React.FC = () => {
   const maskSize = ringConfig.inner.radius * 2 - (isMobile ? 40 : 80); // Smaller mask for mobile
 
   const [isAnyAtomHovered, setIsAnyAtomHovered] = useState(false);
+  // Align atoms with ring stroke by using the ring radius minus half the stroke width
   const [occupiedOrbits, setOccupiedOrbits] = useState<Record<string, number>>({
-    L: ringConfig.outer.radius,
-    A: ringConfig.middle.radius,
-    S: ringConfig.inner.radius,
+    L: ringConfig.outer.radius - ringStroke / 2,
+    A: ringConfig.middle.radius - ringStroke / 2,
+    S: ringConfig.inner.radius - ringStroke / 2,
   });
 
   useEffect(() => {
@@ -165,11 +166,11 @@ const AnimatedHero: React.FC = () => {
 
   useEffect(() => {
     setOccupiedOrbits({
-      L: ringConfig.outer.radius,
-      A: ringConfig.middle.radius,
-      S: ringConfig.inner.radius,
+      L: ringConfig.outer.radius - ringStroke / 2,
+      A: ringConfig.middle.radius - ringStroke / 2,
+      S: ringConfig.inner.radius - ringStroke / 2,
     });
-  }, [ringConfig]);
+  }, [ringConfig, ringStroke]);
 
   const updateAtomOrbit = (atomLetter: string, newOrbit: number) => {
     setOccupiedOrbits(prev => ({
@@ -179,7 +180,11 @@ const AnimatedHero: React.FC = () => {
   };
 
   const getAvailableOrbits = (currentAtom: string) => {
-    const allOrbits = [ringConfig.outer.radius, ringConfig.middle.radius, ringConfig.inner.radius];
+    const allOrbits = [
+      ringConfig.outer.radius - ringStroke / 2,
+      ringConfig.middle.radius - ringStroke / 2,
+      ringConfig.inner.radius - ringStroke / 2,
+    ];
     const currentAtomOrbit = occupiedOrbits[currentAtom];
     
     return allOrbits.filter(orbit => {

--- a/src/components/hero/AtomMaterials.tsx
+++ b/src/components/hero/AtomMaterials.tsx
@@ -43,7 +43,6 @@ export const ATOM_MATERIALS: Record<string, AtomMaterial> = {
 interface AtomShellProps {
   material: AtomMaterial;
   letter: string;
-  label: string;
   isHovered: boolean;
   size?: number;
 }
@@ -51,7 +50,6 @@ interface AtomShellProps {
 export const AtomShell: React.FC<AtomShellProps> = ({
   material,
   letter,
-  label,
   isHovered,
   size = 48,
 }) => {
@@ -84,33 +82,6 @@ export const AtomShell: React.FC<AtomShellProps> = ({
       <span className="relative z-10 font-extrabold tracking-wider">
         {letter}
       </span>
-      
-      {/* Enhanced Tooltip - Fixed positioning */}
-      {isHovered && (
-        <div
-          className="fixed rounded-xl shadow-2xl whitespace-nowrap text-base font-semibold pointer-events-none z-[9999] animate-fade-in"
-          style={{
-            left: "50%",
-            top: "20%",
-            transform: "translate(-50%, -50%)",
-            background: "rgba(0, 0, 0, 0.95)",
-            color: "#ffffff",
-            border: `2px solid ${material.border.match(/rgba\([^)]+\)/)?.[0] || "#ffffff"}`,
-            padding: "0.75rem 1.25rem",
-            backdropFilter: "blur(12px)",
-            boxShadow: `${material.glowEffect}, 0 8px 32px rgba(0,0,0,0.5)`,
-            minWidth: "140px",
-            textAlign: "center" as const,
-            borderRadius: "12px",
-          }}
-        >
-          <div className="flex items-center justify-center gap-2">
-            <span className="font-bold text-lg">{letter}</span>
-            <span className="text-gray-300">–</span>
-            <span className="font-semibold">{label}</span>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/hero/OrbitingAtom.tsx
+++ b/src/components/hero/OrbitingAtom.tsx
@@ -97,7 +97,7 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
       </svg>
       
       <div
-        className="absolute pointer-events-auto cursor-pointer"
+        className="absolute pointer-events-auto cursor-pointer flex flex-col items-center"
         style={{
           offsetPath: `path('M 0 ${currentOrbitRadius} A ${currentOrbitRadius} ${currentOrbitRadius} 0 0 1 ${orbitSize} ${currentOrbitRadius}')`,
           offsetRotate: "0deg", // Keep atoms upright
@@ -125,10 +125,15 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
         <AtomShell
           material={material}
           letter={letter}
-          label={label}
           isHovered={isHovered}
           size={size}
         />
+        {/* Always-visible label for accessibility */}
+        <div
+          className="mt-1 px-2 py-0.5 rounded-full text-xs font-medium text-white bg-black/80 pointer-events-none whitespace-nowrap"
+        >
+          {label}
+        </div>
       </div>
       
       <style>{`


### PR DESCRIPTION
## Summary
- Align atoms with coloured rings by subtracting ring stroke width
- Replace hover-only tooltips with persistent labels beneath each atom

## Testing
- `npm run lint` (fails: React Hook rules-of-hooks errors in unrelated files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f56ddcb5083209d08695be592cdfa