### PR TITLE
feat: add error and loading states for library pages

### DIFF
--- a/apps/web-next/src/app/library/[id]/error.tsx
+++ b/apps/web-next/src/app/library/[id]/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface ErrorProps {
+  error: Error;
+}
+
+export default function Error({ error }: ErrorProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-4 text-center">
+      <h2 className="mb-2 text-lg font-semibold">Something went wrong</h2>
+      <p className="mb-4">We couldn't load this book. Please try again.</p>
+      <button
+        onClick={() => router.refresh()}
+        className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+

--- a/apps/web-next/src/app/library/[id]/loading.tsx
+++ b/apps/web-next/src/app/library/[id]/loading.tsx
@@ -1,0 +1,20 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4">
+      <div className="space-y-2 animate-pulse">
+        <div className="h-8 w-3/4 rounded bg-gray-200" />
+        <div className="h-4 w-1/2 rounded bg-gray-200" />
+      </div>
+      <div className="h-10 w-32 animate-pulse rounded bg-gray-200" />
+      <div className="space-y-2">
+        <div className="h-6 w-1/3 animate-pulse rounded bg-gray-200" />
+        <div className="space-y-1">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-4 w-3/4 animate-pulse rounded bg-gray-200" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web-next/src/app/library/error.tsx
+++ b/apps/web-next/src/app/library/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface ErrorProps {
+  error: Error;
+}
+
+export default function Error({ error }: ErrorProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-4 text-center">
+      <h2 className="mb-2 text-lg font-semibold">Something went wrong</h2>
+      <p className="mb-4">We couldn't load the library. Please try again.</p>
+      <button
+        onClick={() => router.refresh()}
+        className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+

--- a/apps/web-next/src/app/library/loading.tsx
+++ b/apps/web-next/src/app/library/loading.tsx
@@ -1,0 +1,17 @@
+export default function Loading() {
+  return (
+    <div className="space-y-6 p-4">
+      <div className="h-10 w-full max-w-md animate-pulse rounded bg-gray-200" />
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div key={i} className="space-y-2 animate-pulse">
+            <div className="aspect-[2/3] w-full rounded bg-gray-200" />
+            <div className="h-4 w-3/4 rounded bg-gray-200" />
+            <div className="h-3 w-1/2 rounded bg-gray-200" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add loading skeleton for library grid
- add friendly error UI with retry for library pages
- add loading skeleton and error UI for individual book pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4c6fb0508320843aae49a3f6cfaf