### PR TITLE
feat: add book actions and notes

### DIFF
--- a/apps/web-next/src/__tests__/BookActions.test.tsx
+++ b/apps/web-next/src/__tests__/BookActions.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, waitFor, cleanup, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import BookActions from '../components/library/BookActions';
+
+vi.mock('../lib/supabase/userBooks', () => {
+  return {
+    getStatus: vi.fn().mockResolvedValue(null),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+    toggleWishlist: vi.fn().mockResolvedValue(true),
+  };
+});
+
+vi.mock('../lib/supabase/notes', () => {
+  return {
+    getNote: vi.fn().mockResolvedValue(''),
+    upsertNote: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../integrations/supabase/client', () => {
+  return {
+    supabase: {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+        insert: vi.fn().mockResolvedValue({}),
+      })),
+    },
+  };
+});
+
+import { setStatus, toggleWishlist } from '../lib/supabase/userBooks';
+
+describe('BookActions', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+  it('adds book to library', async () => {
+    render(<BookActions bookId="1" />);
+    const addBtn = await screen.findByTestId('add-btn');
+    fireEvent.click(addBtn);
+    await waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith('1', 'to_read');
+    });
+  });
+
+  it('toggles wishlist', async () => {
+    render(<BookActions bookId="1" />);
+    const wishBtn = await screen.findByTestId('wishlist-btn');
+    fireEvent.click(wishBtn);
+    await waitFor(() => {
+      expect(toggleWishlist).toHaveBeenCalledWith('1');
+    });
+  });
+
+});
+

--- a/apps/web-next/src/app/library/[id]/page.tsx
+++ b/apps/web-next/src/app/library/[id]/page.tsx
@@ -1,0 +1,49 @@
+import BookActions from '../../../components/library/BookActions';
+import { supabase } from '@/integrations/supabase/client';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default async function BookPage({ params }: PageProps) {
+  const { id } = params;
+  const { data: book } = await supabase
+    .from('books_library')
+    .select('*, authors(*)')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (!book) {
+    return <div className="p-4">Book not found</div>;
+  }
+
+  const { data: related } = await supabase
+    .from('books_library')
+    .select('id, title, cover_image_url')
+    .eq('author_id', book.author_id)
+    .neq('id', book.id)
+    .limit(6);
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <div>
+        <h1 className="text-3xl font-bold">{book.title}</h1>
+        {book.authors && <p className="text-gray-600">{book.authors.name}</p>}
+      </div>
+      <BookActions bookId={book.id} fileUrl={book.pdf_url} />
+      {related && related.length > 0 && (
+        <div>
+          <h2 className="text-xl font-semibold mt-6">Related Books</h2>
+          <ul className="list-disc ml-5">
+            {related.map((rb) => (
+              <li key={rb.id}>{rb.title}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/apps/web-next/src/components/library/BookActions.tsx
+++ b/apps/web-next/src/components/library/BookActions.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { getStatus, setStatus, toggleWishlist, ReadingStatus } from '../../lib/supabase/userBooks';
+import { getNote, upsertNote } from '../../lib/supabase/notes';
+import { supabase } from '@/integrations/supabase/client';
+
+interface Props {
+  bookId: string;
+  fileUrl?: string | null;
+}
+
+export default function BookActions({ bookId, fileUrl }: Props) {
+  const [status, setStatusState] = useState<ReadingStatus | null>(null);
+  const [wishlisted, setWishlisted] = useState(false);
+  const [note, setNote] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    getStatus(bookId).then(setStatusState);
+    getNote(bookId).then(setNote);
+    supabase
+      .from('user_wishlist')
+      .select('id')
+      .eq('book_id', bookId)
+      .maybeSingle()
+      .then(({ data }) => setWishlisted(!!data));
+  }, [bookId]);
+
+  const handleAdd = async () => {
+    await setStatus(bookId, 'to_read');
+    setStatusState('to_read');
+  };
+
+  const handleWishlist = async () => {
+    const next = await toggleWishlist(bookId);
+    setWishlisted(next);
+  };
+
+  const handleStatusChange = async (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const newStatus = e.target.value as ReadingStatus;
+    await setStatus(bookId, newStatus);
+    setStatusState(newStatus);
+  };
+
+  const handleOpen = async () => {
+    await supabase
+      .from('book_events')
+      .insert({ book_id: bookId, event: 'view' });
+  };
+
+  const handleDownload = async () => {
+    await supabase
+      .from('book_events')
+      .insert({ book_id: bookId, event: 'download' });
+  };
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (note !== '') {
+        upsertNote(bookId, note)
+          .then(() => setSaved(true))
+          .catch(() => setSaved(false));
+      }
+    }, 1500);
+    return () => clearTimeout(t);
+  }, [note, bookId]);
+
+  return (
+    <div className="space-y-4">
+      {status ? (
+        <select
+          value={status}
+          onChange={handleStatusChange}
+          className="border rounded p-2"
+          data-testid="status-select"
+        >
+          <option value="to_read">To Read</option>
+          <option value="reading">Reading</option>
+          <option value="completed">Completed</option>
+        </select>
+      ) : (
+        <Button onClick={handleAdd} data-testid="add-btn">
+          Add to My Library
+        </Button>
+      )}
+      <Button onClick={handleWishlist} data-testid="wishlist-btn">
+        {wishlisted ? 'Remove from Wishlist' : 'Add to Wishlist'}
+      </Button>
+      <div className="space-x-2">
+        <Button onClick={handleOpen} data-testid="open-btn">
+          Open
+        </Button>
+        {fileUrl && (
+          <Button onClick={handleDownload} data-testid="download-btn">
+            Download
+          </Button>
+        )}
+      </div>
+      <div>
+        <textarea
+          value={note}
+          onChange={(e) => {
+            setNote(e.target.value);
+            setSaved(false);
+          }}
+          className="w-full border rounded p-2"
+          data-testid="note-editor"
+        />
+        {saved && <span className="text-green-600 ml-2" data-testid="saved-indicator">Saved</span>}
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web-next/src/lib/supabase/notes.ts
+++ b/apps/web-next/src/lib/supabase/notes.ts
@@ -1,0 +1,31 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export async function getNote(bookId: string): Promise<string> {
+  const { data, error } = await supabase
+    .from('user_book_notes')
+    .select('text')
+    .eq('book_id', bookId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getNote error', error);
+    return '';
+  }
+
+  return data?.text ?? '';
+}
+
+export async function upsertNote(bookId: string, text: string): Promise<void> {
+  const { data: user } = await supabase.auth.getUser();
+  if (!user?.user) throw new Error('Not authenticated');
+
+  const { error } = await supabase
+    .from('user_book_notes')
+    .upsert({ book_id: bookId, user_id: user.user.id, text }, { onConflict: 'user_id,book_id' });
+
+  if (error) {
+    console.error('upsertNote error', error);
+    throw error;
+  }
+}
+

--- a/apps/web-next/src/lib/supabase/userBooks.ts
+++ b/apps/web-next/src/lib/supabase/userBooks.ts
@@ -1,0 +1,82 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export type ReadingStatus = 'to_read' | 'reading' | 'completed';
+
+export async function getStatus(bookId: string): Promise<ReadingStatus | null> {
+  const {
+    data,
+    error,
+  } = await supabase
+    .from('user_books')
+    .select('status')
+    .eq('book_id', bookId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getStatus error', error);
+    return null;
+  }
+
+  return (data?.status as ReadingStatus) ?? null;
+}
+
+export async function setStatus(
+  bookId: string,
+  status: ReadingStatus,
+): Promise<void> {
+  const {
+    data: user,
+  } = await supabase.auth.getUser();
+  if (!user?.user) throw new Error('Not authenticated');
+
+  const { error } = await supabase
+    .from('user_books')
+    .upsert({ book_id: bookId, status, user_id: user.user.id }, { onConflict: 'user_id,book_id' });
+
+  if (error) {
+    console.error('setStatus error', error);
+    throw error;
+  }
+}
+
+export async function toggleWishlist(bookId: string): Promise<boolean> {
+  const { data: user } = await supabase.auth.getUser();
+  if (!user?.user) throw new Error('Not authenticated');
+
+  const {
+    data: existing,
+    error: selectError,
+  } = await supabase
+    .from('user_wishlist')
+    .select('id')
+    .eq('book_id', bookId)
+    .eq('user_id', user.user.id)
+    .maybeSingle();
+
+  if (selectError) {
+    console.error('toggleWishlist select error', selectError);
+    throw selectError;
+  }
+
+  if (existing) {
+    const { error } = await supabase
+      .from('user_wishlist')
+      .delete()
+      .eq('id', existing.id);
+    if (error) {
+      console.error('toggleWishlist delete error', error);
+      throw error;
+    }
+    return false;
+  } else {
+    const { error } = await supabase
+      .from('user_wishlist')
+      .insert({ book_id: bookId, user_id: user.user.id });
+    if (error) {
+      console.error('toggleWishlist insert error', error);
+      throw error;
+    }
+    return true;
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement book detail page with related books
- add user book actions (library, wishlist, status, notes)
- provide supabase helpers for user books and notes
- test library actions

## Testing
- `npx vitest run --environment jsdom`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad48dba138832083c0fcae44559fe0