### PR TITLE
Ensure loader hides on errors and use full-screen error fallback

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,26 +1,40 @@
 import React from 'react';
 import { errorHandler } from '@/utils/errorHandler';
+import { ErrorFallback } from '@/components/ErrorFallback';
 
 type Props = { children: React.ReactNode; fallback?: React.ReactNode };
 
 export class ErrorBoundary extends React.Component<Props, { hasError: boolean }> {
   state = { hasError: false };
+
   static getDerivedStateFromError() {
     return { hasError: true };
   }
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
+
+  componentDidCatch(error: Error) {
     errorHandler.reportCustomError(
       error.message,
       { component: 'ErrorBoundary', action: 'componentDidCatch' },
       'critical'
     );
+
+    // Ensure any persistent loader is removed when an error occurs
+    const loader = document.getElementById('loader');
+    if (loader) {
+      loader.style.display = 'none';
+    }
   }
+
   render() {
     if (this.state.hasError) {
-      return this.props.fallback ?? (
-        <div className="p-4">Something went wrong. <button onClick={() => location.reload()}>Reload</button></div>
+      const fallback = this.props.fallback ?? <ErrorFallback />;
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-background p-4">
+          {fallback}
+        </div>
       );
     }
+
     return this.props.children;
   }
 }


### PR DESCRIPTION
## Summary
- remove persistent loader when an error is caught
- show full-screen error fallback when app crashes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68965b76d3d4832095208088686b2f99