### PR TITLE
feat(security): add csrf protection and secure fetch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { toast } from '@/hooks/use-toast';
 import { errorHandler } from '@/utils/errorHandler';
 
 import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { initializeSecurity } from '@/utils/security';
+import { initializeSecurity, initializeSecureSession, setCSRFToken, generateCSRFToken } from '@/utils/security';
 
 // Context imports
 import { AuthProvider } from "./contexts/AuthContext";
@@ -71,6 +71,9 @@ const queryClient = new QueryClient({
 function App() {
   useEffect(() => {
     initializeSecurity();
+    initializeSecureSession();
+    const id = setInterval(() => setCSRFToken(generateCSRFToken()), 30 * 60 * 1000);
+    return () => clearInterval(id);
   }, []);
 
   return (

--- a/src/hooks/useSecureApi.ts
+++ b/src/hooks/useSecureApi.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { secureFetch } from '@/lib/secureFetch';
 import { supabase } from '@/integrations/supabase/client';
-import { setCSRFToken } from '@/utils/security';
+import { setCSRFToken, clearSecureSession } from '@/utils/security';
 
 export function useSecureApi() {
   const fetcher = useCallback((url: string, opts?: RequestInit) => secureFetch(url, opts), []);
@@ -22,6 +22,7 @@ export function useSecureApi() {
   const logout = useCallback(async () => {
     await secureFetch('/api/logout', { method: 'POST' });
     await supabase.auth.signOut();
+    clearSecureSession();
   }, []);
 
   return { fetcher, login, logout };

--- a/src/hooks/useSpeechToText.ts
+++ b/src/hooks/useSpeechToText.ts
@@ -1,5 +1,6 @@
 
 import * as React from 'react';
+import { secureFetch } from '@/lib/secureFetch';
 
 interface UseSpeechToTextOptions {
   onTranscript: (text: string) => void;
@@ -38,10 +39,9 @@ export const useSpeechToText = ({ onTranscript, onError }: UseSpeechToTextOption
             const formData = new FormData();
             formData.append('audio', audioBlob, 'recording.webm');
 
-            const response = await fetch('/api/stt', {
+            const response = await secureFetch('/api/stt', {
               method: 'POST',
               body: formData,
-              credentials: 'include',
             });
 
             if (!response.ok) {

--- a/src/lib/secureFetch.ts
+++ b/src/lib/secureFetch.ts
@@ -2,7 +2,11 @@ import { createSecureHeaders } from '@/utils/security';
 import { toAppError, safeJson } from './errors';
 
 export async function secureFetch(input: string, init: RequestInit = {}) {
-  init.headers = { ...(init.headers || {}), ...createSecureHeaders(true) };
+  const headers = { ...createSecureHeaders(true), ...(init.headers || {}) } as Record<string, string>;
+  if (init.body instanceof FormData) {
+    delete headers['Content-Type'];
+  }
+  init.headers = headers;
   (init as any).credentials = 'include';
 
   try {

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { secureFetch } from '@/lib/secureFetch';
 import { useLocation } from 'react-router-dom';
 
 const useRouter = () => {
@@ -20,7 +21,7 @@ async function fetchBooks({ q, genre }: { q?: string; genre?: string }) {
   const params = new URLSearchParams();
   if (q) params.set('q', q);
   if (genre) params.set('genre', genre);
-  const res = await fetch(`/api/books?${params.toString()}`);
+  const res = await secureFetch(`/api/books?${params.toString()}`);
   if (!res.ok) {
     throw new Error('Failed to fetch books');
   }


### PR DESCRIPTION
## Summary
- implement double-submit CSRF utilities and session helpers
- wrap client requests with secureFetch and rotate CSRF tokens
- verify session and CSRF headers on protected server routes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68961a6f8aa88320835c7d87388a3e5c