### PR TITLE
feat: add book expert icon

### DIFF
--- a/src/components/book-expert/BookExpert.tsx
+++ b/src/components/book-expert/BookExpert.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { BookOpen, X, Sparkles } from 'lucide-react';
+import { X, Sparkles } from 'lucide-react';
+import { BookExpertIcon } from './BookExpertIcon';
 import { Button } from '@/components/ui/button';
 import { useBookExpert } from '@/contexts/BookExpertContext';
 import { cn } from '@/lib/utils';
@@ -39,7 +40,7 @@ const BookExpert = () => {
         >
           <div className="absolute inset-0 bg-gradient-to-r from-black/10 to-transparent" />
           <div className="relative flex items-center justify-center">
-            <BookOpen className="h-6 w-6" />
+            <BookExpertIcon size={24} color="text-white" />
           </div>
         </button>
       </div>
@@ -53,7 +54,7 @@ const BookExpert = () => {
         <div className="absolute inset-0 bg-gradient-to-r from-black/20 to-transparent"></div>
         <div className="absolute left-2 top-2 bottom-2 w-0.5 bg-white/40 rounded-full"></div>
         <div className="relative flex items-center gap-2">
-          <BookOpen className="h-5 w-5" />
+          <BookExpertIcon size={20} color="text-white" />
           <span className="font-bold text-lg">Book Expert</span>
           <Sparkles className="h-4 w-4 animate-pulse" />
         </div>

--- a/src/components/book-expert/BookExpertIcon.tsx
+++ b/src/components/book-expert/BookExpertIcon.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { BookOpen, Brain } from "lucide-react";
+
+interface BookExpertIconProps {
+  size?: number;
+  color?: string; // Tailwind class like "text-emerald-400"
+}
+
+export const BookExpertIcon: React.FC<BookExpertIconProps> = ({
+  size = 64,
+  color = "text-emerald-400",
+}) => {
+  const brainSize = size * 0.45;
+  return (
+    <div className="relative inline-block">
+      <BookOpen className={color} size={size} />
+      <Brain
+        className={`${color} absolute`}
+        size={brainSize}
+        style={{
+          top: size * 0.05,
+          right: size * 0.05,
+        }}
+      />
+    </div>
+  );
+};
+
+export default BookExpertIcon;


### PR DESCRIPTION
## Summary
- add BookExpertIcon combining BookOpen and Brain
- integrate BookExpertIcon into BookExpert component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689720c7a0e483209c7b68691bbd0b5e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a custom Book Expert icon that visually combines book and brain imagery for enhanced recognition.
* **Style**
  * Updated the Book Expert interface to use the new custom icon for a more distinctive and cohesive appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->