### PR TITLE
fix: use shared supabase client for library search

### DIFF
--- a/src/lib/searchLibrary.ts
+++ b/src/lib/searchLibrary.ts
@@ -1,9 +1,4 @@
-import { createClient } from '@supabase/supabase-js'
-
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
+import { supabase } from '@/integrations/supabase/client'
 
 export type BookSearchRow = {
   id: string
@@ -27,7 +22,7 @@ export type SearchParams = {
 export async function searchLibrary(
   query: string,
   params: SearchParams = {},
-  options: { signal?: AbortSignal } = {}
+  options: { signal?: AbortSignal } = {},
 ) {
   const { limit = 50, lang = null, minPopularity = null, genres = null } = params
   const { data, error } = await supabase.rpc<BookSearchRow>(


### PR DESCRIPTION
## Summary
- fix library search to use shared supabase client instead of environment-specific createClient

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acc99e4a2483209e4a77cd8aa63261