### PR TITLE
feat(chatbot): fallback to contextual response

### DIFF
--- a/src/components/chatbot/ChatbotContainer.tsx
+++ b/src/components/chatbot/ChatbotContainer.tsx
@@ -10,6 +10,7 @@ import { useColorCycle } from '@/hooks/chatbot/useColorCycle';
 import { useChatHistory } from '@/hooks/chatbot/useChatHistory';
 import { useChatbotAI } from '@/hooks/chatbot/useChatbotAI';
 import { useSpeechToText } from '@/hooks/useSpeechToText';
+import { generateContextualResponse } from '@/utils/chatbotKnowledge';
 
 const GRADIENTS = [
   'bg-gradient-to-r from-emerald-500 to-blue-500',
@@ -33,8 +34,9 @@ export default function ChatbotContainer() {
       const reply = await ask(text);
       append('assistant', reply);
     } catch (e: any) {
-      append('assistant', 'Sorry—something went wrong. Please try again.');
       console.error(e);
+      const fallback = generateContextualResponse(text);
+      append('assistant', fallback);
     } finally {
       setLoading(false);
     }

--- a/src/components/chatbot/UnifiedChat.tsx
+++ b/src/components/chatbot/UnifiedChat.tsx
@@ -4,6 +4,7 @@ import { ask as askGeneral } from '@/ai/service';
 import { useSpeechToText } from '@/hooks/useSpeechToText';
 import { useColorCycle } from '@/hooks/chatbot/useColorCycle';
 import { VoiceButton } from './presentational/VoiceButton';
+import { generateContextualResponse } from '@/utils/chatbotKnowledge';
 
 const BOOK_GRADIENTS = [
   'bg-gradient-to-r from-violet-500 to-purple-600',
@@ -59,7 +60,8 @@ export default function UnifiedChat() {
       addMessage({ sender: 'ai', text: reply, mode });
     } catch (err) {
       console.error(err);
-      addMessage({ sender: 'ai', text: 'Sorry—something went wrong. Please try again.', mode });
+      const fallback = generateContextualResponse(text);
+      addMessage({ sender: 'ai', text: fallback, mode });
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- provide contextual fallback responses when AI calls fail
- ensure both chatbot containers use offline knowledge instead of generic error

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae2cc8d0f48320b945e26717882951