### PR TITLE
refactor: simplify book routes and clarify author pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,14 +74,15 @@ function App() {
                         <Route path="/profile" element={<Profile />} />
                         <Route path="/social" element={<SocialMedia />} />
                         <Route path="/authors" element={<Authors />} />
+                        {/* Main author profile page accessed via slug */}
                         <Route path="/authors/:slug" element={<AuthorSlugPage />} />
-                        <Route path="/author/:id" element={<AuthorDetails />} />
+                        {/* Legacy author page accessed via /author/:slug */}
+                        <Route path="/author/:slug" element={<AuthorDetails />} />
                         <Route path="/groups" element={<ReadingGroups />} />
                         <Route path="/map" element={<Map />} />
                         <Route path="/about" element={<About />} />
                         <Route path="/blog" element={<Blog />} />
                         <Route path="/book/:id" element={<BookDetails />} />
-                        <Route path="/books/:bookId" element={<BookDetails />} />
                         <Route path="*" element={<NotFound />} />
                       </Routes>
                     </main>

--- a/src/pages/AuthorDetails.tsx
+++ b/src/pages/AuthorDetails.tsx
@@ -22,8 +22,9 @@ import { useToast } from '@/hooks/use-toast';
 import SEO from '@/components/SEO';
 import LoadingSpinner from '@/components/LoadingSpinner';
 
+// Legacy author details page accessed via /author/:slug
 const AuthorDetails = () => {
-  const { id } = useParams<{ id: string }>();
+  const { slug } = useParams<{ slug: string }>();
   const { user } = useAuth();
   const { toast } = useToast();
   const [isFullBioExpanded, setIsFullBioExpanded] = useState(false);
@@ -31,7 +32,7 @@ const AuthorDetails = () => {
   const [showMessageForm, setShowMessageForm] = useState(false);
   const [messageText, setMessageText] = useState('');
 
-  const { data: author, isLoading: authorLoading, error: authorError } = useAuthorBySlug(id);
+  const { data: author, isLoading: authorLoading, error: authorError } = useAuthorBySlug(slug);
   const { data: books = [], isLoading: booksLoading } = useAuthorBooks(author?.id || '');
 
   const handleDownloadPDF = (book: any) => {

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -19,11 +19,10 @@ import { useBookById } from '@/hooks/useBookById';
 import { generateBookSchema, generateBreadcrumbSchema } from '@/utils/schema';
 
 const BookDetails = () => {
-  const { id, bookId } = useParams<{ id?: string; bookId?: string }>();
-  const actualId = id || bookId; // Handle both /book/:id and /books/:bookId routes
-  const { data: book, isLoading, error } = useBookById(actualId);
+  const { id } = useParams<{ id: string }>();
+  const { data: book, isLoading, error } = useBookById(id);
 
-  console.log('BookDetails - Route params:', { id, bookId, actualId });
+  console.log('BookDetails - Route params:', { id });
   console.log('BookDetails - Book data:', book);
   console.log('BookDetails - Loading state:', isLoading);
   console.log('BookDetails - Error state:', error);
@@ -70,7 +69,7 @@ const BookDetails = () => {
           </div>
           <h1 className="text-2xl font-bold text-gray-900 mb-2">Book Not Found</h1>
           <p className="text-gray-600 mb-4">Sorry, we couldn't find the book you're looking for.</p>
-          <p className="text-sm text-gray-500 mb-4">Book ID: {actualId}</p>
+          <p className="text-sm text-gray-500 mb-4">Book ID: {id}</p>
           <Link to="/library">
             <Button variant="outline">
               <ArrowLeft className="w-4 h-4 mr-2" />
@@ -84,7 +83,7 @@ const BookDetails = () => {
 
   const rating = book.rating || 4.2;
   const ratingCount = Math.floor(Math.random() * 500 + 100);
-  const canonicalUrl = `https://sahadhyayi.com/books/${actualId}`;
+  const canonicalUrl = `https://sahadhyayi.com/book/${id}`;
   
   const seoTitle = `${book.title}${book.author ? ` by ${book.author}` : ''} - Read Online`;
   const seoDescription = book.description 
@@ -106,7 +105,7 @@ const BookDetails = () => {
   const breadcrumbItems = [
     { name: 'Explore', path: '/library' },
     ...(book.genre ? [{ name: book.genre, path: `/library?genre=${encodeURIComponent(book.genre)}` }] : []),
-    { name: book.title, path: `/books/${actualId}`, current: true }
+    { name: book.title, path: `/book/${id}`, current: true }
   ];
 
   const bookSchema = generateBookSchema({

--- a/src/pages/authors/[slug].tsx
+++ b/src/pages/authors/[slug].tsx
@@ -26,6 +26,7 @@ import Breadcrumb from '@/components/ui/breadcrumb';
 import { slugify } from '@/utils/slugify';
 import SocialShare from '@/components/SocialShare';
 
+// Comprehensive author profile page accessed via /authors/:slug
 const AuthorSlugPage = () => {
   const { slug } = useParams<{ slug: string }>();
   const { user } = useAuth();


### PR DESCRIPTION
## Summary
- remove redundant BookDetails route and consolidate on `/book/:id`
- clarify author routing by using slug param and documenting legacy `/author/:slug`

## Testing
- `npm run lint` *(fails: React Hook is called conditionally)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b08ca5188320893494938756105e