### PR TITLE
chore: tighten security and input validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,9 @@
     <!-- Referrer policy for security -->
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
+    <!-- CSP is normally set via HTTP headers in server.js. Meta is a fallback for static preview only. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co wss:;">
+
     <!-- Enhanced Structured Data -->
     <script type="application/ld+json">
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import './sentry';
@@ -8,6 +8,7 @@ import { toast } from '@/hooks/use-toast';
 import { errorHandler } from '@/utils/errorHandler';
 import type { AppError } from '@/lib/errors';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { initializeSecurity } from '@/utils/security';
 
 // Context imports
 import { AuthProvider } from "./contexts/AuthContext";
@@ -83,6 +84,10 @@ const queryClient = new QueryClient({
 });
 
 function App() {
+  useEffect(() => {
+    initializeSecurity();
+  }, []);
+
   return (
     <ErrorBoundary>
       <BrowserRouter>

--- a/src/utils/securityConfig.ts
+++ b/src/utils/securityConfig.ts
@@ -64,18 +64,8 @@ export const SECURITY_CONFIG = {
 
   // File upload restrictions
   FILE_UPLOAD: {
-    MAX_SIZE: 10 * 1024 * 1024, // 10MB
-    ALLOWED_IMAGE_TYPES: [
-      'image/jpeg',
-      'image/png',
-      'image/gif',
-      'image/webp'
-    ],
-    ALLOWED_DOCUMENT_TYPES: [
-      'application/pdf',
-      'text/plain',
-      'application/json'
-    ],
+    ALLOWED_IMAGE_TYPES: ['image/png', 'image/jpeg', 'image/webp'],
+    MAX_SIZE: 5 * 1024 * 1024 // 5MB
   },
 
   // Session security
@@ -87,14 +77,11 @@ export const SECURITY_CONFIG = {
 
   // Trusted domains for external links
   TRUSTED_DOMAINS: [
-    'sahadhyayi.com',
-    'www.sahadhyayi.com',
-    'supabase.com',
-    'github.com',
-    'google.com',
+    'self',
+    '*.supabase.co',
+    'maps.googleapis.com',
     'fonts.googleapis.com',
-    'fonts.gstatic.com',
-    'maps.googleapis.com'
+    'fonts.gstatic.com'
   ],
 
   // Security headers


### PR DESCRIPTION
## Summary
- initialize client security on app load
- enforce CSP and other protective headers with reporting endpoint
- validate uploads and comments using shared helpers
- trim security config domains and add CSP meta fallback

## Testing
- `npm run lint`
- `npm run build` *(fails: The symbol "generateEnhancedPrompt" has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6896029140408320b0644c5636323543