### PR TITLE
fix: adjust hero layout for mobile

### DIFF
--- a/src/components/AnimatedHero.tsx
+++ b/src/components/AnimatedHero.tsx
@@ -34,7 +34,7 @@ const AnimatedHero: React.FC = () => {
     <div className="relative flex items-center justify-center min-h-screen bg-black overflow-hidden">
       {/* RINGS, ATOMS & CENTER CONTENT */}
       <div className="absolute inset-0 flex items-center justify-center">
-        <HeroAtomicRings size={isMobile ? 360 : 720}>
+        <HeroAtomicRings size={isMobile ? 320 : 720}>
           <HeroContent />
         </HeroAtomicRings>
       </div>

--- a/src/components/hero/HeroAtomicRings.tsx
+++ b/src/components/hero/HeroAtomicRings.tsx
@@ -296,7 +296,7 @@ export default function HeroAtomicRings({ size = 720, children }: HeroAtomicRing
       </svg>
       {children && (
         <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
-          <div className="w-full max-w-[60%] pointer-events-auto">{children}</div>
+          <div className="w-full max-w-[55%] sm:max-w-[60%] pointer-events-auto">{children}</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- reduce ring canvas size on mobile
- tighten hero content width for small screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf9faa758832091340885ef0f5fd4