### PR TITLE
feat: add supabase-backed external book search

### DIFF
--- a/src/utils/searchExternalSources.ts
+++ b/src/utils/searchExternalSources.ts
@@ -1,58 +1,48 @@
+import { supabase } from '@/integrations/supabase/client'
+
 export interface ExternalBook {
-  id: string;
-  title: string;
-  author?: string;
-  year?: string;
-  language?: string;
-  extension?: string;
-  size?: string;
-  md5: string;
-  downloadUrl: string;
-  source?: 'libgen' | 'open_access';
+  id: string
+  title: string
+  author?: string
+  year?: string
+  language?: string
+  extension?: string
+  size?: string
+  md5: string
+  downloadUrl: string
+  source?: 'libgen' | 'open_access'
 }
 
 /**
  * Search external sources for books matching the query.
- * Since direct CORS requests to libgen.gs fail in browsers,
- * we'll return an empty array for now and recommend using a backend proxy.
- * Returns an array of ExternalBook objects.
+ * Uses the Supabase edge function `search-books-preview` which aggregates
+ * results from multiple open data providers. Returns an array of
+ * `ExternalBook` objects ready for display.
  */
 export async function searchExternalSources(query: string): Promise<ExternalBook[]> {
-  // TODO: Implement backend proxy for libgen.gs to avoid CORS issues
-  // For now, return empty array to prevent CORS errors
-  console.warn('External source search disabled due to CORS restrictions. Consider implementing a backend proxy.');
-  return [];
-  
-  /* 
-   * Original libgen implementation (commented out due to CORS):
-   * 
-   * const encoded = encodeURIComponent(query);
-   * const url = `https://libgen.gs/search.php?req=${encoded}&res=20&format=json`;
-   * 
-   * try {
-   *   const res = await fetch(url);
-   *   if (!res.ok) throw new Error('Libgen request failed');
-   *   const data = await res.json();
-   * 
-   *   if (!Array.isArray(data)) return [];
-   * 
-   *   return data.map((item: any) => {
-   *     const md5: string = item.md5;
-   *     return {
-   *       id: md5,
-   *       md5,
-   *       title: item.title || 'Unknown Title',
-   *       author: item.author,
-   *       year: item.year,
-   *       language: item.language,
-   *       extension: item.extension,
-   *       size: item.filesize || item.filesize_size || item.size,
-   *       downloadUrl: `http://library.lol/main/${md5}`
-   *     } as ExternalBook;
-   *   });
-   * } catch (err) {
-   *   console.error('searchExternalSources error:', err);
-   *   return [];
-   * }
-   */
+  try {
+    const { data, error } = await supabase.functions.invoke('search-books-preview', {
+      body: { searchTerm: query }
+    })
+
+    if (error) throw error
+
+    return (data?.books || [])
+      .filter((book: any) => book.pdf_url)
+      .map((book: any) => ({
+        id: book.isbn || book.title,
+        title: book.title || 'Unknown Title',
+        author: book.author,
+        year: book.publication_year ? String(book.publication_year) : undefined,
+        language: book.language,
+        extension: book.pdf_url ? 'pdf' : undefined,
+        size: book.pages ? `${book.pages} pages` : undefined,
+        md5: book.isbn || book.title,
+        downloadUrl: book.pdf_url,
+        source: 'open_access'
+      }))
+  } catch (err) {
+    console.error('searchExternalSources error:', err)
+    return []
+  }
 }


### PR DESCRIPTION
## Summary
- enable external book search via Supabase edge function

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acccd85e388320b195fddb2e972fd1