### PR TITLE
chore: enforce RLS for WhatsApp contacts

### DIFF
--- a/supabase/migrations/20250813210000-restrict-whatsapp-contacts-owner.sql
+++ b/supabase/migrations/20250813210000-restrict-whatsapp-contacts-owner.sql
@@ -1,0 +1,8 @@
+-- Restrict whatsapp_contacts access to contact owner only
+ALTER TABLE public.whatsapp_contacts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view their own WhatsApp contacts" ON public.whatsapp_contacts;
+DROP POLICY IF EXISTS "Users can manage their own WhatsApp contacts" ON public.whatsapp_contacts;
+
+CREATE POLICY "contact owner access only" ON public.whatsapp_contacts
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- enforce row-level security on `whatsapp_contacts`
- replace broad policies with a single policy allowing only the contact owner to access their data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf986a54483209297659d21ec2bb1