### PR TITLE
feat: add Instagram link to footer

### DIFF
--- a/lovable-website.html
+++ b/lovable-website.html
@@ -321,7 +321,7 @@
                                 <a href="#" class="text-gray-400 hover:text-deep-coral text-2xl transition-colors">
                                     <i class="fab fa-twitter"></i>
                                 </a>
-                                <a href="#" class="text-gray-400 hover:text-deep-coral text-2xl transition-colors">
+                                <a href="https://www.instagram.com/sahadhyayi/" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-deep-coral text-2xl transition-colors">
                                     <i class="fab fa-instagram"></i>
                                 </a>
                                 <a href="#" class="text-gray-400 hover:text-deep-coral text-2xl transition-colors">
@@ -377,7 +377,7 @@
                         <a href="https://x.com/Sahadhyayi" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-deep-coral text-3xl transition-colors">
                             <i class="fab fa-twitter"></i>
                         </a>
-                        <a href="#" class="text-gray-400 hover:text-deep-coral text-3xl transition-colors">
+                        <a href="https://www.instagram.com/sahadhyayi/" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-deep-coral text-3xl transition-colors">
                             <i class="fab fa-instagram"></i>
                         </a>
                         <a href="#" class="text-gray-400 hover:text-deep-coral text-3xl transition-colors">

--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -260,14 +260,16 @@ const GlobalFooter = () => {
               <span className="sr-only">Twitter</span>
               <Twitter className="h-4 w-4" />
             </a>
-            <button
-              onClick={() => handleSocialClick('Instagram')}
+            <a
+              href="https://www.instagram.com/sahadhyayi/"
+              target="_blank"
+              rel="noopener noreferrer"
               className="text-white hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
               title="Instagram"
             >
               <span className="sr-only">Instagram</span>
               <Instagram className="h-4 w-4" />
-            </button>
+            </a>
             <button
               onClick={() => handleSocialClick('LinkedIn')}
               className="text-white hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"


### PR DESCRIPTION
## Summary
- link Instagram icon in React footer to Sahadhyayi profile
- wire up Instagram icon in static website footer to Sahadhyayi profile

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a3504b74483209a6bae59a86a1ea5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Instagram links across the site now open in a new tab with improved security.
- Bug Fixes
  - Replaced placeholder Instagram links with the correct profile URL in contact sections and footer.
  - Updated the footer Instagram icon to use a direct external link instead of an internal click handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->