### PR TITLE
Allow root domain in CORS

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,7 +39,12 @@ app.use(cookieParser());
 app.use(express.json());
 app.use(
   cors({
-    origin: [/\.sahadhyayi\.com$/, 'http://localhost:5173', 'http://127.0.0.1:5173'],
+    origin: [
+      /\.sahadhyayi\.com$/,
+      'https://sahadhyayi.com',
+      'http://localhost:5173',
+      'http://127.0.0.1:5173',
+    ],
     credentials: true,
   })
 );


### PR DESCRIPTION
## Summary
- allow sahadhyayi.com root domain in server CORS origin list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689658d42dc483209836aded99e9c8f5