### PR TITLE
refactor: remove conditional hook checks

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -26,11 +26,6 @@ export const useAuth = () => {
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   
-  // Add safety check for React hooks
-  if (!React || typeof useState !== 'function') {
-    return React.createElement('div', { children });
-  }
-  
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);

--- a/src/contexts/QuotesContext.tsx
+++ b/src/contexts/QuotesContext.tsx
@@ -28,10 +28,6 @@ export const useQuotes = () => {
 };
 
 export const QuotesProvider = ({ children }: { children: React.ReactNode }) => {
-  // Add safety check for React hooks
-  if (!React || typeof useState !== 'function') {
-    return React.createElement('div', { children });
-  }
 
   const [quotes, setQuotes] = useState<Quote[]>([]);
 

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -171,44 +171,22 @@ function toast({ ...props }: Toast) {
 }
 
 function useToast() {
-  console.log('useToast hook called...');
-  console.log('React available in useToast:', !!React);
-  
-  // Add comprehensive safety check for React hooks availability
-  if (!React || !React.useState || typeof useState !== 'function') {
-    console.warn('React hooks not available, returning fallback');
-    return {
-      toasts: [],
-      toast: () => ({ id: '', dismiss: () => {}, update: () => {} }),
-      dismiss: () => {},
-    };
-  }
-  
-  try {
-    const [state, setState] = useState(memoryState)
+  const [state, setState] = useState(memoryState)
 
-    useEffect(() => {
-      listeners.push(setState)
-      return () => {
-        const index = listeners.indexOf(setState)
-        if (index > -1) {
-          listeners.splice(index, 1)
-        }
+  useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
       }
-    }, [state])
-
-    return {
-      ...state,
-      toast,
-      dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
     }
-  } catch (error) {
-    console.error('Error in useToast:', error);
-    return {
-      toasts: [],
-      toast: () => ({ id: '', dismiss: () => {}, update: () => {} }),
-      dismiss: () => {},
-    };
+  }, [])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
   }
 }
 

--- a/src/hooks/useSpeechToText.ts
+++ b/src/hooks/useSpeechToText.ts
@@ -11,18 +11,6 @@ export const useSpeechToText = ({ onTranscript, onError }: UseSpeechToTextOption
   console.log('useSpeechToText hook called...');
   console.log('React available in useSpeechToText:', !!React);
   console.log('React.useState available:', typeof React.useState);
-  
-  // Add safety check for React hooks
-  if (!React || typeof React.useState !== 'function') {
-    console.error('React hooks not available in useSpeechToText');
-    return {
-      isRecording: false,
-      isProcessing: false,
-      startRecording: async () => {},
-      stopRecording: () => {},
-      toggleRecording: () => {},
-    };
-  }
 
   const [isRecording, setIsRecording] = React.useState(false);
   const [isProcessing, setIsProcessing] = React.useState(false);


### PR DESCRIPTION
## Summary
- remove conditional hook guards in AuthProvider and QuotesProvider
- simplify useToast and useSpeechToText hooks by calling hooks unconditionally

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm test -- --watch=false` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895a7880bc0832094b73614127c9644