### PR TITLE
Fix PDF reader and audio summary

### DIFF
--- a/src/components/audio/AudioSummaryPlayer.tsx
+++ b/src/components/audio/AudioSummaryPlayer.tsx
@@ -137,7 +137,7 @@ const AudioSummaryPlayer: React.FC<AudioSummaryPlayerProps> = ({
     );
   }
 
-  const audioUrl = audioSummary?.audio_url || (createAudioSummary.data && URL.createObjectURL(new Blob()));
+  const audioUrl = audioSummary?.audio_url || createAudioSummary.data?.audio_url;
 
   return (
     <Card className="bg-gradient-to-r from-blue-50 to-indigo-50 border-blue-200">

--- a/src/components/books/BookReader.tsx
+++ b/src/components/books/BookReader.tsx
@@ -750,26 +750,13 @@ const BookReader = ({ bookId, bookTitle, pdfUrl, epubUrl }: BookReaderProps) => 
               </>
             ) : isPdf ? (
               <div className="relative">
-                <object
+                <iframe
                   key={currentPage}
-                  data={`${pdfUrl}#toolbar=1&navpanes=1&scrollbar=1&page=${currentPage}`}
-                  type="application/pdf"
+                  src={`${pdfUrl}#toolbar=1&navpanes=1&scrollbar=1&page=${currentPage}`}
                   className={`w-full border rounded-lg ${isFullscreen ? 'h-screen' : 'h-[600px]'}`}
                   style={{ width: '100%', height: '100%' }}
-                >
-                  <p className="p-4 text-center text-gray-500">
-                    Unable to display PDF.{" "}
-                    <a
-                      href={pdfUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline"
-                    >
-                      Download
-                    </a>{" "}
-                    instead.
-                  </p>
-                </object>
+                  title={bookTitle}
+                />
                 {/* PDF Navigation Helper */}
                 <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 bg-black/70 text-white px-4 py-2 rounded-lg text-sm">
                   Page {currentPage}{totalPages ? ` of ${totalPages}` : ''}


### PR DESCRIPTION
## Summary
- ensure PDF books render by swapping embedded object with iframe
- load generated audio summary URLs so playback works after creation

## Testing
- `npm run lint` (fails: React Hook rules violations)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689593b6167c8320b4b09ae0c284a2bd