### PR TITLE
Fix chatbot toggle visibility

### DIFF
--- a/src/components/chatbot/presentational/ChatWindow.tsx
+++ b/src/components/chatbot/presentational/ChatWindow.tsx
@@ -10,30 +10,34 @@ interface ChatWindowProps {
 
 export function ChatWindow({ isOpen, onToggle, gradientClass, children, loading }: ChatWindowProps) {
   return (
-    <aside
-      aria-label="Chat window"
-      role="complementary"
-      className={`fixed bottom-6 right-6 z-50 w-[360px] max-h-[70vh] rounded-xl shadow-lg overflow-hidden ${isOpen ? '' : 'pointer-events-none opacity-0'}`}
-    >
-      <div className={`h-2 ${gradientClass}`} />
-      <section
-        id="chat-panel"
-        role="region"
-        aria-live="polite"
-        aria-busy={loading}
-        className="bg-background border border-border rounded-b-xl"
-      >
-        {children}
-      </section>
+    <>
+      {isOpen && (
+        <aside
+          aria-label="Chat window"
+          role="complementary"
+          className="fixed bottom-16 right-6 z-50 w-[360px] max-h-[70vh] rounded-xl shadow-lg overflow-hidden"
+        >
+          <div className={`h-2 ${gradientClass}`} />
+          <section
+            id="chat-panel"
+            role="region"
+            aria-live="polite"
+            aria-busy={loading}
+            className="bg-background border border-border rounded-b-xl"
+          >
+            {children}
+          </section>
+        </aside>
+      )}
       <button
         aria-label={isOpen ? 'Minimize chat' : 'Open chat'}
         aria-expanded={isOpen}
         aria-controls="chat-panel"
         onClick={onToggle}
-        className="absolute -top-3 right-3 rounded-full border bg-background px-2 py-1 text-xs"
+        className="fixed bottom-6 right-6 z-50 rounded-full border bg-background px-2 py-1 text-xs shadow-lg"
       >
         {isOpen ? '—' : 'Chat'}
       </button>
-    </aside>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- ensure chatbot toggle button stays visible
- render chat window only when open

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68967132681083209ce915d02fe90877