### PR TITLE
Fix missing Bookshelf route for My Books

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import Map from "./pages/Map";
 import About from "./pages/About";
 import Blog from "./pages/Blog";
 import NotFound from "./pages/NotFound";
+import Bookshelf from "./pages/Bookshelf";
 
 import "./App.css";
 
@@ -87,6 +88,7 @@ function App() {
                         <Route path="/about" element={<About />} />
                         <Route path="/blog" element={<Blog />} />
                         <Route path="/book/:id" element={<BookDetails />} />
+                        <Route path="/bookshelf" element={<Bookshelf />} />
                         <Route path="*" element={<NotFound />} />
                       </Routes>
                     </main>


### PR DESCRIPTION
## Summary
- Import Bookshelf page
- Register `/bookshelf` route to resolve 404 for My Books navigation

## Testing
- `npm run lint` *(fails: React Hook is called conditionally)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895909495048320b2b884705de58ca3