### PR TITLE
feat: add session middleware and hook

### DIFF
--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react';
+import { secureFetch } from '@/utils/security';
+
+function getSupabaseAccessToken(): string | null {
+  try {
+    const raw = localStorage.getItem('sb-access-token');
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function useSession() {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const check = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await secureFetch('/api/me');
+      if (res.ok) {
+        const data = await res.json();
+        setUserId(data?.id ?? null);
+      } else {
+        setUserId(null);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const login = useCallback(
+    async (supabaseAccessToken?: string) => {
+      const token = supabaseAccessToken || getSupabaseAccessToken();
+      if (!token) throw new Error('Missing Supabase access token');
+      const res = await secureFetch('/api/session', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const e = await res.json().catch(() => ({}));
+        throw new Error(e?.error || 'Login failed');
+      }
+      await check();
+    },
+    [check]
+  );
+
+  const logout = useCallback(async () => {
+    await secureFetch('/api/logout', { method: 'POST' });
+    setUserId(null);
+  }, []);
+
+  useEffect(() => {
+    check();
+  }, [check]);
+
+  return { userId, loading, check, login, logout };
+}

--- a/src/utils/enhancedChatbotKnowledge.ts
+++ b/src/utils/enhancedChatbotKnowledge.ts
@@ -62,8 +62,28 @@ export const getWebsiteContext = async (): Promise<WebsiteContext> => {
       recentBooks: []
     };
   }
-};
+  };
 
+export const generateEnhancedPrompt = async (
+  userMessage: string,
+  context: WebsiteContext,
+): Promise<string> => {
+  let prompt = `${userMessage}\n\nWEBSITE INFO:\n`;
+  prompt += `Total Books: ${context.totalBooks}\n`;
+  if (context.genres.length) {
+    prompt += `Genres: ${context.genres.join(', ')}\n`;
+  }
+  if (context.features.length) {
+    prompt += `Features: ${context.features.join(', ')}\n`;
+  }
+  if (context.recentBooks.length) {
+    prompt += 'Recent Books:\n';
+    context.recentBooks.forEach((b) => {
+      prompt += `- ${b.title} by ${b.author}\n`;
+    });
+  }
+  return prompt;
+};
 
 export const searchRelevantBooks = async (query: string, limit: number = 5): Promise<BookData[]> => {
   try {


### PR DESCRIPTION
## Summary
- add `requireSession` middleware, session endpoints, and cookie-clearing logout
- protect sensitive routes and expose `/api/me`
- provide `useSession` React hook for login, logout, and session checking
- export `generateEnhancedPrompt` helper to resolve build error

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895faf3344c8320a9d9ddc2fab94938