### PR TITLE
fix: use edge function for community stats

### DIFF
--- a/src/hooks/useCommunityStats.ts
+++ b/src/hooks/useCommunityStats.ts
@@ -62,21 +62,12 @@ export const useCommunityStats = (autoFetch: boolean = true) => {
     }
 
     try {
-      const { count: signups, error: signupError } = await supabase
-        .from('profiles')
-        .select('*', { count: 'exact', head: true });
-
-      if (signupError) throw signupError;
-
-      const { count: visits, error: visitError } = await supabase
-        .from('website_visits')
-        .select('*', { count: 'exact', head: true });
-
-      if (visitError) throw visitError;
+      const { data, error: funcError } = await supabase.functions.invoke('community-stats');
+      if (funcError) throw funcError;
 
       const updated = {
-        totalSignups: signups ?? 0,
-        totalVisits: visits ?? 0,
+        totalSignups: data?.totalSignups ?? 0,
+        totalVisits: data?.totalVisits ?? 0,
         lastUpdated: new Date().toISOString(),
       };
 


### PR DESCRIPTION
## Summary
- read community stats via Supabase edge function for accurate counts
- refresh stats in real time when profiles or visits change

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf8f9fd9883209e4e39d8318c39d3