### PR TITLE
fix: guard search filter against missing author

### DIFF
--- a/src/components/library/BooksCollection.tsx
+++ b/src/components/library/BooksCollection.tsx
@@ -182,9 +182,9 @@ const BooksCollection = ({
       // Search filter
       if (searchQuery) {
         const query = searchQuery.toLowerCase();
-        const matchesSearch = 
+        const matchesSearch =
           book.title.toLowerCase().includes(query) ||
-          book.author.toLowerCase().includes(query) ||
+          (book.author && book.author.toLowerCase().includes(query)) ||
           (book.genre && book.genre.toLowerCase().includes(query));
         if (!matchesSearch) {
           return false;


### PR DESCRIPTION
## Summary
- prevent runtime crash when filtering books without author metadata

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae2e3ec30c832089f32943ffa2963a