### PR TITLE
fix: set search_path for plpgsql functions

### DIFF
--- a/supabase/migrations/20250705193520-8affc2c3-c7b3-4c6b-b644-79d9b65a8221.sql
+++ b/supabase/migrations/20250705193520-8affc2c3-c7b3-4c6b-b644-79d9b65a8221.sql
@@ -29,6 +29,7 @@ RETURNS TABLE (
 ) 
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   RETURN QUERY

--- a/supabase/migrations/20250706201442-18b6bff5-8049-4604-aa2e-2982c6a84ab9.sql
+++ b/supabase/migrations/20250706201442-18b6bff5-8049-4604-aa2e-2982c6a84ab9.sql
@@ -24,6 +24,7 @@ CREATE OR REPLACE FUNCTION cleanup_unused_books()
 RETURNS integer
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 DECLARE
     deleted_count integer := 0;

--- a/supabase/migrations/20250709075118-73cb012e-e4a2-4a04-91df-9c4b62159e90.sql
+++ b/supabase/migrations/20250709075118-73cb012e-e4a2-4a04-91df-9c4b62159e90.sql
@@ -47,7 +47,8 @@ BEGIN
   ),
   updated_at = NOW();
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 -- Execute the function to update book counts
 SELECT update_author_book_counts();

--- a/supabase/migrations/20250709085640-e13509ce-42b4-4edf-af36-210c927dc212.sql
+++ b/supabase/migrations/20250709085640-e13509ce-42b4-4edf-af36-210c927dc212.sql
@@ -19,6 +19,7 @@ RETURNS TABLE (
 ) 
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   RETURN QUERY

--- a/supabase/migrations/20250710221951-a3e5b362-d409-4348-928c-be7f07b871b9.sql
+++ b/supabase/migrations/20250710221951-a3e5b362-d409-4348-928c-be7f07b871b9.sql
@@ -156,6 +156,7 @@ RETURNS TABLE (
 ) 
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   RETURN QUERY
@@ -191,7 +192,8 @@ BEGIN
   ),
   updated_at = NOW();
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 -- Execute the function to update book counts based on actual books in the library
 SELECT update_author_book_counts();

--- a/supabase/migrations/20250714201037-594df198-9454-4237-9079-0d8a6e38045d.sql
+++ b/supabase/migrations/20250714201037-594df198-9454-4237-9079-0d8a6e38045d.sql
@@ -195,7 +195,8 @@ BEGIN
   END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+  SET search_path = 'public, pg_catalog';
 
 -- Trigger for friend request acceptance
 DROP TRIGGER IF EXISTS trigger_friend_request_acceptance ON friend_requests;

--- a/supabase/migrations/20250720185827-b712d9d2-9b54-48ea-bb23-aefe5f1144ba.sql
+++ b/supabase/migrations/20250720185827-b712d9d2-9b54-48ea-bb23-aefe5f1144ba.sql
@@ -24,6 +24,7 @@ CREATE OR REPLACE FUNCTION get_website_visit_count()
 RETURNS bigint
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   RETURN (SELECT COUNT(*) FROM public.website_visits);
@@ -39,6 +40,7 @@ CREATE OR REPLACE FUNCTION record_website_visit(
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   INSERT INTO public.website_visits (ip_address, user_agent, page_url)

--- a/supabase/migrations/20250721142435-61f48b1e-6476-4137-88f7-35c0ea110fff.sql
+++ b/supabase/migrations/20250721142435-61f48b1e-6476-4137-88f7-35c0ea110fff.sql
@@ -13,6 +13,7 @@ CREATE OR REPLACE FUNCTION public.record_website_visit(
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $function$
 BEGIN
   INSERT INTO public.website_visits (ip_address, user_agent, page_url, country_code)

--- a/supabase/migrations/20250721144559-705749f0-844f-4bce-af51-002abeb415ce.sql
+++ b/supabase/migrations/20250721144559-705749f0-844f-4bce-af51-002abeb415ce.sql
@@ -69,7 +69,8 @@ BEGIN
   NEW.updated_at = now();
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 CREATE TRIGGER avatar_updated_at_trigger
   BEFORE UPDATE ON public.user_avatars
@@ -82,7 +83,8 @@ BEGIN
   NEW.last_updated = now();
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 CREATE TRIGGER location_updated_trigger
   BEFORE UPDATE ON public.user_locations

--- a/supabase/migrations/20250722000000-add-country-to-website-visits.sql
+++ b/supabase/migrations/20250722000000-add-country-to-website-visits.sql
@@ -12,6 +12,7 @@ CREATE OR REPLACE FUNCTION record_website_visit(
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   INSERT INTO public.website_visits (ip_address, user_agent, page_url, country)

--- a/supabase/migrations/20250723135546-930d5171-000c-4b4d-b758-db5d7e34f854.sql
+++ b/supabase/migrations/20250723135546-930d5171-000c-4b4d-b758-db5d7e34f854.sql
@@ -8,7 +8,8 @@ RETURNS TEXT AS $$
 BEGIN
   RETURN LOWER(TRIM(REGEXP_REPLACE(name, '[^a-zA-Z0-9\s]', '', 'g')));
 END;
-$$ LANGUAGE plpgsql IMMUTABLE;
+$$ LANGUAGE plpgsql IMMUTABLE
+  SET search_path = 'public, pg_catalog';
 
 -- Step 3: Create function to link existing books to authors
 CREATE OR REPLACE FUNCTION link_books_to_authors()
@@ -58,7 +59,8 @@ BEGIN
   
   RETURN linked_count;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 -- Step 4: Execute the linking function
 SELECT link_books_to_authors();
@@ -84,6 +86,7 @@ RETURNS TABLE(
 ) 
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   RETURN QUERY
@@ -140,7 +143,8 @@ BEGIN
     RETURN NEW;
   END IF;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 -- Create trigger for automatic book count updates
 DROP TRIGGER IF EXISTS trigger_update_author_books_count ON public.books_library;

--- a/supabase/migrations/20250723143127-d23517bb-c852-4a1b-ab54-735726cd710a.sql
+++ b/supabase/migrations/20250723143127-d23517bb-c852-4a1b-ab54-735726cd710a.sql
@@ -80,7 +80,8 @@ BEGIN
   END IF;
   RETURN NULL;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+  SET search_path = 'public, pg_catalog';
 
 -- Trigger to automatically update follower counts
 CREATE TRIGGER author_follower_count_trigger
@@ -98,6 +99,7 @@ CREATE OR REPLACE FUNCTION notify_author_followers(
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   INSERT INTO public.notifications (user_id, author_id, type, title, message)

--- a/supabase/migrations/20250723144017-75622cf8-e538-426d-8e9a-59b970acfe82.sql
+++ b/supabase/migrations/20250723144017-75622cf8-e538-426d-8e9a-59b970acfe82.sql
@@ -116,6 +116,7 @@ CREATE OR REPLACE FUNCTION notify_followers_on_post()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   -- Only notify on insert of published posts

--- a/supabase/migrations/20250723144132-a4816e58-22e2-47c3-81f8-2d7a5db9bf06.sql
+++ b/supabase/migrations/20250723144132-a4816e58-22e2-47c3-81f8-2d7a5db9bf06.sql
@@ -116,6 +116,7 @@ CREATE OR REPLACE FUNCTION notify_followers_on_post()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   -- Only notify on insert of published posts

--- a/supabase/migrations/20250723221147-e23108c5-0c2e-4969-888e-9784cf05cdc1.sql
+++ b/supabase/migrations/20250723221147-e23108c5-0c2e-4969-888e-9784cf05cdc1.sql
@@ -154,7 +154,8 @@ BEGIN
   
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+  SET search_path = 'public, pg_catalog';
 
 -- Function to notify followers when author creates an event
 CREATE OR REPLACE FUNCTION public.notify_followers_on_event()
@@ -176,7 +177,8 @@ BEGIN
   
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+  SET search_path = 'public, pg_catalog';
 
 -- Create triggers for notifications
 CREATE TRIGGER notify_followers_on_qa_answer_trigger

--- a/supabase/migrations/20250727000000-create-community-stats-cache.sql
+++ b/supabase/migrations/20250727000000-create-community-stats-cache.sql
@@ -16,6 +16,7 @@ CREATE OR REPLACE FUNCTION public.refresh_community_stats_cache()
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = 'public, pg_catalog'
 AS $$
 BEGIN
   UPDATE public.community_stats_cache


### PR DESCRIPTION
## Summary
- specify `search_path` for PL/pgSQL functions to satisfy SUPA_function_search_path_mutable linting
- ensure user-related triggers and notification helpers run with explicit schema context

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf99b3c108320b9e951a4eb13e0d0