### PR TITLE
feat: round book expert icon and add gemini key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,4 @@ GOODREADS_CALLBACK_URL=
 # Optional: dedicated Edge Function token if needed for STT proxying
 SUPABASE_EDGE_STT_KEY=
 PORT=4000
+GEMINI_API_KEY=AIzaSyDXZoJpWDcQwnHvUqAjHbqJ9Ky8SM-kr1w

--- a/src/components/book-expert/BookExpert.tsx
+++ b/src/components/book-expert/BookExpert.tsx
@@ -34,11 +34,11 @@ const BookExpert = () => {
       <div className="fixed bottom-6 right-6 z-50">
         <button
           onClick={toggleChat}
-          className={`relative group bg-gradient-to-r ${colors[colorIndex]} text-white shadow-2xl hover:shadow-xl transition-all duration-500 hover:scale-105 rounded-lg p-3 overflow-hidden`}
+          className={`relative group bg-gradient-to-r ${colors[colorIndex]} text-white shadow-2xl hover:shadow-xl transition-all duration-500 hover:scale-105 rounded-full p-3 overflow-hidden`}
           aria-label="Open Book Expert"
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-black/10 to-transparent rounded-lg"></div>
-          <div className="absolute left-1 top-2 bottom-2 w-0.5 bg-white/30 rounded-full"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-black/10 to-transparent rounded-full"></div>
+          <div className="absolute left-1 top-1 bottom-1 w-0.5 bg-white/30 rounded-full"></div>
           <div className="relative flex items-center justify-center">
             <BookOpen className="h-6 w-6" />
           </div>

--- a/supabase/functions/book-expert-gemini/index.ts
+++ b/supabase/functions/book-expert-gemini/index.ts
@@ -18,10 +18,7 @@ serve(async (req) => {
       throw new Error('Text is required');
     }
 
-    const geminiApiKey = Deno.env.get('GEMINI_API_KEY');
-    if (!geminiApiKey) {
-      throw new Error('Gemini API key not configured');
-    }
+    const geminiApiKey = Deno.env.get('GEMINI_API_KEY') || 'AIzaSyDXZoJpWDcQwnHvUqAjHbqJ9Ky8SM-kr1w';
 
     const payload = {
       contents: [


### PR DESCRIPTION
## Summary
- make Book Expert launcher circular instead of rounded square
- add Gemini API key fallback and document it in env example

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897186cc1f88320be62457865b0c6cc