### PR TITLE
Improve navigation accessibility and semantics

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -73,9 +73,7 @@ const Navigation = () => {
   };
 
   return (
-    <nav
-      role="navigation"
-      aria-label="Main"
+    <header
       className={`fixed top-0 left-0 right-0 z-[100] transition-all duration-300 ${
         scrolled
           ? 'bg-white/95 backdrop-blur-md shadow-lg border-b border-gray-200'
@@ -89,6 +87,7 @@ const Navigation = () => {
       >
         Skip to main content
       </a>
+      <nav role="navigation" aria-label="Main" className="w-full">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
@@ -110,11 +109,11 @@ const Navigation = () => {
                   <Link
                     key={item.name}
                     to={item.href}
-                    className={`text-sm font-medium transition-colors duration-200 hover:text-amber-600 ${
-                      (location.pathname === item.href || 
-                       (item.href === "/" && location.pathname === "/dashboard" && user)) 
-                        ? 'text-amber-600 border-b-2 border-amber-600 pb-1' 
-                        : 'text-gray-700'
+                    className={`text-sm font-medium transition-colors duration-200 hover:text-amber-700 ${
+                      (location.pathname === item.href ||
+                       (item.href === "/" && location.pathname === "/dashboard" && user))
+                        ? 'text-amber-700 border-b-2 border-amber-700 pb-1'
+                        : 'text-gray-900'
                     }`}
                   >
                     {item.name}
@@ -132,7 +131,10 @@ const Navigation = () => {
                       <DropdownMenuTrigger asChild>
                         <Button variant="ghost" className="flex items-center space-x-2 p-2">
                           <Avatar className="h-8 w-8">
-                            <AvatarImage src={user.user_metadata?.avatar_url} />
+                            <AvatarImage
+                              src={user.user_metadata?.avatar_url}
+                              alt={user.user_metadata?.full_name || user.email || 'User avatar'}
+                            />
                             <AvatarFallback className="bg-gradient-to-br from-amber-400 to-orange-500 text-white">
                               {getUserInitials(user.email || 'U')}
                             </AvatarFallback>
@@ -164,15 +166,15 @@ const Navigation = () => {
                 ) : (
                   <div className="flex items-center space-x-4">
                     <SignInLink>
-                      <Button variant="ghost" size="sm" className="border-2 border-orange-500 text-orange-600 hover:bg-orange-50">
-                        Sign In
-                      </Button>
-                    </SignInLink>
-                    <Link to="/signup">
+                        <Button variant="ghost" size="sm" className="border-2 border-orange-600 text-orange-700 hover:bg-orange-50">
+                          Sign In
+                        </Button>
+                      </SignInLink>
+                      <Link to="/signup">
                       <Button size="sm" className="bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-700 hover:to-orange-700 text-white">
                         Sign Up
                       </Button>
-                    </Link>
+                      </Link>
                   </div>
                 )}
               </div>
@@ -192,7 +194,7 @@ const Navigation = () => {
                 variant="ghost"
                 size="sm"
                 onClick={() => setIsOpen(!isOpen)}
-                className="p-2 border-2 border-orange-500 text-orange-600 hover:bg-orange-50"
+                className="p-2 border-2 border-orange-600 text-orange-700 hover:bg-orange-50"
                 aria-label={isOpen ? 'Close navigation menu' : 'Open navigation menu'}
                 ref={menuButtonRef}
               >
@@ -215,10 +217,10 @@ const Navigation = () => {
                   to={item.href}
                   onClick={() => setIsOpen(false)}
                   className={`block px-3 py-2 text-sm font-medium rounded-md transition-colors duration-200 ${
-                    (location.pathname === item.href || 
-                     (item.href === "/" && location.pathname === "/dashboard" && user)) 
-                      ? 'text-amber-600 bg-amber-50' 
-                      : 'text-gray-700 hover:text-amber-600 hover:bg-gray-50'
+                    (location.pathname === item.href ||
+                     (item.href === "/" && location.pathname === "/dashboard" && user))
+                      ? 'text-amber-700 bg-amber-50'
+                      : 'text-gray-900 hover:text-amber-700 hover:bg-gray-50'
                   }`}
                 >
                   {item.name}
@@ -229,7 +231,10 @@ const Navigation = () => {
                 <div className="pt-4 border-t border-gray-200">
                   <div className="flex items-center px-3 py-2">
                     <Avatar className="h-10 w-10 mr-3">
-                      <AvatarImage src={user.user_metadata?.avatar_url} />
+                      <AvatarImage
+                        src={user.user_metadata?.avatar_url}
+                        alt={user.user_metadata?.full_name || user.email || 'User avatar'}
+                      />
                       <AvatarFallback className="bg-gradient-to-br from-amber-400 to-orange-500 text-white">
                         {getUserInitials(user.email || 'U')}
                       </AvatarFallback>
@@ -244,7 +249,7 @@ const Navigation = () => {
                   <Link
                     to="/profile"
                     onClick={() => setIsOpen(false)}
-                    className="block px-3 py-2 text-sm font-medium text-gray-700 hover:text-amber-600 hover:bg-gray-50 rounded-md"
+                    className="block px-3 py-2 text-sm font-medium text-gray-900 hover:text-amber-700 hover:bg-gray-50 rounded-md"
                   >
                     <User className="inline mr-2 h-4 w-4" />
                     Profile
@@ -252,14 +257,14 @@ const Navigation = () => {
                   <Link
                     to="/settings"
                     onClick={() => setIsOpen(false)}
-                    className="block px-3 py-2 text-sm font-medium text-gray-700 hover:text-amber-600 hover:bg-gray-50 rounded-md"
+                    className="block px-3 py-2 text-sm font-medium text-gray-900 hover:text-amber-700 hover:bg-gray-50 rounded-md"
                   >
                     <Settings className="inline mr-2 h-4 w-4" />
                     Settings
                   </Link>
                   <button
                     onClick={handleSignOut}
-                    className="block w-full text-left px-3 py-2 text-sm font-medium text-gray-700 hover:text-amber-600 hover:bg-gray-50 rounded-md"
+                    className="block w-full text-left px-3 py-2 text-sm font-medium text-gray-900 hover:text-amber-700 hover:bg-gray-50 rounded-md"
                   >
                     <LogOut className="inline mr-2 h-4 w-4" />
                     Sign Out
@@ -268,7 +273,7 @@ const Navigation = () => {
               ) : (
                 <div className="pt-4 space-y-3 border-t border-gray-200">
                   <SignInLink onClick={() => setIsOpen(false)} className="block">
-                    <Button variant="ghost" size="sm" className="w-full justify-center border-2 border-orange-500 text-orange-600 hover:bg-orange-50">
+                    <Button variant="ghost" size="sm" className="w-full justify-center border-2 border-orange-600 text-orange-700 hover:bg-orange-50">
                       Sign In
                     </Button>
                   </SignInLink>
@@ -283,7 +288,8 @@ const Navigation = () => {
           </div>
         )}
       </div>
-    </nav>
+      </nav>
+    </header>
   );
 };
 

--- a/src/components/library/ResultsList.tsx
+++ b/src/components/library/ResultsList.tsx
@@ -30,13 +30,14 @@ export default function ResultsList({ results, loading, error }: Props) {
 
   return (
     <div ref={parentRef} style={{ height: '60vh', overflow: 'auto' }}>
-      <div
+      <ul
+        role="list"
         style={{ height: rowVirtualizer.getTotalSize(), position: 'relative', width: '100%' }}
       >
         {rowVirtualizer.getVirtualItems().map((virtualRow) => {
           const book = results[virtualRow.index]
           return (
-            <div
+            <li
               key={book.id}
               ref={rowVirtualizer.measureElement}
               className="flex gap-4 border-b p-4"
@@ -49,7 +50,12 @@ export default function ResultsList({ results, loading, error }: Props) {
               }}
             >
               {book.cover_url && (
-                <img src={book.cover_url} alt="" className="w-16 h-24 object-cover" />
+                <img
+                  src={book.cover_url}
+                  alt={`${book.title} book cover`}
+                  loading="lazy"
+                  className="w-16 h-24 object-cover"
+                />
               )}
               <div className="flex-1">
                 <h3 className="font-semibold">
@@ -72,15 +78,17 @@ export default function ResultsList({ results, loading, error }: Props) {
               </div>
               <div className="flex flex-col items-end gap-2">
                 <span className="text-xs bg-amber-100 px-2 py-0.5 rounded">{book.popularity}</span>
-                <button className="text-sm px-2 py-1 border rounded">Add to shelf</button>
+                <button className="text-sm px-2 py-1 border rounded bg-gray-100 text-gray-900 hover:bg-gray-200">
+                  Add to shelf
+                </button>
               </div>
-            </div>
+            </li>
           )
         })}
         {loading && (
-          <div className="p-4">Loading…</div>
+          <li className="p-4">Loading…</li>
         )}
-      </div>
+      </ul>
     </div>
   )
 }

--- a/src/components/navigation/MobileNavMenu.tsx
+++ b/src/components/navigation/MobileNavMenu.tsx
@@ -51,12 +51,15 @@ const MobileNavMenu = ({ isOpen, onClose }: MobileNavMenuProps) => {
             Navigate through Sahadhyayi and manage your account.
           </SheetDescription>
         </SheetHeader>
-        <div className="grid gap-4 py-4">
+        <nav aria-label="Mobile navigation" className="grid gap-4 py-4">
           {user ? (
             <>
               <div className="flex items-center space-x-2">
                 <Avatar>
-                  <AvatarImage src={user.user_metadata?.avatar_url || ""} />
+                  <AvatarImage
+                    src={user.user_metadata?.avatar_url || ""}
+                    alt={user.user_metadata?.full_name || user.email || 'User avatar'}
+                  />
                   <AvatarFallback>
                     {user.user_metadata?.full_name?.charAt(0).toUpperCase() || user.email?.charAt(0).toUpperCase() || "U"}
                   </AvatarFallback>
@@ -81,7 +84,7 @@ const MobileNavMenu = ({ isOpen, onClose }: MobileNavMenuProps) => {
                   key={item.path}
                   to={item.path}
                   className={`flex items-center px-4 py-2 rounded-md hover:bg-gray-100 ${
-                    isActive(item.path) ? "text-orange-600" : "text-gray-700"
+                    isActive(item.path) ? "text-orange-700" : "text-gray-900"
                   }`}
                   onClick={onClose}
                 >
@@ -100,10 +103,10 @@ const MobileNavMenu = ({ isOpen, onClose }: MobileNavMenuProps) => {
             </>
           ) : (
             <>
-              <SignInLink className="block px-4 py-2 rounded-md hover:bg-gray-100">
+              <SignInLink className="block px-4 py-2 rounded-md hover:bg-gray-100 text-gray-900">
                 Sign In
               </SignInLink>
-              <Link to="/signup" className="block px-4 py-2 rounded-md hover:bg-gray-100">
+              <Link to="/signup" className="block px-4 py-2 rounded-md hover:bg-gray-100 text-gray-900">
                 Sign Up
               </Link>
               {navItems.map((item) => (
@@ -111,7 +114,7 @@ const MobileNavMenu = ({ isOpen, onClose }: MobileNavMenuProps) => {
                   key={item.path}
                   to={item.path}
                   className={`flex items-center px-4 py-2 rounded-md hover:bg-gray-100 ${
-                    isActive(item.path) ? "text-orange-600" : "text-gray-700"
+                    isActive(item.path) ? "text-orange-700" : "text-gray-900"
                   }`}
                   onClick={onClose}
                 >
@@ -121,7 +124,7 @@ const MobileNavMenu = ({ isOpen, onClose }: MobileNavMenuProps) => {
               ))}
             </>
           )}
-        </div>
+        </nav>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
## Summary
- wrap site navigation in semantic header/nav and improve color contrast
- add alt text and lazy-loading to book search results with semantic list
- expose mobile nav as `<nav>` with descriptive avatar alt text

## Testing
- `npm run lint`
- `npm run build`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68b03fc9fd708320861a76ef812afd2b