### PR TITLE
fix: use new book media fields

### DIFF
--- a/apps/web-next/src/app/library/[id]/page.tsx
+++ b/apps/web-next/src/app/library/[id]/page.tsx
@@ -14,7 +14,7 @@ export default async function BookPage(props: any) {
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
       <h1 className="text-3xl font-bold">{book.title}</h1>
-      <BookActions bookId={book.id} fileUrl={book.pdf_url} />
+      <BookActions bookId={book.id} fileUrl={book.file_url} />
     </div>
   );
 }

--- a/apps/web-next/src/components/library/BookCard.tsx
+++ b/apps/web-next/src/components/library/BookCard.tsx
@@ -9,8 +9,7 @@ interface Props {
 
 export default function BookCard({ book }: Props) {
   const router = useRouter();
-  const cover =
-    book.cover_image_url ?? 'https://placehold.co/200x300?text=No+Cover';
+  const cover = book.cover_url ?? 'https://placehold.co/200x300?text=No+Cover';
 
   return (
     <button

--- a/apps/web-next/src/components/library/CurrentReads.tsx
+++ b/apps/web-next/src/components/library/CurrentReads.tsx
@@ -61,7 +61,7 @@ export default function CurrentReads() {
           <div className="aspect-[2/3] w-full overflow-hidden rounded bg-gray-100">
             <img
               src={
-                item.book.cover_image_url ??
+                item.book.cover_url ??
                 'https://placehold.co/200x300?text=No+Cover'
               }
               alt={item.book.title}

--- a/apps/web-next/src/integrations/supabase/types.ts
+++ b/apps/web-next/src/integrations/supabase/types.ts
@@ -527,7 +527,7 @@ export type Database = {
           author: string | null
           author_bio: string | null
           author_id: string | null
-          cover_image_url: string | null
+          cover_url: string | null
           created_at: string | null
           description: string | null
           genre: string | null
@@ -535,7 +535,7 @@ export type Database = {
           isbn: string | null
           language: string | null
           pages: number | null
-          pdf_url: string | null
+          file_url: string | null
           publication_year: number | null
           title: string
         }
@@ -543,7 +543,7 @@ export type Database = {
           author?: string | null
           author_bio?: string | null
           author_id?: string | null
-          cover_image_url?: string | null
+          cover_url?: string | null
           created_at?: string | null
           description?: string | null
           genre?: string | null
@@ -551,7 +551,7 @@ export type Database = {
           isbn?: string | null
           language?: string | null
           pages?: number | null
-          pdf_url?: string | null
+          file_url?: string | null
           publication_year?: number | null
           title: string
         }
@@ -559,7 +559,7 @@ export type Database = {
           author?: string | null
           author_bio?: string | null
           author_id?: string | null
-          cover_image_url?: string | null
+          cover_url?: string | null
           created_at?: string | null
           description?: string | null
           genre?: string | null
@@ -567,7 +567,7 @@ export type Database = {
           isbn?: string | null
           language?: string | null
           pages?: number | null
-          pdf_url?: string | null
+          file_url?: string | null
           publication_year?: number | null
           title?: string
         }
@@ -585,7 +585,7 @@ export type Database = {
         Row: {
           author: string | null
           author_bio: string | null
-          cover_image_url: string | null
+          cover_url: string | null
           created_at: string | null
           description: string | null
           genre: string | null
@@ -593,7 +593,7 @@ export type Database = {
           isbn: string | null
           language: string | null
           pages: number | null
-          pdf_url: string | null
+          file_url: string | null
           publication_year: number | null
           title: string
           updated_at: string | null
@@ -601,7 +601,7 @@ export type Database = {
         Insert: {
           author?: string | null
           author_bio?: string | null
-          cover_image_url?: string | null
+          cover_url?: string | null
           created_at?: string | null
           description?: string | null
           genre?: string | null
@@ -609,7 +609,7 @@ export type Database = {
           isbn?: string | null
           language?: string | null
           pages?: number | null
-          pdf_url?: string | null
+          file_url?: string | null
           publication_year?: number | null
           title: string
           updated_at?: string | null
@@ -617,7 +617,7 @@ export type Database = {
         Update: {
           author?: string | null
           author_bio?: string | null
-          cover_image_url?: string | null
+          cover_url?: string | null
           created_at?: string | null
           description?: string | null
           genre?: string | null
@@ -625,7 +625,7 @@ export type Database = {
           isbn?: string | null
           language?: string | null
           pages?: number | null
-          pdf_url?: string | null
+          file_url?: string | null
           publication_year?: number | null
           title?: string
           updated_at?: string | null
@@ -1610,7 +1610,7 @@ export type Database = {
       reading_progress: {
         Row: {
           book_title: string
-          cover_image_url: string | null
+          cover_url: string | null
           current_page: number
           id: number
           total_pages: number
@@ -1618,7 +1618,7 @@ export type Database = {
         }
         Insert: {
           book_title: string
-          cover_image_url?: string | null
+          cover_url?: string | null
           current_page?: number
           id?: number
           total_pages: number
@@ -1626,7 +1626,7 @@ export type Database = {
         }
         Update: {
           book_title?: string
-          cover_image_url?: string | null
+          cover_url?: string | null
           current_page?: number
           id?: number
           total_pages?: number

--- a/apps/web-next/src/lib/types.ts
+++ b/apps/web-next/src/lib/types.ts
@@ -12,8 +12,8 @@ export interface Book {
   publication_year?: number | null;
   pages?: number | null;
   isbn?: string | null;
-  cover_image_url?: string | null;
-  pdf_url?: string | null;
+  cover_url?: string | null;
+  file_url?: string | null;
   created_at?: string | null;
   description?: string | null;
 }


### PR DESCRIPTION
## Summary
- align Book types with new `cover_url` and `file_url` fields
- display covers and file links using updated fields in library pages
- update generated Supabase types for renamed media columns

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad9bf25b0c8320ad9107306e0680f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Book covers now display consistently across Library and Current Reads.
  * File links for books (download/open) use the correct source, improving reliability.

* **Refactor**
  * Standardized cover and file URL fields across the app and data layer to reduce inconsistencies and prevent broken images/links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->