### PR TITLE
Enable opening book reader from library views

### DIFF
--- a/src/components/library/BookGridView.tsx
+++ b/src/components/library/BookGridView.tsx
@@ -145,6 +145,22 @@ const BookGridView = ({ books }: BookGridViewProps) => {
                   <TooltipContent>Download</TooltipContent>
                 </Tooltip>
 
+                {/* Read */}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="icon"
+                      variant="outline"
+                      onClick={() => handleReadBook(book)}
+                      disabled={!book.pdf_url}
+                      aria-label={`Read ${book.title}`}
+                    >
+                      <BookOpen className="w-4 h-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Read</TooltipContent>
+                </Tooltip>
+
                 {/* Details */}
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/src/components/library/BookListView.tsx
+++ b/src/components/library/BookListView.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
-import { Eye } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
 import BookReader from './BookReader';
 import type { Book } from '@/hooks/useLibraryBooks';
 
@@ -76,7 +76,17 @@ const BookListView = ({ books }: BookListViewProps) => {
 
               {/* Actions */}
               <div className="flex-shrink-0 w-48 space-y-3">
-                
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => handleReadBook(book)}
+                  disabled={!book.pdf_url}
+                  aria-label={`Read ${book.title}`}
+                >
+                  <BookOpen className="w-4 h-4 mr-2" />
+                  Read
+                </Button>
+
                 <Select
                   value={userShelves[book.id] || 'want-to-read'}
                   onValueChange={(value) => handleShelfChange(book.id, value)}


### PR DESCRIPTION
## Summary
- add a Read action to library grid view
- add a Read action to library list view

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68966f296e108320b08287775e45eb7c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Read" button to both grid and list views of the library, allowing users to open books directly if a PDF is available.
  * The "Read" button includes an accessible label and tooltip for improved usability.
  * The button is disabled for books without a PDF.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->