### PR TITLE
feat: center hero text within atomic rings

### DIFF
--- a/src/components/AnimatedHero.tsx
+++ b/src/components/AnimatedHero.tsx
@@ -32,9 +32,11 @@ const AnimatedHero: React.FC = () => {
 
   return (
     <div className="relative flex items-center justify-center min-h-screen bg-black overflow-hidden">
-      {/* RINGS & ATOMS */}
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-        <HeroAtomicRings size={isMobile ? 360 : 720} />
+      {/* RINGS, ATOMS & CENTER CONTENT */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <HeroAtomicRings size={isMobile ? 360 : 720}>
+          <HeroContent />
+        </HeroAtomicRings>
       </div>
 
       {/* FLOATING ICONS */}
@@ -48,9 +50,6 @@ const AnimatedHero: React.FC = () => {
           size={icon.size}
         />
       ))}
-
-      {/* CENTER CONTENT */}
-      <HeroContent />
 
       {/* GLOBAL STYLES */}
       <style>{`


### PR DESCRIPTION
## Summary
- render hero text as nucleus within animated rings
- enlarge orbiting atoms and pause animation while hovered

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689990c29c90832099ea1fbfc21f85f7