### PR TITLE
Fix loader persisting after refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,10 +194,23 @@
         sessionStorage.removeItem('redirectPath');
         history.replaceState(null, '', redirectPath);
       }
-      window.addEventListener('load', () => {
+
+      // Hide the loader as soon as the DOM is ready
+      const hideLoader = () => {
         const loader = document.getElementById('loader');
-        if (loader) loader.style.display = 'none';
-      });
+        if (loader) {
+          loader.style.display = 'none';
+        }
+      };
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', hideLoader);
+      } else {
+        hideLoader();
+      }
+
+      // Fallback in case DOMContentLoaded doesn't fire
+      window.addEventListener('load', hideLoader);
     </script>
     <!-- Google Search Console verification -->
     <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,7 +26,13 @@ console.log('Root container found');
 
 function initializeApp() {
   console.log('Initializing app with ReactLoader...');
-  
+
+  // Ensure any initial loader is removed once React starts initializing
+  const initialLoader = document.getElementById('loader');
+  if (initialLoader) {
+    initialLoader.style.display = 'none';
+  }
+
   try {
     const root = createRoot(container);
     console.log('React root created successfully');


### PR DESCRIPTION
## Summary
- Hide initial loader once DOM is ready with fallback
- Remove loader during app initialization to avoid stuck spinner

## Testing
- `npm run lint` *(fails: React Hook "React.useState" is called conditionally)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fb50f951083208acaf82146a4364e