### PR TITLE
Add LinkedIn link to global footer

### DIFF
--- a/src/components/GlobalFooter.tsx
+++ b/src/components/GlobalFooter.tsx
@@ -32,13 +32,6 @@ const GlobalFooter = () => {
     window.location.href = 'mailto:gyan@sahadhyayi.com';
   };
 
-  const handleSocialClick = (platform: string) => {
-    toast({
-      title: `${platform} Coming Soon!`,
-      description: "We're working on our social media presence. Stay tuned!",
-    });
-  };
-
   const handleShowStats = () => {
     if (!showCount) {
       fetchStats();
@@ -270,14 +263,16 @@ const GlobalFooter = () => {
               <span className="sr-only">Instagram</span>
               <Instagram className="h-4 w-4" />
             </a>
-            <button
-              onClick={() => handleSocialClick('LinkedIn')}
+            <a
+              href="https://www.linkedin.com/company/sahadhyayi/"
+              target="_blank"
+              rel="noopener noreferrer"
               className="text-white hover:text-white transition-colors p-2 hover:bg-orange-500 rounded"
               title="LinkedIn"
             >
               <span className="sr-only">LinkedIn</span>
               <Linkedin className="h-4 w-4" />
-            </button>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- link global footer's LinkedIn icon to the Sahadhyayi LinkedIn page
- remove unused social click handler

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a423746ec8320a679877628b5ef07

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global footer LinkedIn control now opens the company page in a new tab, improving direct access to our profile.
  * Uses secure external link behavior (opens in a new tab with appropriate safety attributes).
  * Replaces the previous in-app “Coming Soon!” toast with direct navigation.
  * Preserves existing styling and accessibility (icon and screen-reader label).
  * Other footer items (email link, stats, sign-in/dialog) remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->