### PR TITLE
feat: persist Goodreads tokens and add Libgen proxy

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,6 @@ import { createClient } from '@supabase/supabase-js';
 import goodreads from 'goodreads-api-node';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import express from 'express';
 import cookieParser from 'cookie-parser';
 import crypto from 'crypto';
 import * as Sentry from '@sentry/node';
@@ -17,6 +16,7 @@ import busboy from 'busboy';
 import { validateFileUpload } from './src/utils/security';
 import { SECURITY_CONFIG } from './src/utils/securityConfig';
 import { sanitizeHTML, sanitizeInput } from './src/utils/validation';
+import { parseLibgenHtml } from './server/libgenParser.js';
 
 dotenv.config();
 
@@ -99,6 +99,7 @@ function requireSession(req, res, next) {
   const userId = req.cookies?.sessionId;
   if (!userId) return res.status(401).json({ error: 'Authentication required' });
   req.sessionUserId = userId;
+  req.userId = userId;
   next();
 }
 
@@ -152,18 +153,25 @@ if (GOODREADS_KEY && GOODREADS_SECRET) {
   console.warn('Goodreads API credentials not provided; Goodreads features are disabled.');
 }
 
-const connectedGoodreadsUsers = new Map();
-
-async function authenticate(req, res, next) {
-  const token = req.headers['authorization']?.replace('Bearer ', '');
-  if (!token) return jsonError(res, 401, 'Authentication required', 'AUTH_REQUIRED');
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser(token);
-  if (error || !user) return jsonError(res, 401, 'Invalid token', 'INVALID_TOKEN', error);
-  req.user = user;
-  next();
+async function loadGoodreadsTokens(req, res, next) {
+  try {
+    const userId = req.userId;
+    const { data, error } = await supabase
+      .from('user_goodreads')
+      .select('access_token, access_token_secret')
+      .eq('id', userId)
+      .maybeSingle();
+    if (error) {
+      return res.status(500).json({ error: 'DB error', code: 'DB_ERROR', details: error });
+    }
+    if (!data) {
+      return res.status(401).json({ error: 'Goodreads not linked', code: 'GOODREADS_NOT_LINKED' });
+    }
+    req.goodreadsTokens = data;
+    next();
+  } catch (e) {
+    next(Object.assign(new Error('GOODREADS_TOKENS_ERROR'), { status: 500, details: e }));
+  }
 }
 
 io.use(async (socket, next) => {
@@ -221,52 +229,96 @@ io.on('connection', (socket) => {
   });
 });
 
-app.get('/goodreads/request-token', authenticate, async (req, res) => {
+app.get('/goodreads/connect', requireSession, async (req, res, next) => {
   if (!goodreadsClient) {
     return jsonError(res, 503, 'Goodreads integration not configured', 'GOODREADS_NOT_CONFIGURED');
   }
   try {
-    const url = await goodreadsClient.getRequestToken();
-    const urlObj = new URL(url);
-    urlObj.searchParams.set('state', req.user.id);
-    res.json({ url: urlObj.toString() });
-  } catch (error) {
-    return jsonError(res, 500, error.message, 'GOODREADS_ERROR', error);
+    const callbackUrl = process.env.GOODREADS_CALLBACK_URL;
+    const { oauthToken, oauthTokenSecret, authorizeUrl } = await goodreadsClient.getRequestToken(
+      callbackUrl
+    );
+    req.app.locals[`gr_${req.userId}`] = { oauthTokenSecret };
+    return res.redirect(authorizeUrl);
+  } catch (e) {
+    next(Object.assign(new Error('GOODREADS_CONNECT_ERROR'), { status: 500, details: e }));
   }
 });
 
-app.get('/goodreads/callback', async (req, res) => {
+app.get('/goodreads/callback', requireSession, async (req, res, next) => {
   if (!goodreadsClient) {
     return jsonError(res, 503, 'Goodreads integration not configured', 'GOODREADS_NOT_CONFIGURED');
   }
   try {
-    await goodreadsClient.getAccessToken();
-    const user = await goodreadsClient.getCurrentUserInfo();
-    const state = typeof req.query.state === 'string' ? req.query.state : undefined;
-    if (state) {
-      connectedGoodreadsUsers.set(state, user.user.id);
+    const { oauth_token, oauth_verifier } = req.query;
+    const temp = req.app.locals[`gr_${req.userId}`];
+    if (!temp) {
+      return res
+        .status(400)
+        .json({ error: 'Missing temp token', code: 'OAUTH_STATE_MISSING' });
     }
-    res.send('Goodreads connected. You can close this window.');
-  } catch (error) {
-    return jsonError(res, 500, error.message, 'GOODREADS_ERROR', error);
+
+    const { accessToken, accessTokenSecret } = await goodreadsClient.getAccessToken({
+      oauthToken: oauth_token,
+      oauthVerifier: oauth_verifier,
+      oauthTokenSecret: temp.oauthTokenSecret,
+    });
+
+    const { error } = await supabase.from('user_goodreads').upsert({
+      id: req.userId,
+      access_token: accessToken,
+      access_token_secret: accessTokenSecret,
+    });
+    if (error) {
+      return res.status(500).json({ error: 'Persist failed', code: 'DB_ERROR', details: error });
+    }
+
+    delete req.app.locals[`gr_${req.userId}`];
+    return res.send('Goodreads connected. You can close this window.');
+  } catch (e) {
+    next(Object.assign(new Error('GOODREADS_CALLBACK_ERROR'), { status: 500, details: e }));
   }
 });
 
-app.get('/goodreads/bookshelf', authenticate, async (req, res) => {
-  if (!goodreadsClient) {
-    return jsonError(res, 503, 'Goodreads integration not configured', 'GOODREADS_NOT_CONFIGURED');
-  }
-  const userId = connectedGoodreadsUsers.get(req.user.id);
-  if (!userId) return jsonError(res, 401, 'Not authenticated with Goodreads', 'GOODREADS_NOT_AUTH');
+app.get('/goodreads/bookshelf', requireSession, loadGoodreadsTokens, async (req, res, next) => {
   try {
-    const books = await goodreadsClient.getBooksOnUserShelf(String(userId), 'read', {
+    const client = goodreads({
+      key: GOODREADS_KEY,
+      secret: GOODREADS_SECRET,
+      accessToken: req.goodreadsTokens.access_token,
+      accessTokenSecret: req.goodreadsTokens.access_token_secret,
+    });
+    const user = await client.getCurrentUserInfo();
+    const userId = user?.user?.id || user?.id;
+    const books = await client.getBooksOnUserShelf(String(userId), 'read', {
       per_page: 200,
     });
-    res.json(books);
-    } catch (error) {
-      return jsonError(res, 500, error.message, 'GOODREADS_ERROR', error);
+    return res.json({ books });
+  } catch (e) {
+    next(Object.assign(new Error('GOODREADS_FETCH_ERROR'), { status: 502, details: e }));
+  }
+});
+
+app.get('/api/libgen', requireSession, async (req, res, next) => {
+  try {
+    const q = (req.query.q || '').toString().trim();
+    if (!q) {
+      return res.status(400).json({ error: 'Missing q', code: 'VALIDATION_ERROR' });
     }
-  });
+    const url = `https://libgen.is/search.php?req=${encodeURIComponent(q)}&res=25&column=title`;
+    const resp = await fetch(url, { timeout: 15000 });
+    if (!resp.ok) {
+      return res
+        .status(502)
+        .json({ error: 'Libgen gateway error', code: 'UPSTREAM_ERROR', details: resp.status });
+    }
+    const html = await resp.text();
+    const books = parseLibgenHtml(html).slice(0, 25);
+    return res.json({ success: true, books });
+  } catch (e) {
+    next(Object.assign(new Error('LIBGEN_PROXY_ERROR'), { status: 500, details: e }));
+  }
+});
 
   app.post('/api/stt', (req, res) => {
   const bb = busboy({ headers: req.headers });
@@ -404,22 +456,26 @@ app.post('/api/comments', checkSession, async (req, res, next) => {
   }
 });
 
-app.post('/goodreads/export', authenticate, async (req, res) => {
-  if (!goodreadsClient) {
+app.post('/goodreads/export', requireSession, loadGoodreadsTokens, async (req, res, next) => {
+  if (!GOODREADS_KEY || !GOODREADS_SECRET) {
     return jsonError(res, 503, 'Goodreads integration not configured', 'GOODREADS_NOT_CONFIGURED');
   }
   const { books } = req.body;
-  const userId = connectedGoodreadsUsers.get(req.user.id);
-  if (!userId) return jsonError(res, 401, 'Not authenticated with Goodreads', 'GOODREADS_NOT_AUTH');
   try {
+    const client = goodreads({
+      key: GOODREADS_KEY,
+      secret: GOODREADS_SECRET,
+      accessToken: req.goodreadsTokens.access_token,
+      accessTokenSecret: req.goodreadsTokens.access_token_secret,
+    });
     for (const book of books || []) {
       if (book.goodreadsId) {
-        await goodreadsClient.addBookToShelf(book.goodreadsId, 'read');
+        await client.addBookToShelf(book.goodreadsId, 'read');
       }
     }
     res.json({ success: true });
-  } catch (error) {
-    return jsonError(res, 500, error.message, 'GOODREADS_ERROR', error);
+  } catch (e) {
+    next(Object.assign(new Error('GOODREADS_EXPORT_ERROR'), { status: 500, details: e }));
   }
 });
 

--- a/server/libgenParser.js
+++ b/server/libgenParser.js
@@ -1,0 +1,41 @@
+export function parseLibgenHtml(html) {
+  const books = [];
+  const rowRegex = /<tr[^>]*>(.*?)<\/tr>/gs;
+  let match;
+  let index = 0;
+  while ((match = rowRegex.exec(html)) !== null) {
+    const row = match[1];
+    if (index === 0) { index++; continue; }
+    const cellRegex = /<td[^>]*>(.*?)<\/td>/gs;
+    const cells = [];
+    let cellMatch;
+    while ((cellMatch = cellRegex.exec(row)) !== null) {
+      cells.push(cellMatch[1]);
+    }
+    if (cells.length < 10) { index++; continue; }
+    const strip = (str) => str.replace(/<[^>]+>/g, '').trim();
+    const title = strip(cells[2]);
+    const author = strip(cells[1]);
+    const publisher = strip(cells[3]);
+    const year = strip(cells[4]);
+    const size = strip(cells[7]);
+    const format = strip(cells[8]);
+    const mirrorMatch = cells[9].match(/href=['"]([^'"]+)['"]/);
+    const mirrorLink = mirrorMatch ? mirrorMatch[1] : '';
+    if (title && author && mirrorLink) {
+      books.push({
+        id: `libgen-${index}`,
+        title,
+        author,
+        publisher,
+        year,
+        format,
+        size,
+        mirrorLink,
+        source: 'libgen'
+      });
+    }
+    index++;
+  }
+  return books;
+}

--- a/src/hooks/useGoodreadsIntegration.ts
+++ b/src/hooks/useGoodreadsIntegration.ts
@@ -1,3 +1,5 @@
+import { secureFetch } from '@/lib/secureFetch';
+
 export interface GoodreadsBook {
   id: string;
   title: string;
@@ -7,27 +9,25 @@ export interface GoodreadsBook {
 }
 
 export const useGoodreadsIntegration = () => {
-  const initiateLogin = async () => {
-    const res = await fetch('/goodreads/request-token');
-    const data = await res.json();
-    if (data.url) {
-      window.open(data.url, '_blank', 'width=600,height=600');
-    } else {
-      throw new Error('Failed to get Goodreads auth URL');
+  const initiateLogin = () => {
+    window.open('/goodreads/connect', '_blank', 'width=600,height=600');
+  };
+
+  const importBooks = async () => {
+    try {
+      const res = await secureFetch('/goodreads/bookshelf');
+      return res.json();
+    } catch (e: any) {
+      if (e.code === 'GOODREADS_NOT_LINKED') return null;
+      throw e;
     }
   };
 
-  const importBooks = async (userId: string) => {
-    const res = await fetch(`/goodreads/bookshelf?userId=${encodeURIComponent(userId)}`);
-    if (!res.ok) throw new Error('Failed to fetch bookshelf');
-    return res.json();
-  };
-
-  const exportHistory = async (userId: string, books: GoodreadsBook[]) => {
-    await fetch('/goodreads/export', {
+  const exportHistory = async (books: GoodreadsBook[]) => {
+    await secureFetch('/goodreads/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId, books }),
+      body: JSON.stringify({ books }),
     });
   };
 

--- a/src/utils/libgenApi.ts
+++ b/src/utils/libgenApi.ts
@@ -1,3 +1,5 @@
+import { secureFetch } from '@/lib/secureFetch';
+
 export interface LibgenBook {
   id: string;
   title: string;
@@ -16,120 +18,12 @@ interface LibgenHtmlResponse {
   error?: string;
 }
 
-// Function to parse Libgen HTML response
-function parseLibgenHtml(html: string): LibgenBook[] {
-  try {
-    // Create a temporary DOM parser
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    
-    // Look for table rows containing book data
-    const rows = doc.querySelectorAll('table[border="1"] tr');
-    const books: LibgenBook[] = [];
-    
-    rows.forEach((row, index) => {
-      // Skip header row
-      if (index === 0) return;
-      
-      const cells = row.querySelectorAll('td');
-      if (cells.length >= 9) {
-        // Extract book information from table cells
-        const titleCell = cells[2];
-        const authorCell = cells[1];
-        const publisherCell = cells[3];
-        const yearCell = cells[4];
-        const formatCell = cells[8];
-        const sizeCell = cells[7];
-        
-        // Extract mirror links
-        const mirrorLinks = cells[9]?.querySelectorAll('a') || [];
-        const firstMirrorLink = mirrorLinks[0]?.getAttribute('href') || '';
-        
-        if (titleCell && authorCell && firstMirrorLink) {
-          books.push({
-            id: `libgen-${index}`,
-            title: titleCell.textContent?.trim() || 'Unknown Title',
-            author: authorCell.textContent?.trim() || 'Unknown Author',
-            publisher: publisherCell?.textContent?.trim() || '',
-            year: yearCell?.textContent?.trim() || '',
-            format: formatCell?.textContent?.trim() || '',
-            size: sizeCell?.textContent?.trim() || '',
-            mirrorLink: firstMirrorLink,
-            source: 'libgen'
-          });
-        }
-      }
-    });
-    
-    return books;
-  } catch (error) {
-    console.error('Error parsing Libgen HTML:', error);
-    return [];
-  }
-}
-
-// Function to search Libgen
 export async function searchLibgen(query: string): Promise<LibgenHtmlResponse> {
   try {
-    const encodedQuery = encodeURIComponent(query);
-    const url = `https://libgen.is/search.php?req=${encodedQuery}&res=25&column=title`;
-    
-    // Use a CORS proxy for development
-    const proxyUrl = `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`;
-    
-    const response = await fetch(proxyUrl);
-    
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    
-    const data = await response.json();
-    const html = data.contents;
-    
-    const books = parseLibgenHtml(html);
-    
-    return {
-      success: true,
-      books
-    };
+    const res = await secureFetch(`/api/libgen?q=${encodeURIComponent(query)}`);
+    return await res.json();
   } catch (error) {
     console.error('Error searching Libgen:', error);
-    return {
-      success: false,
-      books: [],
-      error: error instanceof Error ? error.message : 'Failed to search Libgen'
-    };
-  }
-}
-
-// Alternative approach using a different CORS proxy
-export async function searchLibgenAlternative(query: string): Promise<LibgenHtmlResponse> {
-  try {
-    const encodedQuery = encodeURIComponent(query);
-    const url = `https://libgen.is/search.php?req=${encodedQuery}&res=25&column=title`;
-    
-    // Use cors-anywhere proxy (note: this requires the proxy to be running)
-    const proxyUrl = `https://cors-anywhere.herokuapp.com/${url}`;
-    
-    const response = await fetch(proxyUrl, {
-      headers: {
-        'X-Requested-With': 'XMLHttpRequest'
-      }
-    });
-    
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    
-    const html = await response.text();
-    const books = parseLibgenHtml(html);
-    
-    return {
-      success: true,
-      books
-    };
-  } catch (error) {
-    console.error('Error searching Libgen (alternative):', error);
     return {
       success: false,
       books: [],

--- a/supabase/migrations/20250801000000-user-goodreads.sql
+++ b/supabase/migrations/20250801000000-user-goodreads.sql
@@ -1,0 +1,20 @@
+create table if not exists public.user_goodreads (
+  id uuid primary key references auth.users(id) on delete cascade,
+  access_token text not null,
+  access_token_secret text not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create or replace function public.touch_updated_at()
+returns trigger language plpgsql as $$
+begin new.updated_at = now(); return new; end $$;
+
+drop trigger if exists trg_ug_updated on public.user_goodreads;
+create trigger trg_ug_updated before update on public.user_goodreads
+for each row execute function public.touch_updated_at();
+
+alter table public.user_goodreads enable row level security;
+
+create policy ug_owner_select on public.user_goodreads
+for select to authenticated using (auth.uid() = id);


### PR DESCRIPTION
## Summary
- persist Goodreads OAuth tokens per-user and use per-request tokens
- add CORS-safe Libgen search proxy with HTML parser
- update frontend hooks and utilities to use new backend routes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68961a397a2083208b056dbd4ae0eb02