### PR TITLE
Remove extra chat icon

### DIFF
--- a/src/components/chatbot/UnifiedChat.tsx
+++ b/src/components/chatbot/UnifiedChat.tsx
@@ -28,7 +28,7 @@ interface Message {
 export default function UnifiedChat() {
   const [mode, setMode] = useState<Mode>('book');
   const gradientClass = useColorCycle(mode === 'book' ? BOOK_GRADIENTS : CHAT_GRADIENTS, 5000);
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -123,13 +123,6 @@ export default function UnifiedChat() {
           </div>
         </aside>
       )}
-      <button
-        onClick={() => setIsOpen(o => !o)}
-        aria-label={isOpen ? 'Close chat' : 'Open chat'}
-        className="fixed bottom-6 right-6 z-50 rounded-full border bg-background px-3 py-1 text-xs shadow-lg"
-      >
-        {isOpen ? '—' : 'Chat'}
-      </button>
     </>
   );
 }

--- a/src/components/chatbot/presentational/ChatWindow.tsx
+++ b/src/components/chatbot/presentational/ChatWindow.tsx
@@ -8,7 +8,7 @@ interface ChatWindowProps {
   loading?: boolean;
 }
 
-export function ChatWindow({ isOpen, onToggle, gradientClass, children, loading }: ChatWindowProps) {
+export function ChatWindow({ isOpen, onToggle: _onToggle, gradientClass, children, loading }: ChatWindowProps) {
   return (
     <>
       {isOpen && (
@@ -29,15 +29,6 @@ export function ChatWindow({ isOpen, onToggle, gradientClass, children, loading 
           </section>
         </aside>
       )}
-      <button
-        aria-label={isOpen ? 'Minimize chat' : 'Open chat'}
-        aria-expanded={isOpen}
-        aria-controls="chat-panel"
-        onClick={onToggle}
-        className="fixed bottom-6 right-6 z-50 rounded-full border bg-background px-2 py-1 text-xs shadow-lg"
-      >
-        {isOpen ? '—' : 'Chat'}
-      </button>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Hide standalone chat window toggle so only the AI Book Expert is visible
- Keep UnifiedChat closed by default without rendering its toggle button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a394f3dafc8320913f813ad0bab5f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Removed the chat open/close control; the chat window no longer renders, effectively disabling the in‑app chat experience.
  - Eliminated the minimize/open button and related accessibility labels and interactions.

- Chores
  - Cleaned up unused properties in chat UI components without changing the public interface.

- Known Impact
  - Chat messages, input, sending, and voice features are no longer accessible via the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->