### PR TITLE
fix(hero): restore full orbit animations

### DIFF
--- a/src/components/hero/OrbitingAtom.tsx
+++ b/src/components/hero/OrbitingAtom.tsx
@@ -36,6 +36,7 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
   
   const material = ATOM_MATERIALS[materialId];
   const orbitSize = currentOrbitRadius * 2;
+  const initialDelay = -(initialAngle / 360) * duration;
 
   // Chemistry rule: Switch to unoccupied orbits only
   useEffect(() => {
@@ -92,8 +93,8 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
       >
         <defs>
           <path
-            id={`half-circle-path-${currentOrbitRadius}`}
-            d={`M 0 ${currentOrbitRadius} A ${currentOrbitRadius} ${currentOrbitRadius} 0 0 1 ${orbitSize} ${currentOrbitRadius}`}
+            id={`full-circle-path-${currentOrbitRadius}`}
+            d={`M ${currentOrbitRadius} 0 A ${currentOrbitRadius} ${currentOrbitRadius} 0 1 1 ${currentOrbitRadius} ${orbitSize} A ${currentOrbitRadius} ${currentOrbitRadius} 0 1 1 ${currentOrbitRadius} 0`}
           />
         </defs>
       </svg>
@@ -101,9 +102,10 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
       <div
         className="absolute pointer-events-auto cursor-pointer flex flex-col items-center"
         style={{
-          offsetPath: `path('M 0 ${currentOrbitRadius} A ${currentOrbitRadius} ${currentOrbitRadius} 0 0 1 ${orbitSize} ${currentOrbitRadius}')`,
+          offsetPath: `path('M ${currentOrbitRadius} 0 A ${currentOrbitRadius} ${currentOrbitRadius} 0 1 1 ${currentOrbitRadius} ${orbitSize} A ${currentOrbitRadius} ${currentOrbitRadius} 0 1 1 ${currentOrbitRadius} 0')`,
           offsetRotate: "0deg", // Keep atoms upright
           animation: `moveAtom-${duration} ${duration}s linear infinite`,
+          animationDelay: `${initialDelay}s`,
           animationPlayState: (isHovered || isTransitioning || isPaused) ? "paused" : "running",
           left: 0,
           top: `-${size/2}px`, // Center atom vertically on the path


### PR DESCRIPTION
## Summary
- restore full circular paths for AnimatedHero atoms
- offset atom animations using initial angle

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896a8a5fb8483208fc1d1aa2b871e0a