### PR TITLE
fix: improve digital library error handling

### DIFF
--- a/apps/web-next/src/app/library/page.tsx
+++ b/apps/web-next/src/app/library/page.tsx
@@ -55,7 +55,8 @@ export default function LibraryPage() {
       })
       .catch((err) => {
         if (err.name !== 'AbortError') {
-          setError('Something went wrong while loading books.');
+          console.error('Failed to load books', err);
+          setError('Failed to load books. Please try again later.');
         }
       })
       .finally(() => setLoading(false));

--- a/apps/web-next/src/lib/supabase/books.ts
+++ b/apps/web-next/src/lib/supabase/books.ts
@@ -11,7 +11,6 @@ export async function getBooks(
   let query = supabaseClient
     .from('books_library')
     .select('*')
-    .order('created_at', { ascending: false })
     .limit(limit + 1);
 
   if (signal) {
@@ -55,7 +54,10 @@ export async function getBooks(
   }
 
   const { data, error } = await query;
-  if (error) throw error;
+  if (error) {
+    console.error('getBooks error', error);
+    throw error;
+  }
 
   const items = (data as Book[]).slice(0, limit);
   const nextCursor = data && data.length > limit ? (data as Book[])[limit - 1].id : undefined;


### PR DESCRIPTION
## Summary
- avoid redundant default ordering in library book query
- log Supabase failures and show clearer message when books fail to load

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad8d58a1f48320a1efa192242bfa15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Book sorting now consistently reflects the selected sort option without unintended overrides.
  - Improved user-facing error message when loading books fails, providing clearer guidance to retry later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->