### PR TITLE
refactor: centralize AI pipeline

### DIFF
--- a/src/ai/schema.ts
+++ b/src/ai/schema.ts
@@ -1,9 +1,12 @@
 import { z } from 'zod';
 
-export const AiAnswer = z.object({
+export const AiResponseSchema = z.object({
   reply: z.string().min(1).max(1200),
-  references: z.array(z.object({ bookId: z.string().optional(), title: z.string().optional() })).max(5),
+  references: z.array(z.object({
+    bookId: z.string().optional(),
+    title: z.string().optional()
+  })).max(5),
   followup: z.string().optional()
 });
 
-export type AiAnswerType = z.infer<typeof AiAnswer>;
+export type AiResponseParsed = z.infer<typeof AiResponseSchema>;

--- a/src/ai/templates.ts
+++ b/src/ai/templates.ts
@@ -1,13 +1,12 @@
-import { AiContext, Intent } from './types';
+import type { AiRequest } from './types';
 
-export const PROMPT_V1 = (
-  { intent, question, ctx }: { intent: Intent; question: string; ctx: AiContext }
-) => `
+export const PROMPT_V1 = ({ question, intent, ctx }: AiRequest) => `
 You are Sahadhyayi’s reading assistant.
 Rules:
-- Be concise (2–3 sentences unless asked otherwise).
+- Be concise: 2–3 sentences unless asked otherwise.
 - Cite book titles when you reference them.
-- If unsure, ask a clarifying question.
+- If unsure, ask a short clarifying question.
+- Never invent facts; if no match, guide the user to search the library.
 
 User intent: ${intent}
 Question: "${question}"
@@ -16,10 +15,13 @@ Site context:
 - Total books: ${ctx.site.totalBooks}
 - Top genres: ${ctx.site.topGenres.slice(0,5).join(', ')}
 
-Relevant books:
-${ctx.books.slice(0,3).map(b => `- ${b.title} by ${b.author}${b.snippet ? ` — ${b.snippet}` : ''}`).join('\n')}
+Relevant books (max 3):
+${ctx.books.map(b => `- ${b.title}${b.author ? ` by ${b.author}` : ''}${b.snippet ? ` — ${b.snippet}` : ''}`).join('\n')}
+
+Respond ONLY as compact JSON with keys: reply, references[], followup.
 `;
 
-export const templates = {
+export const TEMPLATES = {
   V1: PROMPT_V1,
-};
+  V2: PROMPT_V1 // placeholder for future experiments
+} as const;

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,7 +1,31 @@
 export type Intent = 'book_query' | 'general' | 'help' | 'policy';
 
+export interface SiteContext {
+  totalBooks: number;
+  topGenres: string[];
+}
+
+export interface BookCtx {
+  id: string;
+  title: string;
+  author?: string;
+  snippet?: string; // short summary/excerpt
+}
+
 export interface AiContext {
-  site: { totalBooks: number; topGenres: string[] };
-  books: Array<{ id: string; title: string; author: string; genre?: string; snippet?: string }>;
-  user?: { id: string; name?: string; reading?: string[] };
+  site: SiteContext;
+  books: BookCtx[];
+}
+
+export interface AiRequest {
+  question: string;
+  intent: Intent;
+  ctx: AiContext;
+  promptVersion: 'V1' | 'V2';
+}
+
+export interface AiResponse {
+  reply: string;
+  references: Array<{ bookId?: string; title?: string }>;
+  followup?: string;
 }

--- a/src/ai/utils/hash.ts
+++ b/src/ai/utils/hash.ts
@@ -1,0 +1,7 @@
+export function createHash(s: string) {
+  // tiny poor-man hash (ok for cache keys)
+  let h = 0, i = 0;
+  const len = s.length;
+  while (i < len) h = (h << 5) - h + s.charCodeAt(i++) | 0;
+  return 'h' + (h >>> 0).toString(36);
+}


### PR DESCRIPTION
## Summary
- add versioned AI prompt templates and typed request/response contracts
- validate model output with zod and cache responses
- wire ChatbotContext to new ai.ask with rate limiting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895fe80ca408320b7092a3443d9e699