### PR TITLE
Revamp homepage with streamlined hero and navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import SignInLink from '@/components/SignInLink';
 import { Menu, X, ChevronDown, User, LogOut, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -21,9 +21,11 @@ const Navigation = () => {
   const [scrolled, setScrolled] = React.useState(false);
   const { user, signOut } = useAuth();
   const location = useLocation();
+  const navigate = useNavigate();
   const isMobile = useIsMobile();
   const menuRef = React.useRef<HTMLDivElement>(null);
   const menuButtonRef = React.useRef<HTMLButtonElement>(null);
+  const [search, setSearch] = React.useState("");
 
   React.useEffect(() => {
     const handleScroll = () => {
@@ -54,14 +56,22 @@ const Navigation = () => {
     { name: "Home", href: "/dashboard" },
     { name: "Library", href: "/library" },
     { name: "Authors", href: "/authors" },
-    { name: "Social Media", href: "/social" },
+    { name: "Community", href: "/social" },
     { name: "My Books", href: "/bookshelf" },
   ] : [
     { name: "Home", href: "/" },
     { name: "Library", href: "/library" },
     { name: "Authors", href: "/authors" },
-    { name: "Social Media", href: "/social" },
+    { name: "Community", href: "/social" },
   ];
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (search.trim()) {
+      navigate(`/library?search=${encodeURIComponent(search.trim())}`);
+      setSearch("");
+    }
+  };
 
   const handleSignOut = async () => {
     await signOut();
@@ -111,9 +121,9 @@ const Navigation = () => {
                     key={item.name}
                     to={item.href}
                     className={`text-sm font-medium transition-colors duration-200 hover:text-amber-600 ${
-                      (location.pathname === item.href || 
-                       (item.href === "/" && location.pathname === "/dashboard" && user)) 
-                        ? 'text-amber-600 border-b-2 border-amber-600 pb-1' 
+                      (location.pathname === item.href ||
+                       (item.href === "/" && location.pathname === "/dashboard" && user))
+                        ? 'text-amber-600 border-b-2 border-amber-600 pb-1'
                         : 'text-gray-700'
                     }`}
                   >
@@ -121,6 +131,21 @@ const Navigation = () => {
                   </Link>
                 ))}
               </div>
+
+              {/* Search Bar */}
+              <form onSubmit={handleSearchSubmit} className="relative">
+                <label htmlFor="nav-search" className="sr-only">
+                  Search books
+                </label>
+                <input
+                  id="nav-search"
+                  type="search"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search books"
+                  className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-amber-600"
+                />
+              </form>
 
               {/* User Actions */}
               <div className="flex items-center space-x-4">

--- a/src/components/home/PopularBooks.tsx
+++ b/src/components/home/PopularBooks.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+
+const books = [
+  { title: 'The Great Gatsby', cover: 'https://placehold.co/200x300?text=Gatsby' },
+  { title: 'Pride and Prejudice', cover: 'https://placehold.co/200x300?text=Pride' },
+  { title: '1984', cover: 'https://placehold.co/200x300?text=1984' },
+  { title: 'To Kill a Mockingbird', cover: 'https://placehold.co/200x300?text=Mockingbird' }
+];
+
+const PopularBooks: React.FC = () => (
+  <section className="py-16 px-4 bg-neutral">
+    <div className="max-w-6xl mx-auto">
+      <h2 className="text-2xl sm:text-3xl font-bold text-brand mb-8 text-center">Popular Books</h2>
+      <Carousel className="w-full" opts={{ align: 'start' }}>
+        <CarouselContent>
+          {books.map((book, idx) => (
+            <CarouselItem key={idx} className="basis-2/3 sm:basis-1/3 lg:basis-1/4">
+              <div className="p-4 text-center">
+                <img src={book.cover} alt={book.title} className="mx-auto h-48 object-cover rounded shadow mb-4" />
+                <p className="text-sm font-medium text-gray-800">{book.title}</p>
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    </div>
+  </section>
+);
+
+export default PopularBooks;
+

--- a/src/components/home/SimpleHero.tsx
+++ b/src/components/home/SimpleHero.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+
+const SimpleHero: React.FC = () => {
+  return (
+    <section className="bg-white text-gray-900 pt-32 pb-16 px-4 text-center">
+      <h1 className="text-4xl sm:text-5xl font-bold text-brand mb-6">
+        Rediscover the joy of deep reading
+      </h1>
+      <p className="max-w-2xl mx-auto mb-8 text-lg text-gray-700">
+        Connect with fellow readers, explore curated collections, and track your progress.
+      </p>
+      <div className="flex flex-col sm:flex-row gap-4 justify-center">
+        <Link to="/signup">
+          <Button className="btn-primary px-8 py-4">
+            Join Sahadhyayi
+          </Button>
+        </Link>
+        <Link to="/about">
+          <Button variant="outline" className="btn-secondary px-8 py-4">
+            Learn More
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default SimpleHero;
+

--- a/src/components/home/Testimonials.tsx
+++ b/src/components/home/Testimonials.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const testimonials = [
+  { quote: 'Sahadhyayi reignited my love for books.', author: 'Anita P.' },
+  { quote: 'A welcoming community for serious readers.', author: 'Ravi S.' },
+  { quote: 'The curated lists help me find my next favorite read.', author: 'Mina K.' }
+];
+
+const Testimonials: React.FC = () => (
+  <section className="py-16 px-4 bg-neutral">
+    <div className="max-w-4xl mx-auto text-center">
+      <h2 className="text-2xl sm:text-3xl font-bold text-brand mb-8">What readers are saying</h2>
+      <ul className="space-y-6">
+        {testimonials.map((t, idx) => (
+          <li key={idx} className="text-gray-800">
+            <p className="text-lg italic mb-2">“{t.quote}”</p>
+            <p className="text-sm text-gray-600">— {t.author}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+);
+
+export default Testimonials;
+

--- a/src/components/home/UpcomingEvents.tsx
+++ b/src/components/home/UpcomingEvents.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+
+const events = [
+  { title: 'September Reading Challenge', date: 'Sep 15', image: 'https://placehold.co/300x150?text=Challenge' },
+  { title: 'Author Q&A: Jane Doe', date: 'Sep 22', image: 'https://placehold.co/300x150?text=Q+A' },
+  { title: 'Community Meetup', date: 'Oct 5', image: 'https://placehold.co/300x150?text=Meetup' }
+];
+
+const UpcomingEvents: React.FC = () => (
+  <section className="py-16 px-4 bg-white">
+    <div className="max-w-6xl mx-auto">
+      <h2 className="text-2xl sm:text-3xl font-bold text-brand mb-8 text-center">Upcoming Events</h2>
+      <Carousel className="w-full" opts={{ align: 'start' }}>
+        <CarouselContent>
+          {events.map((event, idx) => (
+            <CarouselItem key={idx} className="basis-3/4 sm:basis-1/2 lg:basis-1/3">
+              <div className="p-4 bg-neutral rounded shadow text-center h-full flex flex-col justify-between">
+                <img src={event.image} alt="" className="mb-4 h-32 w-full object-cover rounded" />
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-800 mb-2">{event.title}</h3>
+                  <p className="text-sm text-gray-600">{event.date}</p>
+                </div>
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    </div>
+  </section>
+);
+
+export default UpcomingEvents;
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,15 +2,16 @@
 import React from 'react';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BookOpen, Users, Map, Calendar, Star, Headphones, LogIn, UserPlus, User } from "lucide-react";
+import { BookOpen, Users, Map, Calendar, Star, Headphones, UserPlus } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import SignInLink from '@/components/SignInLink';
 import { useAuth } from "@/contexts/authHelpers";
 import { useProfile } from "@/hooks/useProfile";
 import SEO from "@/components/SEO";
-import AnimatedHero from "@/components/AnimatedHero";
-import SahadhyayiCircuit from "@/components/SahadhyayiCircuit";
-import SahadhyayiCapabilities from "@/components/SahadhyayiCapabilities";
+import SimpleHero from "@/components/home/SimpleHero";
+import PopularBooks from "@/components/home/PopularBooks";
+import UpcomingEvents from "@/components/home/UpcomingEvents";
+import Testimonials from "@/components/home/Testimonials";
 import CurrentReads from "@/components/library/CurrentReads";
 
 const Index = () => {
@@ -89,16 +90,12 @@ const Index = () => {
       <script type="application/ld+json">
         {JSON.stringify(structuredData)}
       </script>
-      {/* Animated Hero Section */}
-      <AnimatedHero />
+      {/* Hero Section */}
+      <SimpleHero />
       <div className="page-container">
-        <SahadhyayiCircuit />
-
-        <SahadhyayiCapabilities />
-
         {/* Current Reads Section for Signed-in Users */}
         {user && (
-          <section className="py-8 sm:py-12 lg:py-16 bg-neutral">
+          <section className="py-16 bg-neutral">
             <div className="max-w-6xl mx-auto">
               <div className="text-center mb-8">
                 <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-brand mb-4">
@@ -118,127 +115,24 @@ const Index = () => {
             </div>
           </section>
         )}
-      </div>
-
-      <div className="bg-brand text-white">
-        <div className="page-container">
-
-        {/* What Sahadhyayi Means Section */}
-        <section className="py-8 sm:py-12 lg:py-16">
-          <div className="text-center">
-            <h2 className="text-xl sm:text-2xl lg:text-3xl xl:text-4xl font-bold text-gray-100 mb-4 sm:mb-6 lg:mb-8">What is Sahadhyayi? Understanding Our Name</h2>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8 items-center">
-              <div className="text-left order-2 lg:order-1">
-                <h3 className="text-lg sm:text-xl lg:text-2xl font-semibold text-gray-100 mb-2 sm:mb-3 lg:mb-4">The Sanskrit Meaning of Sahadhyayi</h3>
-                <p className="text-sm sm:text-base lg:text-lg text-gray-300 leading-relaxed mb-3 sm:mb-4 lg:mb-6">
-                  <strong>Sahadhyayi</strong> (सहाध्यायी) is a beautiful Sanskrit word meaning "fellow reader" or "study companion."
-                  It comes from "saha" (together) and "adhyayi" (one who reads or studies). In ancient tradition,
-                  a Sahadhyayi was someone who studied alongside you, shared knowledge, and deepened understanding together.
-                </p>
-                <h3 className="text-lg sm:text-xl lg:text-2xl font-semibold text-gray-100 mb-2 sm:mb-3 lg:mb-4">Why We Chose the Name Sahadhyayi</h3>
-                <p className="text-sm sm:text-base lg:text-lg text-gray-300 leading-relaxed">
-                  Sahadhyayi creates a digital home for readers to connect, share insights, and support each other's reading journey.
-                  <Link to="/about" className="text-orange-400 hover:text-orange-500 font-medium ml-1">Learn more about our mission</Link>.
-                </p>
-              </div>
-              <div className="bg-black p-4 sm:p-6 lg:p-8 rounded-2xl backdrop-blur-sm border border-orange-700 shadow-lg order-1 lg:order-2">
-                <h3 className="text-lg sm:text-xl lg:text-2xl font-semibold text-gray-100 mb-3 sm:mb-4">Why Choose Sahadhyayi for Reading</h3>
-                <div className="space-y-2 sm:space-y-3 text-gray-300 text-xs sm:text-sm lg:text-base">
-                  <div className="flex items-start gap-2 sm:gap-3">
-                    <span className="text-base sm:text-lg lg:text-xl flex-shrink-0">🌎</span>
-                    <div>
-                      <strong>Global Community:</strong> Meet readers who share your passion.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2 sm:gap-3">
-                    <span className="text-base sm:text-lg lg:text-xl flex-shrink-0">📚</span>
-                    <div>
-                      <strong>Deep Reading:</strong> Rediscover focused, meaningful reading.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2 sm:gap-3">
-                    <span className="text-base sm:text-lg lg:text-xl flex-shrink-0">🤝</span>
-                    <div>
-                      <strong>Collaborative Learning:</strong> Grow through shared insights.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2 sm:gap-3">
-                    <span className="text-base sm:text-lg lg:text-xl flex-shrink-0">🕯️</span>
-                    <div>
-                      <strong>Ancient Wisdom, Modern Tech:</strong> Blending tradition with innovation.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2 sm:gap-3">
-                    <span className="text-base sm:text-lg lg:text-xl flex-shrink-0">🗣️</span>
-                    <div>
-                      <strong>Shared Perspectives:</strong> Gain diverse insights from readers worldwide.
-                    </div>
-                  </div>
-                  <div className="flex items-start gap-2 sm:gap-3">
-                    <span className="text-base sm:text-lg lg:text-xl flex-shrink-0">💬</span>
-                    <div>
-                      <strong>Lasting Connections:</strong> Build friendships through shared reading.
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Mission Section */}
-        <section className="py-8 sm:py-12 lg:py-16">
-          <div className="text-center">
-            <h2 className="text-xl sm:text-2xl lg:text-3xl xl:text-4xl font-bold text-gray-100 mb-4 sm:mb-6 lg:mb-8">How Sahadhyayi Revives Reading Culture</h2>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8 items-center">
-              <div className="text-left order-2 lg:order-1">
-                <h3 className="text-lg sm:text-xl lg:text-2xl font-semibold text-gray-100 mb-2 sm:mb-3 lg:mb-4">The Digital Reading Challenge</h3>
-                <p className="text-sm sm:text-base lg:text-lg text-gray-300 leading-relaxed mb-3 sm:mb-4 lg:mb-6">
-                  Modern digital consumption habits are shifting away from deep reading toward passive content like videos and podcasts.
-                  This change impacts our ability to focus deeply, comprehend complex ideas, and engage in meaningful reflection.
-                </p>
-                <h3 className="text-lg sm:text-xl lg:text-2xl font-semibold text-gray-100 mb-2 sm:mb-3 lg:mb-4">Sahadhyayi's Revolutionary Solution</h3>
-                <p className="text-sm sm:text-base lg:text-lg text-gray-300 leading-relaxed">
-                  Sahadhyayi creates a social reading platform that makes books more accessible, interactive, and community-driven.
-                  We combine traditional reading with modern technology to build healthier intellectual habits among fellow readers.
-                  <Link to="/blog" className="text-orange-400 hover:text-orange-500 font-medium ml-1">Read our blog posts</Link> about reading culture.
-                </p>
-              </div>
-              <div className="bg-black p-4 sm:p-6 lg:p-8 rounded-2xl backdrop-blur-sm border border-orange-700 shadow-lg order-1 lg:order-2">
-                <h3 className="text-lg sm:text-xl lg:text-2xl font-semibold text-gray-100 mb-3 sm:mb-4">Benefits of the Sahadhyayi Approach</h3>
-                <ul className="space-y-2 sm:space-y-3 text-gray-300 text-xs sm:text-sm lg:text-base">
-                  <li>• <strong>Improved Focus:</strong> Deep reading enhances attention span significantly</li>
-                  <li>• <strong>Better Comprehension:</strong> Fellow readers help deepen understanding</li>
-                  <li>• <strong>Community Support:</strong> Study companions motivate consistent reading</li>
-                  <li>• <strong>Knowledge Retention:</strong> Collaborative learning builds lasting memories</li>
-                  <li>• <strong>Critical Thinking:</strong> Discussions with fellow readers enhance analysis</li>
-                  <li>• <strong>Intellectual Growth:</strong> Sahadhyayi connections foster lifelong learning</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </section>
 
         {/* Features Section */}
-        <section className="py-8 sm:py-12 lg:py-16 px-4 bg-black">
+        <section className="py-16 px-4 bg-black">
           <div className="max-w-6xl mx-auto">
-            <h2 className="text-xl sm:text-2xl lg:text-3xl xl:text-4xl font-bold text-center text-gray-100 mb-2 sm:mb-3 lg:mb-4">Explore Sahadhyayi's Powerful Tools</h2>
-            <p className="text-sm sm:text-base lg:text-lg xl:text-xl text-gray-300 text-center mb-6 sm:mb-8 lg:mb-12 max-w-3xl mx-auto px-4">
-              Our features are designed to help you read better, understand deeper, and connect meaningfully.
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 lg:gap-8">
+            <h2 className="text-2xl sm:text-3xl font-bold text-center text-gray-100 mb-6">Explore Sahadhyayi's Features</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
               {features.map((feature, index) => {
                 const Icon = feature.icon;
                 return (
                   <Card key={index} className="bg-black/80 backdrop-blur-sm border-orange-700 hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
-                    <CardHeader className="pb-3 sm:pb-4">
-                      <div className="w-8 h-8 sm:w-10 sm:h-10 lg:w-12 lg:h-12 bg-orange-900 rounded-lg flex items-center justify-center mb-2 sm:mb-3 lg:mb-4">
-                        <Icon className="w-4 h-4 sm:w-5 sm:h-5 lg:w-6 lg:h-6 text-orange-400" />
+                    <CardHeader className="pb-4">
+                      <div className="w-12 h-12 bg-orange-900 rounded-lg flex items-center justify-center mb-4 mx-auto">
+                        <Icon className="w-6 h-6 text-orange-400" />
                       </div>
-                      <CardTitle className="text-base sm:text-lg lg:text-xl text-gray-100">{feature.title}</CardTitle>
+                      <CardTitle className="text-lg text-gray-100 text-center">{feature.title}</CardTitle>
                     </CardHeader>
                     <CardContent className="pt-0">
-                      <p className="text-xs sm:text-sm lg:text-base text-gray-300">{feature.description}</p>
+                      <p className="text-sm text-gray-300 text-center">{feature.description}</p>
                     </CardContent>
                   </Card>
                 );
@@ -247,58 +141,9 @@ const Index = () => {
           </div>
         </section>
 
-        {/* Updated Internal Links Section with Equal Sized Cards */}
-        <section className="py-8 sm:py-12 lg:py-16 px-4 bg-black">
-          <div className="max-w-6xl mx-auto text-center">
-            <h2 className="text-xl sm:text-2xl lg:text-3xl xl:text-4xl font-bold text-gray-100 mb-4 sm:mb-6 lg:mb-8">Explore the Sahadhyayi Platform</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 sm:gap-6">
-              <Link to="/library" className="block">
-                <Card className="bg-black border-gray-700 hover:shadow-xl transition-all duration-300 hover:-translate-y-2 h-full">
-                  <CardContent className="p-4 sm:p-6 lg:p-8 text-center flex flex-col justify-between h-full">
-                    <div>
-                      <BookOpen className="w-10 h-10 sm:w-12 sm:h-12 lg:w-16 lg:h-16 text-orange-600 mx-auto mb-3 sm:mb-4 lg:mb-6" />
-                      <h3 className="text-base sm:text-lg lg:text-xl font-bold text-gray-100 mb-2 sm:mb-3 lg:mb-4">Digital Library</h3>
-                      <p className="text-xs sm:text-sm lg:text-base text-gray-300 leading-relaxed">Browse thousands of books with fellow readers in our comprehensive digital collection</p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-              <Link to="/groups" className="block">
-                <Card className="bg-black border-gray-700 hover:shadow-xl transition-all duration-300 hover:-translate-y-2 h-full">
-                  <CardContent className="p-4 sm:p-6 lg:p-8 text-center flex flex-col justify-between h-full">
-                    <div>
-                      <Users className="w-10 h-10 sm:w-12 sm:h-12 lg:w-16 lg:h-16 text-orange-600 mx-auto mb-3 sm:mb-4 lg:mb-6" />
-                      <h3 className="text-base sm:text-lg lg:text-xl font-bold text-gray-100 mb-2 sm:mb-3 lg:mb-4">Reading Groups</h3>
-                      <p className="text-xs sm:text-sm lg:text-base text-gray-300 leading-relaxed">Join meaningful discussions with fellow Sahadhyayi readers who share your literary interests</p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-              <Link to="/map" className="block">
-                <Card className="bg-black border-gray-700 hover:shadow-xl transition-all duration-300 hover:-translate-y-2 h-full">
-                  <CardContent className="p-4 sm:p-6 lg:p-8 text-center flex flex-col justify-between h-full">
-                    <div>
-                      <Map className="w-10 h-10 sm:w-12 sm:h-12 lg:w-16 lg:h-16 text-orange-600 mx-auto mb-3 sm:mb-4 lg:mb-6" />
-                      <h3 className="text-base sm:text-lg lg:text-xl font-bold text-gray-100 mb-2 sm:mb-3 lg:mb-4">Reader Map</h3>
-                      <p className="text-xs sm:text-sm lg:text-base text-gray-300 leading-relaxed">Find and connect with local Sahadhyayi members and book communities in your area</p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-              <Link to="/authors" className="block">
-                <Card className="bg-black border-gray-700 hover:shadow-xl transition-all duration-300 hover:-translate-y-2 h-full">
-                  <CardContent className="p-4 sm:p-6 lg:p-8 text-center flex flex-col justify-between h-full">
-                    <div>
-                      <Calendar className="w-10 h-10 sm:w-12 sm:h-12 lg:w-16 lg:h-16 text-orange-600 mx-auto mb-3 sm:mb-4 lg:mb-6" />
-                      <h3 className="text-base sm:text-lg lg:text-xl font-bold text-gray-100 mb-2 sm:mb-3 lg:mb-4">Meet Authors</h3>
-                      <p className="text-xs sm:text-sm lg:text-base text-gray-300 leading-relaxed">Connect directly with inspiring authors through live Sahadhyayi sessions and Q&As</p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-            </div>
-          </div>
-        </section>
+        <PopularBooks />
+        <UpcomingEvents />
+        <Testimonials />
 
         {/* CTA Section */}
         <section className="py-8 sm:py-12 lg:py-16 text-white">
@@ -322,7 +167,6 @@ const Index = () => {
             </div>
           </div>
         </section>
-        </div>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- simplify hero with a bold headline, accessible colors, and clear Join/Learn CTAs
- add navigation search bar and rename "Social Media" link to "Community"
- introduce Popular Books, Upcoming Events, and Testimonials sections for dynamic content

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b04185f2ac8320871376c9f819e37f