### PR TITLE
Fix library to use books_library table

### DIFF
--- a/apps/web-next/src/app/library/[id]/page.tsx
+++ b/apps/web-next/src/app/library/[id]/page.tsx
@@ -14,7 +14,7 @@ export default async function BookPage(props: any) {
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
       <h1 className="text-3xl font-bold">{book.title}</h1>
-      <BookActions bookId={book.id} fileUrl={book.file_url} />
+      <BookActions bookId={book.id} fileUrl={book.pdf_url} />
     </div>
   );
 }

--- a/apps/web-next/src/components/library/BookCard.tsx
+++ b/apps/web-next/src/components/library/BookCard.tsx
@@ -9,7 +9,8 @@ interface Props {
 
 export default function BookCard({ book }: Props) {
   const router = useRouter();
-  const cover = book.cover_url ?? 'https://placehold.co/200x300?text=No+Cover';
+  const cover =
+    book.cover_image_url ?? 'https://placehold.co/200x300?text=No+Cover';
 
   return (
     <button
@@ -29,14 +30,11 @@ export default function BookCard({ book }: Props) {
         {book.title}
       </h3>
       <div className="mt-1 flex flex-wrap gap-1">
-        <span className="rounded bg-gray-200 px-1 text-[10px] font-medium">
-          {book.language}
-        </span>
-        {book.tags?.map((tag) => (
-          <span key={tag} className="rounded bg-gray-100 px-1 text-[10px]">
-            {tag}
+        {book.language && (
+          <span className="rounded bg-gray-200 px-1 text-[10px] font-medium">
+            {book.language}
           </span>
-        ))}
+        )}
       </div>
     </button>
   );

--- a/apps/web-next/src/components/library/CurrentReads.tsx
+++ b/apps/web-next/src/components/library/CurrentReads.tsx
@@ -60,7 +60,10 @@ export default function CurrentReads() {
         <Link key={item.book_id} href={`/library/${item.book.id}`} className="block text-sm">
           <div className="aspect-[2/3] w-full overflow-hidden rounded bg-gray-100">
             <img
-              src={item.book.cover_url ?? 'https://placehold.co/200x300?text=No+Cover'}
+              src={
+                item.book.cover_image_url ??
+                'https://placehold.co/200x300?text=No+Cover'
+              }
               alt={item.book.title}
               className="h-full w-full object-cover"
             />

--- a/apps/web-next/src/lib/supabase/userBooks.ts
+++ b/apps/web-next/src/lib/supabase/userBooks.ts
@@ -10,7 +10,7 @@ export interface CurrentRead extends UserBook {
 export async function getCurrentReads(userId: string): Promise<CurrentRead[]> {
   const { data, error } = await supabaseClient
     .from('user_books' as any)
-    .select('book_id, status, progress, last_opened_at, books:book_id (*)')
+    .select('book_id, status, progress, last_opened_at, books_library:book_id (*)')
     .eq('user_id', userId)
     .eq('status', 'reading')
     .order('last_opened_at', { ascending: false })
@@ -29,7 +29,7 @@ export async function getCurrentReads(userId: string): Promise<CurrentRead[]> {
     status: item.status as ReadingStatus,
     progress: item.progress,
     last_opened_at: item.last_opened_at,
-    book: item.books as Book,
+    book: item.books_library as Book,
   }));
 }
 

--- a/apps/web-next/src/lib/types.ts
+++ b/apps/web-next/src/lib/types.ts
@@ -4,19 +4,18 @@ export type ReadingStatus = 'to_read' | 'reading' | 'completed';
 export interface Book {
   id: string;
   title: string;
-  title_hi?: string | null;
+  author?: string | null;
+  author_bio?: string | null;
   author_id?: string | null;
-  author_ids?: string[] | null;
-  genres?: string[] | null;
-  tags?: string[] | null;
-  language: Language;
-  year?: number | null;
-  cost?: number | null;
-  cover_url?: string | null;
-  file_url?: string | null;
-  popularity?: number | null;
-  created_at?: string;
-  updated_at?: string;
+  genre?: string | null;
+  language?: Language | null;
+  publication_year?: number | null;
+  pages?: number | null;
+  isbn?: string | null;
+  cover_image_url?: string | null;
+  pdf_url?: string | null;
+  created_at?: string | null;
+  description?: string | null;
 }
 
 export interface Author {


### PR DESCRIPTION
## Summary
- Fetch books from `books_library` instead of deprecated `books` table
- Align book type and Supabase helpers with new schema
- Update library UI to match new fields

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad5ba3c9208320bc40e66e6c20f23c