### PR TITLE
Improve library search robustness

### DIFF
--- a/src/__tests__/librarySearch.test.tsx
+++ b/src/__tests__/librarySearch.test.tsx
@@ -1,3 +1,5 @@
+/** @vitest-environment jsdom */
+
 import { describe, vi, it, expect, beforeEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render, screen, act } from '@testing-library/react'

--- a/src/lib/searchLibrary.ts
+++ b/src/lib/searchLibrary.ts
@@ -33,6 +33,7 @@ export async function searchLibrary(
     .select('id, title, author, genre, language, cover_image_url, description')
     .ilike('title', `%${query.trim()}%`)
     .limit(limit)
+    .abortSignal(options.signal)
     
   if (error) throw error
   
@@ -45,7 +46,9 @@ export async function searchLibrary(
     language: book.language || '',
     cover_url: book.cover_image_url || '',
     popularity: 0,
-    snippet: book.description?.substring(0, 100) + '...' || '',
+    snippet: book.description
+      ? `${book.description.substring(0, 100)}...`
+      : '',
     rank: 1
   }))
 }


### PR DESCRIPTION
## Summary
- allow library search requests to be aborted and avoid spurious snippet text
- run library search tests in a jsdom environment

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run src/__tests__/librarySearch.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ad949b48a88320b75ba6d7bd8ef72f