### PR TITLE
feat: add current reads widget

### DIFF
--- a/src/components/library/CurrentReads.tsx
+++ b/src/components/library/CurrentReads.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { BookOpen } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { useAuth } from '@/contexts/authHelpers';
+import { fetchCurrentReads, updateLastOpenedAt, type CurrentRead } from '@/lib/supabase/userBooks';
+
+const CurrentReads: React.FC = () => {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const { data: books, isLoading, error } = useQuery<CurrentRead[]>({
+    queryKey: ['current-reads', user?.id],
+    queryFn: fetchCurrentReads,
+    enabled: !!user,
+  });
+
+  const handleOpen = async (book: CurrentRead) => {
+    try {
+      await updateLastOpenedAt(book.id);
+    } catch (err) {
+      console.error('Failed to update last opened time', err);
+    }
+    navigate(`/book/${book.book_id}`);
+  };
+
+  if (!user) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center text-base">
+            <BookOpen className="w-5 h-5 mr-2 text-amber-600" />
+            Your Current Reads
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-center space-y-4">
+          <p className="text-sm text-gray-600">Sign in to track your reading progress.</p>
+          <Button asChild>
+            <Link to="/sign-in">Sign In</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center text-base">
+            <BookOpen className="w-5 h-5 mr-2 text-amber-600" />
+            Your Current Reads
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-6 text-gray-500 text-sm">Loading your books...</div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center text-base">
+            <BookOpen className="w-5 h-5 mr-2 text-amber-600" />
+            Your Current Reads
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-6 text-gray-500 text-sm">Failed to load your books.</div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!books || books.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center text-base">
+            <BookOpen className="w-5 h-5 mr-2 text-amber-600" />
+            Your Current Reads
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-center space-y-4">
+          <p className="text-sm text-gray-600">Start reading a book to see it here.</p>
+          <Button asChild>
+            <Link to="/library">Start reading a book</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center text-base">
+          <BookOpen className="w-5 h-5 mr-2 text-amber-600" />
+          Your Current Reads
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {books.map((item) => (
+            <Card
+              key={item.id}
+              className="cursor-pointer overflow-hidden"
+              onClick={() => handleOpen(item)}
+            >
+              <CardContent className="p-4 flex gap-4">
+                {item.books_library?.cover_image_url ? (
+                  <img
+                    src={item.books_library.cover_image_url}
+                    alt={item.books_library.title}
+                    className="w-16 h-24 object-cover rounded"
+                  />
+                ) : (
+                  <div className="w-16 h-24 bg-amber-100 rounded flex items-center justify-center">
+                    <BookOpen className="w-8 h-8 text-amber-600" />
+                  </div>
+                )}
+                <div className="flex-1 min-w-0">
+                  <h4 className="font-semibold text-sm truncate">{item.books_library.title}</h4>
+                  {typeof item.progress === 'number' && (
+                    <div className="mt-2">
+                      <Progress value={item.progress} className="h-2" />
+                      <p className="text-xs text-gray-600 mt-1">{Math.round(item.progress)}%</p>
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CurrentReads;

--- a/src/lib/supabase/userBooks.ts
+++ b/src/lib/supabase/userBooks.ts
@@ -1,0 +1,37 @@
+import { supabase } from '@/integrations/supabase/client-universal';
+import type { Book } from '@/hooks/useLibraryBooks';
+
+export interface CurrentRead {
+  id: string;
+  book_id: string;
+  status: string;
+  progress?: number | null;
+  last_opened_at?: string | null;
+  books_library: Book;
+}
+
+export const fetchCurrentReads = async (): Promise<CurrentRead[]> => {
+  const { data, error } = await supabase
+    .from('user_books')
+    .select(
+      `id, book_id, status, progress, last_opened_at,
+       books_library:book_id (
+         id, title, author, genre, cover_image_url, description, publication_year,
+         language, pdf_url, created_at, price, rating, isbn, pages, author_bio
+       )`
+    )
+    .eq('status', 'reading')
+    .order('last_opened_at', { ascending: false })
+    .limit(6);
+
+  if (error) throw error;
+  return (data || []) as unknown as CurrentRead[];
+};
+
+export const updateLastOpenedAt = async (id: string) => {
+  const { error } = await supabase
+    .from('user_books')
+    .update({ last_opened_at: new Date().toISOString() })
+    .eq('id', id);
+  if (error) throw error;
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,7 +11,7 @@ import SEO from "@/components/SEO";
 import AnimatedHero from "@/components/AnimatedHero";
 import SahadhyayiCircuit from "@/components/SahadhyayiCircuit";
 import SahadhyayiCapabilities from "@/components/SahadhyayiCapabilities";
-import CurrentReads from "@/components/dashboard/CurrentReads";
+import CurrentReads from "@/components/library/CurrentReads";
 
 const Index = () => {
   const { user } = useAuth();
@@ -106,7 +106,7 @@ const Index = () => {
               </h2>
               <p className="text-gray-700 text-lg">Continue your reading journey</p>
             </div>
-            <CurrentReads userId={user.id} />
+            <CurrentReads />
             
             <div className="text-center mt-8">
               <Link to="/dashboard">

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { BookOpen, Download, Plus, Search, Grid, List, X, Calendar, FileText, Globe, User, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useAddLibraryBook } from '@/hooks/useLibrary';
 import { toast } from '@/hooks/use-toast';
+import CurrentReads from '@/components/library/CurrentReads';
 
 interface Book {
   id: string;
@@ -437,6 +438,10 @@ export default function Library() {
               <div className="text-sm text-muted-foreground">Downloads</div>
             </div>
           </div>
+        </div>
+
+        <div className="mb-8">
+          <CurrentReads />
         </div>
 
         {/* Search and Filters */}


### PR DESCRIPTION
## Summary
- fetch reading books from user_books with last opened ordering
- show current reads with progress and sign-in/empty states
- integrate widget on home and library pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4932f7ec8320a5813cde7d974c94