### PR TITLE
fix: remove unsupported dynamic flag from library page

### DIFF
--- a/apps/web-next/src/app/library/page.tsx
+++ b/apps/web-next/src/app/library/page.tsx
@@ -9,8 +9,6 @@ import { getBooks } from '@/lib/supabase/books';
 import type { Book } from '@/lib/types';
 import { makeAbortable } from '@/lib/fetchAbort';
 
-export const dynamic = 'force-dynamic';
-
 const defaultFilters: FilterState = {
   genres: [],
   language: undefined,


### PR DESCRIPTION
## Summary
- avoid forcing dynamic rendering on the library page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae22f9ad308320b9bb48f3cddfca81