### PR TITLE
Refine hero animation pause logic

### DIFF
--- a/src/components/AnimatedHero.tsx
+++ b/src/components/AnimatedHero.tsx
@@ -151,6 +151,8 @@ const AnimatedHero: React.FC = () => {
   const maskSize = 2 * (ringConfig.inner.radius - ringStroke / 2 - 26);
 
   const [isAnyAtomHovered, setIsAnyAtomHovered] = useState(false);
+  const [isReducedMotion, setIsReducedMotion] = useState(false);
+  const [isTabHidden, setIsTabHidden] = useState(false);
   // Align atoms with ring stroke by using the ring radius minus half the stroke width
   const [occupiedOrbits, setOccupiedOrbits] = useState<Record<string, number>>({
     L: ringConfig.outer.radius - ringStroke / 2,
@@ -163,6 +165,24 @@ const AnimatedHero: React.FC = () => {
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  // prefers-reduced-motion (optional)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = () => setIsReducedMotion(mq.matches);
+    onChange();
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, []);
+
+  // pause when tab not visible (optional)
+  useEffect(() => {
+    const onVis = () => setIsTabHidden(document.hidden);
+    onVis();
+    document.addEventListener("visibilitychange", onVis);
+    return () => document.removeEventListener("visibilitychange", onVis);
   }, []);
 
   useEffect(() => {
@@ -194,6 +214,8 @@ const AnimatedHero: React.FC = () => {
     });
   };
 
+  const isPaused = isAnyAtomHovered || isReducedMotion || isTabHidden;
+
   return (
     <div className="relative flex items-center justify-center min-h-screen bg-black overflow-hidden">
       {/* Atomic Rings */}
@@ -205,7 +227,7 @@ const AnimatedHero: React.FC = () => {
           rotation={ring.rotation}
           duration={ring.duration}
           strokeWidth={ringStroke}
-          isPaused={isAnyAtomHovered}
+          isPaused={isPaused}
         />
       ))}
 
@@ -236,6 +258,7 @@ const AnimatedHero: React.FC = () => {
           size={atom.size}
           onHoverChange={setIsAnyAtomHovered}
           onOrbitChange={(newOrbit) => updateAtomOrbit(atom.letter, newOrbit)}
+          isPaused={isPaused}
         />
       ))}
 

--- a/src/components/hero/OrbitingAtom.tsx
+++ b/src/components/hero/OrbitingAtom.tsx
@@ -13,6 +13,7 @@ interface OrbitingAtomProps {
   size?: number;
   onHoverChange?: (isHovered: boolean) => void;
   onOrbitChange?: (newOrbit: number) => void;
+  isPaused?: boolean;
 }
 
 export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
@@ -27,6 +28,7 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
   size = 48,
   onHoverChange,
   onOrbitChange,
+  isPaused = false,
 }) => {
   const [currentOrbitRadius, setCurrentOrbitRadius] = useState(orbitRadius);
   const [isHovered, setIsHovered] = useState(false);
@@ -102,7 +104,7 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
           offsetPath: `path('M 0 ${currentOrbitRadius} A ${currentOrbitRadius} ${currentOrbitRadius} 0 0 1 ${orbitSize} ${currentOrbitRadius}')`,
           offsetRotate: "0deg", // Keep atoms upright
           animation: `moveAtom-${duration} ${duration}s linear infinite`,
-          animationPlayState: (isHovered || isTransitioning) ? "paused" : "running",
+          animationPlayState: (isHovered || isTransitioning || isPaused) ? "paused" : "running",
           left: 0,
           top: `-${size/2}px`, // Center atom vertically on the path
         }}


### PR DESCRIPTION
## Summary
- Separate pause triggers for atom hover, reduced motion, and hidden tab
- Pass aggregated pause state to hero rings and atoms
- Allow OrbitingAtom to respect global pause flag

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689677db6c508320808269d3695cf035