### PR TITLE
feat: track book views and downloads

### DIFF
--- a/src/components/books/BookReader.tsx
+++ b/src/components/books/BookReader.tsx
@@ -40,9 +40,10 @@ interface BookReaderProps {
   bookTitle: string;
   pdfUrl?: string;
   epubUrl?: string;
+  onDownload?: () => void;
 }
 
-const BookReader = ({ bookId, bookTitle, pdfUrl, epubUrl }: BookReaderProps) => {
+const BookReader = ({ bookId, bookTitle, pdfUrl, epubUrl, onDownload }: BookReaderProps) => {
   const { user } = useAuth();
   const { toast } = useToast();
   const { addQuote } = useQuotes();
@@ -558,7 +559,10 @@ const BookReader = ({ bookId, bookTitle, pdfUrl, epubUrl }: BookReaderProps) => 
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => window.open(pdfUrl, '_blank')}
+                  onClick={() => {
+                    onDownload?.();
+                    window.open(pdfUrl, '_blank');
+                  }}
                   className="flex items-center gap-1"
                 >
                   <Download className="w-4 h-4" />

--- a/src/lib/supabase/events.ts
+++ b/src/lib/supabase/events.ts
@@ -1,0 +1,24 @@
+import { supabase } from '@/integrations/supabase/client-universal';
+
+export type BookEventType = 'view' | 'download';
+
+export interface BookEventCounts {
+  views: number;
+  downloads: number;
+}
+
+export const logBookEvent = async (
+  bookId: string,
+  eventType: BookEventType,
+): Promise<BookEventCounts | null> => {
+  const { data, error } = await supabase.functions.invoke('log_book_event', {
+    body: { book_id: bookId, event_type: eventType },
+  });
+
+  if (error) {
+    console.error('Error logging book event:', error);
+    return null;
+  }
+
+  return data as BookEventCounts;
+};

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, Calendar, BookOpen, Globe, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -19,6 +19,7 @@ import { useBookById } from '@/hooks/useBookById';
 import { useBookRatings, useRateBook } from '@/hooks/useBookRatings';
 import StarRating from '@/components/StarRating';
 import { generateBookSchema, generateBreadcrumbSchema } from '@/utils/schema';
+import { logBookEvent } from '@/lib/supabase/events';
 
 const BookDetails = () => {
   const { id } = useParams<{ id: string }>();
@@ -30,6 +31,12 @@ const BookDetails = () => {
   console.log('BookDetails - Book data:', book);
   console.log('BookDetails - Loading state:', isLoading);
   console.log('BookDetails - Error state:', error);
+
+  useEffect(() => {
+    if (book?.id) {
+      logBookEvent(book.id, 'view');
+    }
+  }, [book?.id]);
 
   if (isLoading) {
     return (
@@ -140,6 +147,12 @@ const BookDetails = () => {
 
   const handleAuthorClick = () => {
     console.log('Author clicked:', book.author);
+  };
+
+  const handleDownload = () => {
+    if (book?.id) {
+      logBookEvent(book.id, 'download');
+    }
   };
 
   return (
@@ -383,11 +396,12 @@ const BookDetails = () => {
               <TabsContent value="read" className="mt-0">
                 <Card className="bg-gradient-to-br from-orange-50 to-yellow-50 border-orange-200 shadow-lg">
                   <CardContent className="p-6">
-                    <BookReader 
+                    <BookReader
                       bookId={book.id}
                       bookTitle={book.title}
                       pdfUrl={book.pdf_url}
                       epubUrl={undefined}
+                      onDownload={handleDownload}
                     />
                   </CardContent>
                 </Card>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -83,3 +83,6 @@ verify_jwt = false
 
 [functions.recommendations]
 verify_jwt = false
+
+[functions.log_book_event]
+verify_jwt = true

--- a/supabase/functions/log_book_event/index.ts
+++ b/supabase/functions/log_book_event/index.ts
@@ -1,0 +1,80 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const { book_id, event_type } = await req.json();
+    if (!book_id || !event_type) {
+      return new Response(JSON.stringify({ error: 'Missing book_id or event_type' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      global: { headers: { Authorization: req.headers.get('Authorization')! } },
+    });
+
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { error: insertError } = await supabase
+      .from('book_events')
+      .insert({ book_id, event_type, user_id: user.id });
+    if (insertError) throw insertError;
+
+    const since = new Date();
+    since.setDate(since.getDate() - 14);
+    const sinceISO = since.toISOString();
+
+    const { count: viewsCount, error: viewsError } = await supabase
+      .from('book_events')
+      .select('*', { count: 'exact', head: true })
+      .eq('book_id', book_id)
+      .eq('event_type', 'view')
+      .gte('created_at', sinceISO);
+
+    const { count: downloadsCount, error: downloadsError } = await supabase
+      .from('book_events')
+      .select('*', { count: 'exact', head: true })
+      .eq('book_id', book_id)
+      .eq('event_type', 'download')
+      .gte('created_at', sinceISO);
+
+    if (viewsError) throw viewsError;
+    if (downloadsError) throw downloadsError;
+
+    return new Response(
+      JSON.stringify({ views: viewsCount || 0, downloads: downloadsCount || 0 }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add `log_book_event` edge function to record book view/download events and return 14-day aggregates
- expose `logBookEvent` helper for invoking the function
- track view and download events from `BookDetails` and `BookReader`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4c3118cc8320b1016e0352009732