### PR TITLE
fix: allow external book cover images

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <!-- CSP is normally set via HTTP headers in server.js. Meta is a fallback for static preview only. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co wss:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:;" />
 
     <!-- Enhanced Structured Data -->
     <script type="application/ld+json">

--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ const CSP = [
   "default-src 'self'",
   "script-src 'self' https://maps.googleapis.com",
   "style-src 'self' https://fonts.googleapis.com",
-  "img-src 'self' data: blob:",
+  "img-src 'self' data: blob: https:",
   "font-src 'self' https://fonts.gstatic.com",
   "connect-src 'self' https://*.supabase.co wss:",
   "frame-src 'self'",

--- a/src/utils/securityConfig.ts
+++ b/src/utils/securityConfig.ts
@@ -15,7 +15,7 @@ export const SECURITY_CONFIG = {
     'default-src': ["'self'"],
     'script-src': ["'self'", "https://maps.googleapis.com"],
     'style-src': ["'self'", "https://fonts.googleapis.com"],
-    'img-src': ["'self'", "data:", "blob:"],
+    'img-src': ["'self'", "data:", "blob:", "https:"],
     'font-src': ["'self'", "https://fonts.gstatic.com"],
     'connect-src': ["'self'", "https://*.supabase.co", "wss:"],
     'frame-src': ["'self'"],


### PR DESCRIPTION
## Summary
- allow external image sources in CSP headers and meta tags so book covers display
- update security config for consistent CSP

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68967219ccac8320a3ff0b01fa135e8b