### PR TITLE
feat: add Goodreads per-user tokens and Libgen proxy

### DIFF
--- a/docs/ExternalIntegrations.md
+++ b/docs/ExternalIntegrations.md
@@ -3,11 +3,10 @@
 This project can connect to Goodreads so users can import and export book data.
 
 ## OAuth Login
-Use the `/goodreads/request-token` endpoint to initiate authentication. The server returns a URL that users should visit to grant access.
-The callback handled on `/goodreads/callback` stores the access token for the session.
+Visit `/goodreads/connect` to initiate authentication. The server redirects the user to Goodreads, and `/goodreads/callback` persists the access tokens for the current account.
 
 ## Importing a Bookshelf
-`/goodreads/bookshelf?userId=<id>` returns the user's `read` shelf with ratings.
+`/goodreads/bookshelf` returns the authenticated user's `read` shelf with ratings. If the account isn't linked, it responds with `401` and code `GOODREADS_NOT_LINKED`.
 
 ## Exporting Reading History
-Send a `POST` request to `/goodreads/export` with `{ userId, books }` to add books to the user's `read` shelf.
+Send a `POST` request to `/goodreads/export` with `{ books }` to add books to the user's `read` shelf.

--- a/server/libgenParser.js
+++ b/server/libgenParser.js
@@ -1,0 +1,25 @@
+export function parseLibgenHtml(html) {
+  const books = [];
+  const tableMatch = html.match(/<table[^>]*border=["']?1["']?[^>]*>([\s\S]*?)<\/table>/i);
+  if (!tableMatch) return books;
+  const rows = tableMatch[1].split(/<tr[^>]*>/i).slice(2); // skip header row
+  for (const row of rows) {
+    const cells = [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map(m => m[1]);
+    if (cells.length < 10) continue;
+    const strip = (str) => str.replace(/<[^>]+>/g, '').trim();
+    const mirrorMatch = cells[9].match(/href=["']([^"']+)/i);
+    if (!mirrorMatch) continue;
+    books.push({
+      id: `libgen-${books.length}`,
+      title: strip(cells[2]) || 'Unknown Title',
+      author: strip(cells[1]) || 'Unknown Author',
+      publisher: strip(cells[3]) || '',
+      year: strip(cells[4]) || '',
+      format: strip(cells[8]) || '',
+      size: strip(cells[7]) || '',
+      mirrorLink: mirrorMatch[1],
+      source: 'libgen'
+    });
+  }
+  return books;
+}

--- a/src/hooks/useGoodreadsIntegration.ts
+++ b/src/hooks/useGoodreadsIntegration.ts
@@ -6,28 +6,30 @@ export interface GoodreadsBook {
   goodreadsId?: string;
 }
 
+import { secureFetch } from '@/lib/secureFetch';
+
 export const useGoodreadsIntegration = () => {
-  const initiateLogin = async () => {
-    const res = await fetch('/goodreads/request-token');
-    const data = await res.json();
-    if (data.url) {
-      window.open(data.url, '_blank', 'width=600,height=600');
-    } else {
-      throw new Error('Failed to get Goodreads auth URL');
+  const initiateLogin = () => {
+    window.open('/goodreads/connect', '_blank', 'width=600,height=600');
+  };
+
+  const importBooks = async () => {
+    try {
+      const res = await secureFetch('/goodreads/bookshelf');
+      return res.json();
+    } catch (err: any) {
+      if (err.code === 'GOODREADS_NOT_LINKED') {
+        return { error: 'GOODREADS_NOT_LINKED' } as any;
+      }
+      throw err;
     }
   };
 
-  const importBooks = async (userId: string) => {
-    const res = await fetch(`/goodreads/bookshelf?userId=${encodeURIComponent(userId)}`);
-    if (!res.ok) throw new Error('Failed to fetch bookshelf');
-    return res.json();
-  };
-
-  const exportHistory = async (userId: string, books: GoodreadsBook[]) => {
-    await fetch('/goodreads/export', {
+  const exportHistory = async (books: GoodreadsBook[]) => {
+    await secureFetch('/goodreads/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId, books }),
+      body: JSON.stringify({ books }),
     });
   };
 

--- a/src/utils/libgenApi.ts
+++ b/src/utils/libgenApi.ts
@@ -1,3 +1,5 @@
+import { secureFetch } from '@/lib/secureFetch';
+
 export interface LibgenBook {
   id: string;
   title: string;
@@ -16,120 +18,12 @@ interface LibgenHtmlResponse {
   error?: string;
 }
 
-// Function to parse Libgen HTML response
-function parseLibgenHtml(html: string): LibgenBook[] {
-  try {
-    // Create a temporary DOM parser
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    
-    // Look for table rows containing book data
-    const rows = doc.querySelectorAll('table[border="1"] tr');
-    const books: LibgenBook[] = [];
-    
-    rows.forEach((row, index) => {
-      // Skip header row
-      if (index === 0) return;
-      
-      const cells = row.querySelectorAll('td');
-      if (cells.length >= 9) {
-        // Extract book information from table cells
-        const titleCell = cells[2];
-        const authorCell = cells[1];
-        const publisherCell = cells[3];
-        const yearCell = cells[4];
-        const formatCell = cells[8];
-        const sizeCell = cells[7];
-        
-        // Extract mirror links
-        const mirrorLinks = cells[9]?.querySelectorAll('a') || [];
-        const firstMirrorLink = mirrorLinks[0]?.getAttribute('href') || '';
-        
-        if (titleCell && authorCell && firstMirrorLink) {
-          books.push({
-            id: `libgen-${index}`,
-            title: titleCell.textContent?.trim() || 'Unknown Title',
-            author: authorCell.textContent?.trim() || 'Unknown Author',
-            publisher: publisherCell?.textContent?.trim() || '',
-            year: yearCell?.textContent?.trim() || '',
-            format: formatCell?.textContent?.trim() || '',
-            size: sizeCell?.textContent?.trim() || '',
-            mirrorLink: firstMirrorLink,
-            source: 'libgen'
-          });
-        }
-      }
-    });
-    
-    return books;
-  } catch (error) {
-    console.error('Error parsing Libgen HTML:', error);
-    return [];
-  }
-}
-
-// Function to search Libgen
 export async function searchLibgen(query: string): Promise<LibgenHtmlResponse> {
   try {
-    const encodedQuery = encodeURIComponent(query);
-    const url = `https://libgen.is/search.php?req=${encodedQuery}&res=25&column=title`;
-    
-    // Use a CORS proxy for development
-    const proxyUrl = `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`;
-    
-    const response = await fetch(proxyUrl);
-    
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    
-    const data = await response.json();
-    const html = data.contents;
-    
-    const books = parseLibgenHtml(html);
-    
-    return {
-      success: true,
-      books
-    };
+    const res = await secureFetch(`/api/libgen?q=${encodeURIComponent(query)}`);
+    return res.json();
   } catch (error) {
     console.error('Error searching Libgen:', error);
-    return {
-      success: false,
-      books: [],
-      error: error instanceof Error ? error.message : 'Failed to search Libgen'
-    };
-  }
-}
-
-// Alternative approach using a different CORS proxy
-export async function searchLibgenAlternative(query: string): Promise<LibgenHtmlResponse> {
-  try {
-    const encodedQuery = encodeURIComponent(query);
-    const url = `https://libgen.is/search.php?req=${encodedQuery}&res=25&column=title`;
-    
-    // Use cors-anywhere proxy (note: this requires the proxy to be running)
-    const proxyUrl = `https://cors-anywhere.herokuapp.com/${url}`;
-    
-    const response = await fetch(proxyUrl, {
-      headers: {
-        'X-Requested-With': 'XMLHttpRequest'
-      }
-    });
-    
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    
-    const html = await response.text();
-    const books = parseLibgenHtml(html);
-    
-    return {
-      success: true,
-      books
-    };
-  } catch (error) {
-    console.error('Error searching Libgen (alternative):', error);
     return {
       success: false,
       books: [],

--- a/supabase/functions/libgen-search/index.ts
+++ b/supabase/functions/libgen-search/index.ts
@@ -1,0 +1,26 @@
+import { serve } from 'https://deno.land/std/http/server.ts';
+import { parseLibgenHtml } from './parser.ts';
+
+serve(async (req) => {
+  try {
+    const { searchParams } = new URL(req.url);
+    const q = (searchParams.get('q') || '').trim();
+    if (!q) {
+      return new Response(JSON.stringify({ error: 'Missing q' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    const resp = await fetch(`https://libgen.is/search.php?req=${encodeURIComponent(q)}&res=25&column=title`);
+    const html = await resp.text();
+    const books = parseLibgenHtml(html).slice(0, 25);
+    return new Response(JSON.stringify({ success: true, books }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (_e) {
+    return new Response(JSON.stringify({ error: 'EDGE_LIBGEN_ERROR' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/libgen-search/parser.ts
+++ b/supabase/functions/libgen-search/parser.ts
@@ -1,0 +1,33 @@
+export interface LibgenBook {
+  title: string;
+  author: string;
+  publisher?: string;
+  year?: string;
+  format?: string;
+  size?: string;
+  mirrorUrl: string;
+}
+
+export function parseLibgenHtml(html: string): LibgenBook[] {
+  const books: LibgenBook[] = [];
+  const tableMatch = html.match(/<table[^>]*border=["']?1["']?[^>]*>([\s\S]*?)<\/table>/i);
+  if (!tableMatch) return books;
+  const rows = tableMatch[1].split(/<tr[^>]*>/i).slice(2);
+  for (const row of rows) {
+    const cells = [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map(m => m[1]);
+    if (cells.length < 10) continue;
+    const strip = (str: string) => str.replace(/<[^>]+>/g, '').trim();
+    const mirrorMatch = cells[9].match(/href=["']([^"']+)/i);
+    if (!mirrorMatch) continue;
+    books.push({
+      title: strip(cells[2]) || 'Unknown Title',
+      author: strip(cells[1]) || 'Unknown Author',
+      publisher: strip(cells[3]) || '',
+      year: strip(cells[4]) || '',
+      format: strip(cells[8]) || '',
+      size: strip(cells[7]) || '',
+      mirrorUrl: mirrorMatch[1],
+    });
+  }
+  return books;
+}

--- a/supabase/migrations/20250801000000-add-user-goodreads.sql
+++ b/supabase/migrations/20250801000000-add-user-goodreads.sql
@@ -1,0 +1,20 @@
+create table if not exists public.user_goodreads (
+  id uuid primary key references auth.users(id) on delete cascade,
+  access_token text not null,
+  access_token_secret text not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create or replace function public.touch_updated_at()
+returns trigger language plpgsql as $$
+begin new.updated_at = now(); return new; end $$;
+
+drop trigger if exists trg_ug_updated on public.user_goodreads;
+create trigger trg_ug_updated before update on public.user_goodreads
+for each row execute function public.touch_updated_at();
+
+alter table public.user_goodreads enable row level security;
+
+create policy ug_owner_select on public.user_goodreads
+for select to authenticated using (auth.uid() = id);


### PR DESCRIPTION
## Summary
- store Goodreads OAuth tokens per user in `user_goodreads` and load via middleware
- proxy Libgen searches server-side and expose `/api/libgen`
- add Supabase Edge Function and SQL migration

## Testing
- `npm run lint`
- `npm run build` *(fails: The symbol "generateEnhancedPrompt" has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_689601ab00c48320ad25eba03a82f1e1