### PR TITLE
feat: add searchable library grid

### DIFF
--- a/apps/web-next/src/app/library/page.tsx
+++ b/apps/web-next/src/app/library/page.tsx
@@ -1,7 +1,118 @@
-import LibraryWrapper from '../../components/LibraryWrapper';
+'use client';
+
+import { useEffect, useState } from 'react';
+import LibraryGrid from '@/components/library/LibraryGrid';
+import SearchAndFilters, { FilterState } from '@/components/library/SearchAndFilters';
+import Paginator from '@/components/library/Paginator';
+import { getBooks } from '@/lib/supabase/books';
+import type { Book } from '@/lib/types';
+import useDebouncedValue from '@/lib/useDebouncedValue';
 
 export const dynamic = 'force-dynamic';
 
+const defaultFilters: FilterState = {
+  genres: [],
+  language: undefined,
+  price: undefined,
+  yearRange: [undefined, undefined],
+  sort: 'newest',
+};
+
 export default function LibraryPage() {
-  return <LibraryWrapper />;
+  const [query, setQuery] = useState('');
+  const [filters, setFilters] = useState<FilterState>(defaultFilters);
+  const [books, setBooks] = useState<Book[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+  const [history, setHistory] = useState<string[]>([]);
+
+  const debouncedQuery = useDebouncedValue(query, 300);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    getBooks(
+      {
+        q: debouncedQuery || undefined,
+        genres: filters.genres,
+        language: filters.language,
+        price: filters.price,
+        yearRange: filters.yearRange,
+        sort: filters.sort,
+        cursor,
+      },
+      controller.signal,
+    )
+      .then((res) => {
+        setBooks(res.items);
+        setNextCursor(res.nextCursor);
+      })
+      .catch((err) => {
+        if (err.name !== 'AbortError') {
+          setError('Something went wrong while loading books.');
+        }
+      })
+      .finally(() => setLoading(false));
+
+    return () => controller.abort();
+  }, [debouncedQuery, filters, cursor]);
+
+  const handleQueryChange = (val: string) => {
+    setQuery(val);
+    setCursor(undefined);
+    setHistory([]);
+  };
+
+  const handleFiltersChange = (f: FilterState) => {
+    setFilters(f);
+    setCursor(undefined);
+    setHistory([]);
+  };
+
+  const handleNext = () => {
+    if (nextCursor) {
+      setHistory((h) => [...h, cursor ?? '']);
+      setCursor(nextCursor);
+    }
+  };
+
+  const handlePrev = () => {
+    setHistory((h) => {
+      const newHist = [...h];
+      const prev = newHist.pop();
+      setCursor(prev || undefined);
+      return newHist;
+    });
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      <SearchAndFilters
+        query={query}
+        onQueryChange={handleQueryChange}
+        filters={filters}
+        onFiltersChange={handleFiltersChange}
+      />
+      {error && <p className="text-red-600">{error}</p>}
+      <LibraryGrid books={books} loading={loading} />
+      {!loading && !error && books.length === 0 && (
+        <div className="text-center">
+          <p>No results found.</p>
+          <a className="text-blue-600 underline" href="/ultimate-book-finder">
+            Try the Ultimate Book Finder
+          </a>
+        </div>
+      )}
+      <Paginator
+        hasPrev={history.length > 0}
+        hasNext={!!nextCursor}
+        onPrev={handlePrev}
+        onNext={handleNext}
+      />
+    </div>
+  );
 }

--- a/apps/web-next/src/components/library/BookCard.tsx
+++ b/apps/web-next/src/components/library/BookCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { Book } from '@/lib/types';
+
+interface Props {
+  book: Book;
+}
+
+export default function BookCard({ book }: Props) {
+  const router = useRouter();
+  const cover = book.cover_url ?? 'https://placehold.co/200x300?text=No+Cover';
+
+  return (
+    <button
+      onClick={() => router.push(`/library/${book.id}`)}
+      className="text-left"
+      aria-label={`View details for ${book.title}`}
+    >
+      <div className="aspect-[2/3] w-full overflow-hidden rounded bg-gray-100">
+        <img
+          src={cover}
+          alt={book.title}
+          className="h-full w-full object-cover"
+        />
+      </div>
+      <h3 className="mt-2 line-clamp-2 text-sm font-semibold">{book.title}</h3>
+      {book.authors && (
+        <p className="text-xs text-gray-600 line-clamp-1">
+          {book.authors.map((a) => a.name).join(', ')}
+        </p>
+      )}
+      <div className="mt-1 flex flex-wrap gap-1">
+        <span className="rounded bg-gray-200 px-1 text-[10px] font-medium">
+          {book.language}
+        </span>
+        {book.tags.map((tag) => (
+          <span key={tag} className="rounded bg-gray-100 px-1 text-[10px]">
+            {tag}
+          </span>
+        ))}
+      </div>
+    </button>
+  );
+}

--- a/apps/web-next/src/components/library/LibraryGrid.tsx
+++ b/apps/web-next/src/components/library/LibraryGrid.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { Book } from '@/lib/types';
+import BookCard from './BookCard';
+
+interface Props {
+  books: Book[];
+  loading: boolean;
+}
+
+export default function LibraryGrid({ books, loading }: Props) {
+  if (loading) {
+    return (
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div key={i} className="animate-pulse space-y-2">
+            <div className="aspect-[2/3] w-full rounded bg-gray-200" />
+            <div className="h-4 w-3/4 rounded bg-gray-200" />
+            <div className="h-3 w-1/2 rounded bg-gray-200" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+      {books.map((book) => (
+        <BookCard key={book.id} book={book} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web-next/src/components/library/Paginator.tsx
+++ b/apps/web-next/src/components/library/Paginator.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+interface Props {
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export default function Paginator({ hasPrev, hasNext, onPrev, onNext }: Props) {
+  return (
+    <div className="mt-4 flex justify-center gap-4">
+      <button
+        onClick={onPrev}
+        disabled={!hasPrev}
+        className="rounded border px-3 py-1 disabled:opacity-50"
+        aria-label="Previous page"
+      >
+        Previous
+      </button>
+      <button
+        onClick={onNext}
+        disabled={!hasNext}
+        className="rounded border px-3 py-1 disabled:opacity-50"
+        aria-label="Next page"
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/apps/web-next/src/components/library/SearchAndFilters.tsx
+++ b/apps/web-next/src/components/library/SearchAndFilters.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import type { Language, SortOption } from '@/lib/types';
+
+export interface FilterState {
+  genres: string[];
+  language?: Language;
+  price?: 'free' | 'paid';
+  yearRange: [number | undefined, number | undefined];
+  sort: SortOption;
+}
+
+interface Props {
+  query: string;
+  onQueryChange: (value: string) => void;
+  filters: FilterState;
+  onFiltersChange: (filters: FilterState) => void;
+}
+
+const GENRES = ['Fiction', 'Nonfiction', 'Poetry', 'History', 'Science'];
+
+export default function SearchAndFilters({
+  query,
+  onQueryChange,
+  filters,
+  onFiltersChange,
+}: Props) {
+  const update = (partial: Partial<FilterState>) =>
+    onFiltersChange({ ...filters, ...partial });
+
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder="Search by title, author, tags..."
+        aria-label="Search books"
+        className="flex-1 rounded border px-2 py-1"
+      />
+      <select
+        multiple
+        value={filters.genres}
+        onChange={(e) => {
+          const opts = Array.from(e.target.selectedOptions).map((o) => o.value);
+          update({ genres: opts });
+        }}
+        className="rounded border px-2 py-1"
+        aria-label="Filter by genre"
+      >
+        {GENRES.map((g) => (
+          <option key={g} value={g}>
+            {g}
+          </option>
+        ))}
+      </select>
+      <select
+        value={filters.language ?? ''}
+        onChange={(e) =>
+          update({ language: e.target.value ? (e.target.value as Language) : undefined })
+        }
+        className="rounded border px-2 py-1"
+        aria-label="Filter by language"
+      >
+        <option value="">All languages</option>
+        <option value="EN">English</option>
+        <option value="HI">Hindi</option>
+      </select>
+      <select
+        value={filters.price ?? ''}
+        onChange={(e) =>
+          update({ price: e.target.value ? (e.target.value as 'free' | 'paid') : undefined })
+        }
+        className="rounded border px-2 py-1"
+        aria-label="Filter by price"
+      >
+        <option value="">All</option>
+        <option value="free">Free</option>
+        <option value="paid">Paid</option>
+      </select>
+      <div className="flex gap-1">
+       <input
+          type="number"
+          value={filters.yearRange[0] ?? ''}
+          onChange={(e) =>
+            update({
+              yearRange: [
+                e.target.value ? Number(e.target.value) : undefined,
+                filters.yearRange[1],
+              ],
+            })
+          }
+          className="w-20 rounded border px-2 py-1"
+          placeholder="From"
+          aria-label="From year"
+        />
+       <input
+          type="number"
+          value={filters.yearRange[1] ?? ''}
+          onChange={(e) =>
+            update({
+              yearRange: [
+                filters.yearRange[0],
+                e.target.value ? Number(e.target.value) : undefined,
+              ],
+            })
+          }
+          className="w-20 rounded border px-2 py-1"
+          placeholder="To"
+          aria-label="To year"
+        />
+      </div>
+      <select
+        value={filters.sort}
+        onChange={(e) => update({ sort: e.target.value as SortOption })}
+        className="rounded border px-2 py-1"
+        aria-label="Sort books"
+      >
+        <option value="newest">Newest</option>
+        <option value="popularity">Popularity</option>
+        <option value="az">A→Z</option>
+        <option value="za">Z→A</option>
+      </select>
+    </div>
+  );
+}

--- a/apps/web-next/src/lib/supabase/books.ts
+++ b/apps/web-next/src/lib/supabase/books.ts
@@ -1,0 +1,83 @@
+/*
+-- Suggested indexes for books
+CREATE INDEX ON books USING GIN (tags);
+CREATE INDEX ON books (language);
+CREATE INDEX ON books (created_at DESC);
+CREATE INDEX ON books (popularity DESC);
+CREATE INDEX ON books (lower(title) text_pattern_ops);
+*/
+
+import { supabase } from '@/integrations/supabase/client';
+import { z } from 'zod';
+import { bookSchema, type Book, type GetBooksParams } from '@/lib/types';
+
+export async function getBooks(
+  params: GetBooksParams,
+  signal?: AbortSignal,
+): Promise<{ items: Book[]; nextCursor?: string }> {
+  const limit = 24;
+  let query = supabase
+    .from('books')
+    .select('*, authors:authors(id,name,photo_url)')
+    .limit(limit + 1);
+
+  if (signal) {
+    query = query.abortSignal(signal);
+  }
+
+  if (params.cursor) {
+    query = query.gt('id', params.cursor);
+  }
+
+  if (params.genres && params.genres.length > 0) {
+    query = query.contains('genres', params.genres);
+  }
+
+  if (params.language) {
+    query = query.eq('language', params.language);
+  }
+
+  if (params.price === 'free') {
+    query = query.or('cost.is.null,cost.eq.0');
+  } else if (params.price === 'paid') {
+    query = query.gt('cost', 0);
+  }
+
+  if (params.yearRange) {
+    const [from, to] = params.yearRange;
+    if (from) query = query.gte('year', from);
+    if (to) query = query.lte('year', to);
+  }
+
+  switch (params.sort) {
+    case 'popularity':
+      query = query.order('popularity', { ascending: false });
+      break;
+    case 'az':
+      query = query.order('title', { ascending: true });
+      break;
+    case 'za':
+      query = query.order('title', { ascending: false });
+      break;
+    case 'newest':
+    default:
+      query = query.order('created_at', { ascending: false });
+      break;
+  }
+
+  if (params.q) {
+    const like = `%${params.q}%`;
+    query = query.or(
+      `title.ilike.${like},title_hi.ilike.${like},tags.ilike.${like},authors!inner(name.ilike.${like})`,
+    );
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+
+  const parsed = z.array(bookSchema).parse(data) as Book[];
+  const items = parsed.slice(0, limit);
+  const nextCursor = parsed.length > limit ? parsed[limit - 1].id : undefined;
+
+  return { items, nextCursor };
+}

--- a/apps/web-next/src/lib/types.ts
+++ b/apps/web-next/src/lib/types.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+export const languageSchema = z.union([z.literal('HI'), z.literal('EN')]);
+export type Language = z.infer<typeof languageSchema>;
+
+export const authorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  photo_url: z.string().url().nullable().optional(),
+});
+export type Author = z.infer<typeof authorSchema>;
+
+export const bookSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  title_hi: z.string().optional(),
+  author_ids: z.array(z.string()),
+  genres: z.array(z.string()),
+  tags: z.array(z.string()),
+  language: languageSchema,
+  year: z.number().int().optional(),
+  cost: z.number().nullable().optional(),
+  cover_url: z.string().url().nullable().optional(),
+  file_url: z.string().url().nullable().optional(),
+  popularity: z.number().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  authors: z.array(authorSchema).optional(),
+});
+export type Book = z.infer<typeof bookSchema>;
+
+export type SortOption = 'newest' | 'popularity' | 'az' | 'za';
+
+export interface GetBooksParams {
+  q?: string;
+  genres?: string[];
+  language?: Language;
+  price?: 'free' | 'paid';
+  yearRange?: [number | undefined, number | undefined];
+  sort?: SortOption;
+  cursor?: string;
+}

--- a/apps/web-next/src/lib/useDebouncedValue.ts
+++ b/apps/web-next/src/lib/useDebouncedValue.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export default function useDebouncedValue<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- implement typed Book & Author models and Supabase `getBooks` query helper
- add debounced search, filters and pagination on new library page
- build responsive UI components for book cards and grid

## Testing
- `npm run lint` *(passes with warnings)*
- `npm run build` *(incomplete; process interrupted during Vite build)*
- `cd apps/web-next && npm run build` *(fails: border-border class does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ad48b26c748320802218ecc3c75942