### PR TITLE
Refine mobile hero text and button sizing

### DIFF
--- a/src/components/hero/HeroContent.tsx
+++ b/src/components/hero/HeroContent.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 export const HeroContent: React.FC = () => {
   return (
     <div className="relative z-10 text-center max-w-sm px-4 sm:px-6 py-8 mx-auto">
-      <h1 className="text-4xl sm:text-5xl font-bold mb-4">
+      <h1 className="text-3xl sm:text-5xl font-bold mb-4">
         <span
           className="text-transparent bg-clip-text animate-gradient-shift"
           style={{
@@ -16,16 +16,16 @@ export const HeroContent: React.FC = () => {
         </span>
       </h1>
 
-      <h2 className="text-xl sm:text-2xl font-semibold text-white mb-4">
+      <h2 className="text-lg sm:text-2xl font-semibold text-white mb-4">
         The Book Readers Social Media
       </h2>
 
-      <p className="text-gray-300 text-base sm:text-lg mb-8 leading-relaxed">
+      <p className="text-gray-300 text-sm sm:text-lg mb-8 leading-relaxed">
         Find new books, connect with readers, and share your love of reading—all in one friendly community.
       </p>
 
       <Link to="/library">
-        <button className="group px-6 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-red-500 via-green-500 to-blue-500 text-white rounded-full font-semibold transition-all duration-300 flex items-center justify-center gap-3 shadow-xl mx-auto text-base sm:text-lg hover:shadow-2xl hover:scale-105">
+        <button className="group px-4 sm:px-8 py-2 sm:py-4 bg-gradient-to-r from-red-500 via-green-500 to-blue-500 text-white rounded-full font-semibold transition-all duration-300 flex items-center justify-center gap-2 sm:gap-3 shadow-xl mx-auto text-sm sm:text-lg hover:shadow-2xl hover:scale-105">
           <span role="img" aria-label="Book" className="group-hover:animate-bounce">📚</span>
           <span>Explore the Library</span>
         </button>


### PR DESCRIPTION
## Summary
- decrease animated hero heading and subheading font sizes on small screens
- shrink hero description and call-to-action button for mobile

## Testing
- `npm run lint` *(fails: React hooks called conditionally in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f7dc7d83483209a903a31b7480ce7