### PR TITLE
feat: filter books and use BookCard

### DIFF
--- a/src/components/library/BookGrid.tsx
+++ b/src/components/library/BookGrid.tsx
@@ -1,40 +1,43 @@
 
 import React, { useState } from 'react';
-import { Card, CardContent, CardFooter } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Link } from 'react-router-dom';
-import { slugify } from '@/utils/slugify';
+import BookCard from './BookCard';
 import { BookOpen } from 'lucide-react';
 import { useBooksByGenre, useGenres } from '@/hooks/useLibraryBooks';
 import type { Book, Genre } from '@/hooks/useLibraryBooks';
 
 const BookGrid = () => {
   const [selectedGenre, setSelectedGenre] = useState<string>('All');
-  const [readIds, setReadIds] = useState<string[]>([]);
   const { data: books = [], isLoading: booksLoading } = useBooksByGenre(selectedGenre);
   const { data: genres = [], isLoading: genresLoading } = useGenres();
 
-  const markAsRead = (id: string) => {
-    if (!readIds.includes(id)) {
-      setReadIds([...readIds, id]);
+  const validBooks = books.filter((book: Book) =>
+    Boolean(book.title) && Boolean((book as any).coverUrl || book.cover_image_url)
+  );
+
+  const handleDownloadPDF = (book: Book) => {
+    if (book.pdf_url) {
+      const link = document.createElement('a');
+      link.href = book.pdf_url;
+      link.download = `${book.title}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else {
+      alert('PDF not available for this book');
     }
   };
 
   if (booksLoading || genresLoading) {
     return (
       <div className="max-w-7xl mx-auto p-4">
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {[...Array(6)].map((_, i) => (
-            <Card key={i} className="animate-pulse">
-              <CardContent className="p-6">
-                <div className="h-4 bg-gray-200 rounded mb-2"></div>
-                <div className="h-3 bg-gray-200 rounded mb-2"></div>
-                <div className="h-3 bg-gray-200 rounded w-2/3"></div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        {validBooks.length > 0 ? (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="h-64 bg-gray-200 animate-pulse rounded" />
+            ))}
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -63,40 +66,18 @@ const BookGrid = () => {
 
       {/* Books Grid */}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {books.map((book: Book) => (
-          <Card key={book.id} className="flex flex-col">
-            <CardContent className="flex-1 space-y-1 p-6">
-              <h3 className="text-lg font-semibold">{book.title}</h3>
-              <p className="text-sm text-gray-500">
-                <Link to={`/authors/${slugify(book.author)}`}>{book.author}</Link>
-              </p>
-              {book.genre && (
-                <p className="text-xs text-blue-600 font-medium">{book.genre}</p>
-              )}
-              {book.description && (
-                <p className="text-sm text-gray-700 line-clamp-2">
-                  {book.description}
-                </p>
-              )}
-            </CardContent>
-            <CardFooter className="pt-0">
-              <Link to={`/books/${book.id}`} className="ml-auto">
-                <Button size="sm" className="bg-amber-600 hover:bg-amber-700">
-                  About
-                </Button>
-              </Link>
-            </CardFooter>
-          </Card>
+        {validBooks.map((book: Book) => (
+          <BookCard key={book.id} book={book} onDownloadPDF={handleDownloadPDF} />
         ))}
       </div>
-      
-      {books.length === 0 && (
+
+      {validBooks.length === 0 && (
         <div className="text-center py-12">
           <BookOpen className="w-16 h-16 text-gray-300 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-gray-900 mb-2">No books found</h3>
           <p className="text-gray-500">
-            {selectedGenre === 'All' 
-              ? 'No books are available in the library yet.' 
+            {selectedGenre === 'All'
+              ? 'No books are available in the library yet.'
               : `No books found in the ${selectedGenre} genre.`}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- filter out books without titles or covers
- map valid results to `BookCard`
- suppress skeletons when no books remain

## Testing
- `npm run lint` *(fails: React hook usage errors in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b56ec9b48320bf6fc77734d243eb