### PR TITLE
harden client and server security

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,11 +6,21 @@ import { createClient } from '@supabase/supabase-js';
 import goodreads from 'goodreads-api-node';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { validateCSP, validateSessionIntegrity } from '@/utils/security';
 
 dotenv.config();
 
 const app = express();
 app.use(express.json());
+
+app.use((req, res, next) => {
+  if (!validateSessionIntegrity()) return res.status(401).send('Session invalid');
+  const policy = req.headers['content-security-policy'];
+  if (policy && !validateCSP(policy.toString())) {
+    return res.status(400).send('CSP violation');
+  }
+  next();
+});
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,9 @@
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
-// Security initialization
-// import { initializeSecurity } from "./utils/security";
-
-// TODO: Re-enable security initialization after fixing import issues
-// if (typeof window !== 'undefined') {
-//   initializeSecurity();
-// }
+import { initializeSecurity } from "@/utils/security";
 
 // Context imports
 import { AuthProvider } from "./contexts/AuthContext";
@@ -58,6 +52,10 @@ const queryClient = new QueryClient({
 });
 
 function App() {
+  useEffect(() => {
+    initializeSecurity();
+  }, []);
+
   return (
     <ErrorBoundary>
       <BrowserRouter>

--- a/src/components/groups/GroupMessaging.tsx
+++ b/src/components/groups/GroupMessaging.tsx
@@ -11,6 +11,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
 import { formatDistanceToNow } from 'date-fns';
+import { sanitizeHTML, sanitizeInput } from '@/utils/validation';
 
 interface GroupMessagingProps {
   groupId: string;
@@ -132,9 +133,10 @@ const GroupMessaging: React.FC<GroupMessagingProps> = ({
     if (!newMessage.trim() || !user) return;
 
     try {
+      const sanitized = sanitizeInput(newMessage.trim());
       await sendMessage.mutateAsync({
         groupId,
-        content: newMessage.trim()
+        content: sanitized
       });
       setNewMessage('');
       inputRef.current?.focus();
@@ -198,9 +200,9 @@ const GroupMessaging: React.FC<GroupMessagingProps> = ({
   const renderMessage = (message: Message) => {
     const isOwnMessage = message.sender_id === user?.id;
     const mentions = extractMentions(message.content);
-    
-    // Highlight mentions in message content
-    let displayContent = message.content;
+
+    // Sanitize and highlight mentions in message content
+    let displayContent = sanitizeHTML(message.content);
     mentions.forEach(mention => {
       displayContent = displayContent.replace(
         new RegExp(`@${mention}`, 'g'),

--- a/src/hooks/useBookCoverUpload.ts
+++ b/src/hooks/useBookCoverUpload.ts
@@ -1,4 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
+import { validateFileUpload } from '@/utils/security';
+import { SECURITY_CONFIG } from '@/utils/securityConfig';
 
 /**
  * Upload a book cover image to the `book-covers` bucket in Supabase Storage.
@@ -11,8 +13,13 @@ export async function uploadBookCover(
   const bucket = 'book-covers';
   const filePath = `${bookId}/${Date.now()}_${file.name}`;
 
-  if (!file.type.startsWith('image/')) {
-    throw new Error('Only image uploads allowed');
+  const { valid, error } = validateFileUpload(
+    file,
+    SECURITY_CONFIG.FILE_UPLOAD.ALLOWED_IMAGE_TYPES,
+    SECURITY_CONFIG.FILE_UPLOAD.MAX_SIZE
+  );
+  if (!valid) {
+    throw new Error(error);
   }
 
   // Create the bucket if it doesn't already exist

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -42,8 +42,8 @@ export const setSecurityHeaders = (): void => {
   // Content Security Policy
   const cspContent = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://www.google.com",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "script-src 'self' https://maps.googleapis.com https://www.google.com",
+    "style-src 'self' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https: blob:",
     "connect-src 'self' https://*.supabase.co https://maps.googleapis.com",
@@ -51,7 +51,8 @@ export const setSecurityHeaders = (): void => {
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
-    "frame-ancestors 'none'"
+    "frame-ancestors 'none'",
+    "report-uri /csp-report-endpoint"
   ].join('; ');
 
   // Create or update CSP meta tag
@@ -273,10 +274,14 @@ export const initializeSecurity = (): void => {
   // Detect developer tools (basic detection)
   if (process.env.NODE_ENV === 'production') {
     setInterval(() => {
-      if (window.outerHeight - window.innerHeight > 200 || 
+      if (window.outerHeight - window.innerHeight > 200 ||
           window.outerWidth - window.innerWidth > 200) {
         logSecurityEvent('DEVTOOLS_DETECTED');
       }
     }, 1000);
   }
 };
+
+export { validateCSP } from './validation';
+
+

--- a/src/utils/securityConfig.ts
+++ b/src/utils/securityConfig.ts
@@ -14,14 +14,12 @@ export const SECURITY_CONFIG = {
   CSP: {
     'default-src': ["'self'"],
     'script-src': [
-      "'self'", 
-      "'unsafe-inline'", // Required for React inline scripts
+      "'self'",
       "https://maps.googleapis.com",
       "https://www.google.com"
     ],
     'style-src': [
-      "'self'", 
-      "'unsafe-inline'", // Required for styled-components and CSS-in-JS
+      "'self'",
       "https://fonts.googleapis.com"
     ],
     'font-src': [
@@ -47,6 +45,7 @@ export const SECURITY_CONFIG = {
     'base-uri': ["'self'"],
     'form-action': ["'self'"],
     'frame-ancestors': ["'none'"],
+    'report-uri': ['/csp-report-endpoint'],
     'upgrade-insecure-requests': []
   },
 
@@ -89,9 +88,7 @@ export const SECURITY_CONFIG = {
   TRUSTED_DOMAINS: [
     'sahadhyayi.com',
     'www.sahadhyayi.com',
-    'supabase.com',
-    'github.com',
-    'google.com',
+    'supabase.co',
     'fonts.googleapis.com',
     'fonts.gstatic.com',
     'maps.googleapis.com'


### PR DESCRIPTION
## Summary
- initialize client security on app load
- tighten CSP and trusted domain settings
- sanitize and validate uploads and group messages
- gate API requests with session and CSP checks

## Testing
- `npm run lint` *(fails: React Hooks must be called unconditionally)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895a8952fcc8320bf7c91cc1096eb45