### PR TITLE
Add library merge audit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,14 @@ This project makes use of open-source packages, and we are committed to complyin
 ## External Integrations
 
 Sahadhyayi can connect to Goodreads so you can import your existing bookshelf and export your reading history back to Goodreads. See [docs/ExternalIntegrations.md](docs/ExternalIntegrations.md) for details.
+
+## Library Merge Audit
+
+Use `tools/library-merge-audit.sh` to catch merge issues in library code.
+
+```bash
+bash tools/library-merge-audit.sh
+```
+
+The script reports duplicate `Book`/`Author` type definitions, TODO/CONFLICT markers, and unresolved imports in `apps/web-next/src/lib/supabase/books.ts`.
+It exits with a non-zero status if any issues are found.

--- a/tools/library-merge-audit.sh
+++ b/tools/library-merge-audit.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+issues=0
+
+# 1. Check for duplicate type definitions of Book
+mapfile -t book_defs < <(rg -l "^type\s+Book" --glob "*.ts" || true)
+if [ "${#book_defs[@]}" -gt 1 ]; then
+  echo "Duplicate 'Book' type definitions found:" >&2
+  printf '%s\n' "${book_defs[@]}" >&2
+  issues=1
+fi
+
+# 2. Check for duplicate type definitions of Author
+mapfile -t author_defs < <(rg -l "^type\s+Author" --glob "*.ts" || true)
+if [ "${#author_defs[@]}" -gt 1 ]; then
+  echo "Duplicate 'Author' type definitions found:" >&2
+  printf '%s\n' "${author_defs[@]}" >&2
+  issues=1
+fi
+
+# 3. Search for TODO or conflict markers in library-related files
+mapfile -t todo_conflicts < <(rg -n "TODO|CONFLICT|<<<<<<<|>>>>>>>" apps/web-next/src/lib || true)
+if [ "${#todo_conflicts[@]}" -gt 0 ]; then
+  echo "TODO/CONFLICT markers detected in library files:" >&2
+  printf '%s\n' "${todo_conflicts[@]}" >&2
+  issues=1
+fi
+
+# 4. Verify imports for lib/supabase/books.ts via TypeScript
+if ! npx tsc --noEmit apps/web-next/src/lib/supabase/books.ts >/tmp/library_audit_tsc.log 2>&1; then
+  echo "TypeScript import resolution errors in lib/supabase/books.ts:" >&2
+  cat /tmp/library_audit_tsc.log >&2
+  issues=1
+fi
+rm -f /tmp/library_audit_tsc.log
+
+if [ "$issues" -ne 0 ]; then
+  echo "Library merge audit found issues." >&2
+  exit 1
+fi
+
+echo "Library merge audit passed."


### PR DESCRIPTION
## Summary
- add script to audit library code for duplicate Book/Author types, TODO/CONFLICT markers, and unresolved imports in `books.ts`
- document the audit script in the README

## Testing
- `npm run lint`
- `npm run build`
- `bash tools/library-merge-audit.sh` *(fails: Cannot find module '@/integrations/supabase/client' and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4cb30da88320a3f26833aed75477