### PR TITLE
feat: log book events via edge function

### DIFF
--- a/src/components/books/BookCover.tsx
+++ b/src/components/books/BookCover.tsx
@@ -12,9 +12,10 @@ interface BookCoverProps {
   bookId: string;
   description?: string;
   pdfUrl?: string;
+  onDownload?: () => void;
 }
 
-const BookCover = ({ title, coverImageUrl, price, bookId, description, pdfUrl }: BookCoverProps) => {
+const BookCover = ({ title, coverImageUrl, price, bookId, description, pdfUrl, onDownload }: BookCoverProps) => {
   const handleDownloadPDF = () => {
     if (pdfUrl) {
       // Check if it's a direct PDF download or a preview link
@@ -31,6 +32,7 @@ const BookCover = ({ title, coverImageUrl, price, bookId, description, pdfUrl }:
         // Preview link (Google Books, etc.)
         window.open(pdfUrl, '_blank');
       }
+      onDownload?.();
     } else {
       alert('PDF not available for this book');
     }

--- a/src/lib/supabase/events.ts
+++ b/src/lib/supabase/events.ts
@@ -1,0 +1,13 @@
+import { supabase } from '@/integrations/supabase/client-universal';
+
+export const logBookEvent = async (
+  bookId: string,
+  eventType: 'view' | 'download'
+) => {
+  const { data, error } = await supabase.functions.invoke('log_book_event', {
+    body: { book_id: bookId, event_type: eventType },
+  });
+
+  if (error) throw error;
+  return data as { views: number; downloads: number };
+};

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, Calendar, BookOpen, Globe, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -19,12 +19,25 @@ import { useBookById } from '@/hooks/useBookById';
 import { useBookRatings, useRateBook } from '@/hooks/useBookRatings';
 import StarRating from '@/components/StarRating';
 import { generateBookSchema, generateBreadcrumbSchema } from '@/utils/schema';
+import { logBookEvent } from '@/lib/supabase/events';
 
 const BookDetails = () => {
   const { id } = useParams<{ id: string }>();
   const { data: book, isLoading, error } = useBookById(id);
   const { data: ratingData, isLoading: ratingLoading } = useBookRatings(id);
   const rateMutation = useRateBook(id);
+
+  useEffect(() => {
+    if (book?.id) {
+      logBookEvent(book.id, 'view').catch(() => {});
+    }
+  }, [book?.id]);
+
+  const handleDownloadEvent = () => {
+    if (book?.id) {
+      logBookEvent(book.id, 'download').catch(() => {});
+    }
+  };
 
   console.log('BookDetails - Route params:', { id });
   console.log('BookDetails - Book data:', book);
@@ -193,6 +206,7 @@ const BookDetails = () => {
                 price={book.price}
                 description={book.description}
                 pdfUrl={book.pdf_url}
+                onDownload={handleDownloadEvent}
               />
             </div>
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -83,3 +83,6 @@ verify_jwt = false
 
 [functions.recommendations]
 verify_jwt = false
+
+[functions.log_book_event]
+verify_jwt = true

--- a/supabase/functions/log_book_event/index.ts
+++ b/supabase/functions/log_book_event/index.ts
@@ -1,0 +1,84 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    global: { headers: { Authorization: req.headers.get('Authorization')! } }
+  });
+
+  try {
+    if (req.method !== 'POST') {
+      return new Response(
+        JSON.stringify({ error: 'Method not allowed' }),
+        { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { book_id, event_type } = await req.json();
+    if (!book_id || !event_type) {
+      return new Response(
+        JSON.stringify({ error: 'book_id and event_type required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { error: insertError } = await supabase
+      .from('book_events')
+      .insert({ book_id, event_type, user_id: user.id });
+    if (insertError) throw insertError;
+
+    const since = new Date();
+    since.setDate(since.getDate() - 14);
+
+    const { count: viewCount, error: viewError } = await supabase
+      .from('book_events')
+      .select('*', { count: 'exact', head: true })
+      .eq('book_id', book_id)
+      .eq('event_type', 'view')
+      .gte('created_at', since.toISOString());
+    if (viewError) throw viewError;
+
+    const { count: downloadCount, error: downloadError } = await supabase
+      .from('book_events')
+      .select('*', { count: 'exact', head: true })
+      .eq('book_id', book_id)
+      .eq('event_type', 'download')
+      .gte('created_at', since.toISOString());
+    if (downloadError) throw downloadError;
+
+    return new Response(
+      JSON.stringify({
+        views: viewCount || 0,
+        downloads: downloadCount || 0,
+      }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (err) {
+    console.error('Error logging book event:', err);
+    return new Response(
+      JSON.stringify({ error: 'Server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});
+


### PR DESCRIPTION
## Summary
- add `log_book_event` edge function to record views/downloads and return recent aggregates
- expose `logBookEvent` helper and track view/download actions in book details
- configure function in Supabase and pass download callback from `BookCover`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4c0e5f108320b358d26c97f2ccfc