### PR TITLE
fix: avoid 403 errors on external book covers

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     <meta http-equiv="content-language" content="en-IN" />
     
     <!-- Referrer policy for security -->
-    <meta name="referrer" content="strict-origin-when-cross-origin" />
+    <meta name="referrer" content="no-referrer" />
 
     <!-- CSP is normally set via HTTP headers in server.js. Meta is a fallback for static preview only. -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'" />

--- a/src/components/ui/LazyImage.tsx
+++ b/src/components/ui/LazyImage.tsx
@@ -24,6 +24,7 @@ export function LazyImage({
         decoding="async"
         alt={alt}
         src={src}
+        referrerPolicy="no-referrer"
         className={className}
         width={width}
         height={height}


### PR DESCRIPTION
## Summary
- ensure page sends no referrer to external book-cover hosts
- load cover images without referrer headers in `LazyImage`

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adabd7ed2c8320a4f91d5332d0dd36