### PR TITLE
feat: replace facebook emoji with icon

### DIFF
--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -1,6 +1,6 @@
 
 import React from "react";
-import { Users, Mail, LogIn } from "lucide-react";
+import { Users, Mail, LogIn, Facebook } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Link, useNavigate, useLocation } from "react-router-dom";
@@ -248,7 +248,7 @@ const GlobalFooter = () => {
               title="Facebook"
             >
               <span className="sr-only">Facebook</span>
-              📘
+              <Facebook className="h-4 w-4" />
             </a>
             <button
               onClick={() => handleSocialClick('Twitter')}


### PR DESCRIPTION
## Summary
- use lucide-react Facebook icon in footer instead of emoji

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d553ff248320b145a9dda8c135c7