### PR TITLE
feat: improve genre browsing

### DIFF
--- a/src/hooks/usePaginatedLibraryBooks.ts
+++ b/src/hooks/usePaginatedLibraryBooks.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client-universal';
 import type { Book } from './useLibraryBooks';
+import { mapBook } from './useLibraryBooks';
 
 interface UsePaginatedLibraryBooksParams {
   searchQuery?: string;
@@ -59,6 +60,8 @@ export const usePaginatedLibraryBooks = (params: UsePaginatedLibraryBooksParams 
       if (selectedGenre && selectedGenre !== 'All') {
         if (selectedGenre === 'Hindi') {
           query = query.eq('language', 'Hindi');
+        } else if (selectedGenre === 'Other') {
+          query = query.is('genre', null);
         } else {
           query = query.eq('genre', selectedGenre);
         }
@@ -91,22 +94,7 @@ export const usePaginatedLibraryBooks = (params: UsePaginatedLibraryBooksParams 
       setTotalPages(calculatedTotalPages);
 
       // Map and sort books by completeness before pagination
-      const allMappedBooks: Book[] = (data || []).map(book => ({
-        id: book.id,
-        title: book.title,
-        author: book.author || 'Unknown Author',
-        genre: book.genre,
-        cover_image_url: book.cover_image_url,
-        description: book.description,
-        publication_year: book.publication_year,
-        language: book.language || 'English',
-        pdf_url: book.pdf_url,
-        created_at: book.created_at,
-        price: 0,
-        isbn: book.isbn,
-        pages: book.pages,
-        author_bio: book.author_bio
-      }));
+      const allMappedBooks: Book[] = (data || []).map(mapBook);
 
       // Sort by completeness
       const sortedBooks = allMappedBooks.sort((a, b) => {

--- a/src/pages/BookLibrary.tsx
+++ b/src/pages/BookLibrary.tsx
@@ -4,6 +4,7 @@ import { SearchBar } from '@/components/ui/search-bar';
 import FilterPopup from '@/components/library/FilterPopup';
 import BooksCollection from '@/components/library/BooksCollection';
 import GenreSelector from '@/components/library/GenreSelector';
+import { useGenres } from '@/hooks/useLibraryBooks';
 import SEO from '@/components/SEO';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -17,6 +18,14 @@ const BookLibrary = () => {
 
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+
+  const { data: genresData } = useGenres();
+
+  const availableGenres = React.useMemo(() => {
+    const set = new Set<string>(['All']);
+    genresData?.forEach(g => set.add(g.name));
+    return Array.from(set);
+  }, [genresData]);
 
   useEffect(() => {
     const stored = sessionStorage.getItem('scroll-/library');
@@ -161,21 +170,13 @@ const BookLibrary = () => {
               {/* Genre Selector */}
               <div className="mb-6">
                 <h3 className="text-lg font-semibold text-gray-900 mb-3">Browse by Genre</h3>
-                <GenreSelector
-                  genres={[
-                    'All',
-                    'Science',
-                    'Fiction',
-                    'Fantasy',
-                    'Mystery',
-                    'Hindi',
-                    'Devotional',
-                    'Biography',
-                    'History'
-                  ]}
-                  selected={selectedGenre}
-                  onSelect={setSelectedGenre}
-                />
+                {availableGenres.length > 0 && (
+                  <GenreSelector
+                    genres={availableGenres}
+                    selected={selectedGenre}
+                    onSelect={setSelectedGenre}
+                  />
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- normalize book genres and map unclassified titles to Other
- fetch genres dynamically and expose them for selection
- filter server queries for Hindi and Other categories

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3997092048320842a8e07c5713fea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Genre selector now populates dynamically from your library data.
  - Added “Other” genre filter for items without a genre.
  - Hindi-language books without a genre are grouped under “Hindi.”

- Enhancements
  - Genres are standardized and capitalized for a cleaner, more consistent list.
  - Improved defaults for missing book details (e.g., author shown as “Unknown Author”) to ensure complete listings.
  - More resilient browsing with fallback content if fetching fails.

- Refactor
  - Unified internal mapping for books and genres to reduce inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->