### PR TITLE
feat: add CSRF session handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { toast } from '@/hooks/use-toast';
 import { errorHandler } from '@/utils/errorHandler';
 import type { AppError } from '@/lib/errors';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { initializeSecurity } from '@/utils/security';
+import { initializeSecureSession, setCSRFToken, generateCSRFToken } from '@/utils/security';
 
 // Context imports
 import { AuthProvider } from "./contexts/AuthContext";
@@ -85,7 +85,9 @@ const queryClient = new QueryClient({
 
 function App() {
   useEffect(() => {
-    initializeSecurity();
+    initializeSecureSession();
+    const id = setInterval(() => setCSRFToken(generateCSRFToken()), 30 * 60 * 1000);
+    return () => clearInterval(id);
   }, []);
 
   return (

--- a/src/hooks/useBookRecommendations.ts
+++ b/src/hooks/useBookRecommendations.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { secureFetch } from '@/lib/secureFetch';
 
 export interface RecommendedBook {
   id: string;
@@ -18,7 +19,7 @@ export const useBookRecommendations = (userId?: string) => {
     queryKey: ['book-recommendations', userId],
     queryFn: async (): Promise<RecommendedBook[]> => {
       if (!userId) return [];
-      const response = await fetch(`${BASE_URL}/${userId}`);
+      const response = await secureFetch(`${BASE_URL}/${userId}`);
       if (!response.ok) {
         throw new Error('Failed to fetch recommendations');
       }

--- a/src/hooks/useGoodreadsIntegration.ts
+++ b/src/hooks/useGoodreadsIntegration.ts
@@ -1,3 +1,5 @@
+import { secureFetch } from '@/lib/secureFetch';
+
 export interface GoodreadsBook {
   id: string;
   title: string;
@@ -8,7 +10,7 @@ export interface GoodreadsBook {
 
 export const useGoodreadsIntegration = () => {
   const initiateLogin = async () => {
-    const res = await fetch('/goodreads/request-token');
+    const res = await secureFetch('/goodreads/request-token');
     const data = await res.json();
     if (data.url) {
       window.open(data.url, '_blank', 'width=600,height=600');
@@ -18,13 +20,13 @@ export const useGoodreadsIntegration = () => {
   };
 
   const importBooks = async (userId: string) => {
-    const res = await fetch(`/goodreads/bookshelf?userId=${encodeURIComponent(userId)}`);
+    const res = await secureFetch(`/goodreads/bookshelf?userId=${encodeURIComponent(userId)}`);
     if (!res.ok) throw new Error('Failed to fetch bookshelf');
     return res.json();
   };
 
   const exportHistory = async (userId: string, books: GoodreadsBook[]) => {
-    await fetch('/goodreads/export', {
+    await secureFetch('/goodreads/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ userId, books }),

--- a/src/hooks/useSpeechToText.ts
+++ b/src/hooks/useSpeechToText.ts
@@ -1,5 +1,6 @@
 
 import * as React from 'react';
+import { secureFetch } from '@/lib/secureFetch';
 
 interface UseSpeechToTextOptions {
   onTranscript: (text: string) => void;
@@ -38,10 +39,9 @@ export const useSpeechToText = ({ onTranscript, onError }: UseSpeechToTextOption
             const formData = new FormData();
             formData.append('audio', audioBlob, 'recording.webm');
 
-            const response = await fetch('/api/stt', {
+            const response = await secureFetch('/api/stt', {
               method: 'POST',
               body: formData,
-              credentials: 'include',
             });
 
             if (!response.ok) {

--- a/src/lib/secureFetch.ts
+++ b/src/lib/secureFetch.ts
@@ -2,7 +2,10 @@ import { createSecureHeaders } from '@/utils/security';
 import { toAppError, safeJson } from './errors';
 
 export async function secureFetch(input: string, init: RequestInit = {}) {
-  init.headers = { ...(init.headers || {}), ...createSecureHeaders(true) };
+  init.headers = { ...createSecureHeaders(true), ...(init.headers || {}) };
+  if (init.body instanceof FormData) {
+    delete (init.headers as any)['Content-Type'];
+  }
   (init as any).credentials = 'include';
 
   try {

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { secureFetch } from '@/lib/secureFetch';
 import { useLocation } from 'react-router-dom';
 
 const useRouter = () => {
@@ -20,7 +21,7 @@ async function fetchBooks({ q, genre }: { q?: string; genre?: string }) {
   const params = new URLSearchParams();
   if (q) params.set('q', q);
   if (genre) params.set('genre', genre);
-  const res = await fetch(`/api/books?${params.toString()}`);
+  const res = await secureFetch(`/api/books?${params.toString()}`);
   if (!res.ok) {
     throw new Error('Failed to fetch books');
   }


### PR DESCRIPTION
## Summary
- implement client-side CSRF token helpers with double submit cookie
- add secureFetch wrapper and rotate CSRF token periodically
- issue HttpOnly session cookie and validate CSRF header on server routes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896167836b88320bd4f2e82237448f3