### PR TITLE
fix: align hero animations

### DIFF
--- a/src/components/AnimatedHero.tsx
+++ b/src/components/AnimatedHero.tsx
@@ -155,9 +155,9 @@ const AnimatedHero: React.FC = () => {
   const [isTabHidden, setIsTabHidden] = useState(false);
   // Align atoms with ring stroke by using the ring radius minus half the stroke width
   const [occupiedOrbits, setOccupiedOrbits] = useState<Record<string, number>>({
-    L: ringConfig.outer.radius - ringStroke / 2,
-    A: ringConfig.middle.radius - ringStroke / 2,
-    S: ringConfig.inner.radius - ringStroke / 2,
+    L: ringConfig.outer.radius,
+    A: ringConfig.middle.radius,
+    S: ringConfig.inner.radius,
   });
 
   useEffect(() => {
@@ -187,11 +187,11 @@ const AnimatedHero: React.FC = () => {
 
   useEffect(() => {
     setOccupiedOrbits({
-      L: ringConfig.outer.radius - ringStroke / 2,
-      A: ringConfig.middle.radius - ringStroke / 2,
-      S: ringConfig.inner.radius - ringStroke / 2,
+      L: ringConfig.outer.radius,
+      A: ringConfig.middle.radius,
+      S: ringConfig.inner.radius,
     });
-  }, [ringConfig, ringStroke]);
+  }, [ringConfig]);
 
   const updateAtomOrbit = (atomLetter: string, newOrbit: number) => {
     setOccupiedOrbits(prev => ({
@@ -202,9 +202,9 @@ const AnimatedHero: React.FC = () => {
 
   const getAvailableOrbits = (currentAtom: string) => {
     const allOrbits = [
-      ringConfig.outer.radius - ringStroke / 2,
-      ringConfig.middle.radius - ringStroke / 2,
-      ringConfig.inner.radius - ringStroke / 2,
+      ringConfig.outer.radius,
+      ringConfig.middle.radius,
+      ringConfig.inner.radius,
     ];
     const currentAtomOrbit = occupiedOrbits[currentAtom];
     

--- a/src/components/hero/AtomicRing.tsx
+++ b/src/components/hero/AtomicRing.tsx
@@ -41,6 +41,7 @@ export const AtomicRing: React.FC<AtomicRingProps> = ({
         height: size,
         left: `calc(50% - ${radius}px)`,
         top: `calc(50% - ${radius}px)`,
+        transformOrigin: "50% 50%",
         animation: `spin-${duration}-${radius} ${duration}s linear infinite`,
         animationPlayState: isPaused ? "paused" : "running",
         willChange: "transform",

--- a/src/components/hero/OrbitingAtom.tsx
+++ b/src/components/hero/OrbitingAtom.tsx
@@ -75,6 +75,7 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
   const strokeWidth = 28; // Match AtomicRing strokeWidth
   const pathRadius = currentOrbitRadius - strokeWidth / 2; // Match ring's arc radius
   const center = currentOrbitRadius;
+  const animationDelay = `-${(initialAngle / 360) * duration}s`;
   
   return (
     <div
@@ -94,6 +95,7 @@ export const OrbitingAtom: React.FC<OrbitingAtomProps> = ({
           offsetPath: `circle(${pathRadius}px at ${center}px ${center}px)`,
           offsetRotate: "0deg",
           animation: `moveAtom-${duration} ${duration}s linear infinite`,
+          animationDelay,
           animationPlayState: (isHovered || isTransitioning || isPaused) ? "paused" : "running",
         }}
       >


### PR DESCRIPTION
## Summary
- ensure hero ring and atom paths revolve around the central text
- start atoms at different angles and keep orbits aligned with rings
- fix ring transform origin so arcs rotate properly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689718402d208320aa6af12fd8d96b96