### PR TITLE
feat(ai): centralize prompt pipeline

### DIFF
--- a/src/ai/schema.ts
+++ b/src/ai/schema.ts
@@ -1,9 +1,12 @@
 import { z } from 'zod';
 
-export const AiAnswer = z.object({
+export const AiResponseSchema = z.object({
   reply: z.string().min(1).max(1200),
-  references: z.array(z.object({ bookId: z.string().optional(), title: z.string().optional() })).max(5),
+  references: z.array(z.object({
+    bookId: z.string().optional(),
+    title: z.string().optional()
+  })).max(5),
   followup: z.string().optional()
 });
 
-export type AiAnswerType = z.infer<typeof AiAnswer>;
+export type AiResponseParsed = z.infer<typeof AiResponseSchema>;

--- a/src/ai/service.ts
+++ b/src/ai/service.ts
@@ -1,61 +1,81 @@
-import { templates } from './templates';
-import { AiAnswer, AiAnswerType } from './schema';
-import type { AiContext, Intent } from './types';
+import { createHash } from './utils/hash';
+import { AiResponseSchema, type AiResponseParsed } from './schema';
+import { TEMPLATES } from './templates';
+import type { Intent, AiContext } from './types';
 import { getWebsiteContext, searchRelevantBooks, getBookSummaries } from '@/utils/enhancedChatbotKnowledge';
+import { supabase } from '@/integrations/supabase/client';
 
-export function parseIntent(question: string): Intent {
-  const q = question.toLowerCase();
-  if (/policy|terms|privacy/.test(q)) return 'policy';
-  if (/help|how do i|\?/.test(q)) return 'help';
-  if (/book|novel|author|read|recommend|library|title|genre/.test(q)) return 'book_query';
+const ACTIVE_VER = (import.meta.env.VITE_AI_PROMPT_VERSION as 'V1' | 'V2') || 'V1';
+
+// naive cache in-memory (frontend runtime). Replace with server cache later.
+const cache = new Map<string, AiResponseParsed>();
+
+function classifyIntent(q: string): Intent {
+  const s = q.toLowerCase();
+  if (/help|how to|what can you do/.test(s)) return 'help';
+  if (/policy|terms|privacy/.test(s)) return 'policy';
+  if (/(book|recommend|read|author|genre|summary)/.test(s)) return 'book_query';
   return 'general';
 }
 
-function trimTokens(text: string, maxTokens: number): string {
-  const words = text.split(/\s+/).slice(0, maxTokens);
-  return words.join(' ');
-}
-
-export async function buildContext(question: string): Promise<AiContext> {
+async function buildContext(question: string): Promise<AiContext> {
   const site = await getWebsiteContext();
-  let books = await searchRelevantBooks(question, 5);
-  books = books.slice(0, 3);
-  const summaries = books.length > 0 ? await getBookSummaries(books.map(b => b.id)) : [];
-  let remaining = 600;
-  const booksWithSnippets = books.map(b => {
-    const summary = summaries.find(s => s.book_id === b.id)?.content as string | undefined;
-    if (summary && remaining > 0) {
-      const snippet = trimTokens(summary, remaining);
-      remaining -= snippet.split(/\s+/).length;
-      return { ...b, snippet };
-    }
-    return b;
+  const candidates = await searchRelevantBooks(question);
+  const top = candidates.slice(0, 3);
+  const summaries = await getBookSummaries(top.map(b => b.id));
+  const summaryMap: Record<string, string> = {};
+  for (const s of summaries) {
+    summaryMap[s.book_id] = s.content;
+  }
+  const books = top.map(b => ({
+    id: b.id,
+    title: b.title,
+    author: b.author,
+    snippet: summaryMap[b.id]?.slice(0, 200)
+  }));
+  return { site: { totalBooks: site.totalBooks, topGenres: site.genres.slice(0, 5) }, books };
+}
+
+async function callModel(prompt: string): Promise<string> {
+  const { data, error } = await supabase.functions.invoke('enhanced-book-summary', {
+    body: { prompt, context: 'chatbot_response' }
   });
-  return {
-    site: { totalBooks: site.totalBooks, topGenres: site.genres.slice(0,5) },
-    books: booksWithSnippets,
-  };
+  if (error || !data?.response) {
+    throw new Error(error?.message || 'AI HTTP error');
+  }
+  return data.response;
 }
 
-export async function generatePrompt(question: string) {
-  let intent = parseIntent(question);
+export async function ask(question: string): Promise<AiResponseParsed> {
+  const intent = classifyIntent(question);
   const ctx = await buildContext(question);
-  if (ctx.books.length === 0 && intent === 'book_query') {
-    intent = 'general';
+
+  const key = createHash(JSON.stringify({ question, intent, ctx }));
+  if (cache.has(key)) return cache.get(key)!;
+
+  const tpl = TEMPLATES[ACTIVE_VER];
+  const prompt = tpl({ question, intent, ctx, promptVersion: ACTIVE_VER });
+
+  const t0 = performance.now();
+  const raw = await callModel(prompt);
+  const t1 = performance.now();
+
+  let parsed: AiResponseParsed;
+  try {
+    parsed = AiResponseSchema.parse(JSON.parse(raw));
+  } catch {
+    parsed = { reply: String(raw).slice(0, 1200), references: [] };
   }
-  const version = (import.meta as any).env?.VITE_AI_PROMPT_VERSION || 'V1';
-  const template = templates[version as keyof typeof templates] || templates.V1;
-  const prompt = template({ intent, question, ctx }) + '\n\nRespond as valid JSON with keys: reply, references[], followup.';
-  return { prompt, ctx, intent, version };
+
+  cache.set(key, parsed);
+  console.info('[ai]', {
+    prompt_version: ACTIVE_VER,
+    intent,
+    ctx_sizes: { books: ctx.books.length },
+    latency_ms: Math.round(t1 - t0)
+  });
+
+  return parsed;
 }
 
-export function validateResponse(modelText: string): AiAnswerType {
-  try {
-    const parsed = JSON.parse(modelText);
-    const result = AiAnswer.safeParse(parsed);
-    if (result.success) return result.data;
-  } catch {
-    // ignore
-  }
-  return { reply: modelText, references: [] };
-}
+export { classifyIntent }; // optional export for tests

--- a/src/ai/templates.ts
+++ b/src/ai/templates.ts
@@ -1,13 +1,12 @@
-import { AiContext, Intent } from './types';
+import type { AiRequest } from './types';
 
-export const PROMPT_V1 = (
-  { intent, question, ctx }: { intent: Intent; question: string; ctx: AiContext }
-) => `
+export const PROMPT_V1 = ({ question, intent, ctx }: AiRequest) => `
 You are Sahadhyayi’s reading assistant.
 Rules:
-- Be concise (2–3 sentences unless asked otherwise).
+- Be concise: 2–3 sentences unless asked otherwise.
 - Cite book titles when you reference them.
-- If unsure, ask a clarifying question.
+- If unsure, ask a short clarifying question.
+- Never invent facts; if no match, guide the user to search the library.
 
 User intent: ${intent}
 Question: "${question}"
@@ -16,10 +15,13 @@ Site context:
 - Total books: ${ctx.site.totalBooks}
 - Top genres: ${ctx.site.topGenres.slice(0,5).join(', ')}
 
-Relevant books:
-${ctx.books.slice(0,3).map(b => `- ${b.title} by ${b.author}${b.snippet ? ` — ${b.snippet}` : ''}`).join('\n')}
+Relevant books (max 3):
+${ctx.books.map(b => `- ${b.title}${b.author ? ` by ${b.author}` : ''}${b.snippet ? ` — ${b.snippet}` : ''}`).join('\n')}
+
+Respond ONLY as compact JSON with keys: reply, references[], followup.
 `;
 
-export const templates = {
+export const TEMPLATES = {
   V1: PROMPT_V1,
-};
+  V2: PROMPT_V1 // placeholder for future experiments
+} as const;

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,7 +1,31 @@
 export type Intent = 'book_query' | 'general' | 'help' | 'policy';
 
+export interface SiteContext {
+  totalBooks: number;
+  topGenres: string[];
+}
+
+export interface BookCtx {
+  id: string;
+  title: string;
+  author?: string;
+  snippet?: string; // short summary/excerpt
+}
+
 export interface AiContext {
-  site: { totalBooks: number; topGenres: string[] };
-  books: Array<{ id: string; title: string; author: string; genre?: string; snippet?: string }>;
-  user?: { id: string; name?: string; reading?: string[] };
+  site: SiteContext;
+  books: BookCtx[];
+}
+
+export interface AiRequest {
+  question: string;
+  intent: Intent;
+  ctx: AiContext;
+  promptVersion: 'V1' | 'V2';
+}
+
+export interface AiResponse {
+  reply: string;
+  references: Array<{ bookId?: string; title?: string }>;
+  followup?: string;
 }

--- a/src/ai/utils/hash.ts
+++ b/src/ai/utils/hash.ts
@@ -1,0 +1,7 @@
+export function createHash(s: string) {
+  // tiny poor-man hash (ok for cache keys)
+  let h = 0, i = 0;
+  const len = s.length;
+  while (i < len) h = (h << 5) - h + s.charCodeAt(i++) | 0;
+  return 'h' + (h >>> 0).toString(36);
+}

--- a/src/hooks/chatbot/useChatbotAI.ts
+++ b/src/hooks/chatbot/useChatbotAI.ts
@@ -1,14 +1,8 @@
-import { supabase } from '@/integrations/supabase/client';
 import { useEnhancedGeminiTraining } from '@/hooks/useEnhancedGeminiTraining';
-import {
-  getWebsiteContext,
-  generateEnhancedPrompt,
-  searchRelevantBooks,
-  getBookSummaries,
-  BookData,
-} from '@/utils/enhancedChatbotKnowledge';
 import { generateContextualResponse } from '@/utils/chatbotKnowledge';
 import { useCallback } from 'react';
+import * as ai from '@/ai/service';
+import type { AiContext } from '@/ai/types';
 
 export function useChatbotAI() {
   const {
@@ -21,51 +15,35 @@ export function useChatbotAI() {
 
   const queryAI = useCallback(
     async (userMessage: string) => {
-      let relevantBooks: BookData[] = [];
+      let relevantBooks: AiContext['books'] = [];
       await initializeWebsiteKnowledge();
 
-      const websiteContext = await getWebsiteContext();
-      relevantBooks = await searchRelevantBooks(userMessage, 3);
-      if (relevantBooks.length > 0) {
-        await getBookSummaries(relevantBooks.map((b) => b.id));
-      }
-      const enhancedPrompt = await generateEnhancedPrompt(userMessage, websiteContext);
-      let contextualPrompt = enhancedPrompt;
-      if (relevantBooks.length > 0) {
-        contextualPrompt += '\n\nRELEVANT BOOKS:\n';
-        relevantBooks.forEach((book) => {
-          contextualPrompt += `• "${book.title}" by ${book.author} (${book.genre})\n`;
-        });
-      }
+      try {
+        const result = await ai.ask(userMessage);
+        relevantBooks = result.references.map(r => ({
+          id: r.bookId || '',
+          title: r.title || '',
+          author: undefined,
+          snippet: undefined,
+        }));
 
-      const { data, error } = await supabase.functions.invoke('enhanced-book-summary', {
-        body: {
-          prompt: contextualPrompt,
-          context: 'chatbot_response',
-          bookContext: relevantBooks.length > 0 ? relevantBooks : undefined,
-        },
-      });
-
-      let botResponse = '';
-      if (error) {
-        botResponse = generateContextualResponse(userMessage);
-      } else if (data?.response) {
-        botResponse = data.response;
-      } else {
-        botResponse = generateContextualResponse(userMessage);
+        await saveChatInteraction(userMessage, result.reply, 'enhanced_chat');
+        if (relevantBooks.length > 0) {
+          await saveBookSpecificInteraction(
+            relevantBooks[0].id,
+            relevantBooks[0].title,
+            userMessage,
+            result.reply,
+          );
+        }
+        const trainingDataCount = await getTrainingDataStats();
+        return { text: result.reply, books: relevantBooks, trainingDataCount };
+      } catch (error) {
+        console.error('Chatbot error:', error);
+        const fallback = generateContextualResponse(userMessage);
+        const trainingDataCount = await getTrainingDataStats();
+        return { text: fallback, books: relevantBooks, trainingDataCount };
       }
-
-      await saveChatInteraction(userMessage, botResponse, 'enhanced_chat');
-      if (relevantBooks.length > 0) {
-        await saveBookSpecificInteraction(
-          relevantBooks[0].id,
-          relevantBooks[0].title,
-          userMessage,
-          botResponse,
-        );
-      }
-      const trainingDataCount = await getTrainingDataStats();
-      return { text: botResponse, books: relevantBooks, trainingDataCount };
     },
     [
       initializeWebsiteKnowledge,


### PR DESCRIPTION
## Summary
- add AI module with typed context, prompt templates and zod-validated responses
- hash-based caching and Supabase-backed model call in ai.ask
- route ChatbotContext and chatbot hooks through centralized ask with rate limiting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895fb9456cc83209190052b7b3cda87