### PR TITLE
fix: keep capabilities carousel within page

### DIFF
--- a/src/components/SahadhyayiCapabilities.tsx
+++ b/src/components/SahadhyayiCapabilities.tsx
@@ -65,7 +65,7 @@ const SahadhyayiCapabilities: React.FC = () => {
 
   return (
     <section
-      className="py-12 sm:py-16 px-4 bg-black text-white overflow-visible"
+      className="py-12 sm:py-16 px-4 bg-black text-white overflow-x-hidden"
       aria-label="Sahadhyayi capabilities carousel"
       role="region"
     >
@@ -85,8 +85,8 @@ const SahadhyayiCapabilities: React.FC = () => {
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
         >
-          {/* keep borders visible; no clipping on hover */}
-          <div className="overflow-visible">
+          {/* Ensure cards stay within the page bounds */}
+          <div className="overflow-hidden">
             <div
               className="flex items-stretch gap-4 sm:gap-6 transition-transform duration-700 will-change-transform"
               style={{


### PR DESCRIPTION
## Summary
- prevent capabilities cards from overflowing the viewport
- clip carousel overflow to keep stack inside page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d07a0f050832093b1ece11fb7d7c4