### PR TITLE
Improve accessibility and responsive layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -32,21 +32,28 @@
       body {
         font-family: system-ui, sans-serif;
         display: flex;
+        flex-direction: column;
         min-height: 100vh;
-        align-items: center;
-        justify-content: center;
         padding: 2rem;
         text-align: center;
         background: #000;
         color: #fff;
       }
-      #fallback {
+      main {
+        flex: 1;
         max-width: 600px;
+        width: 100%;
+        margin: 0 auto;
         display: none;
       }
-      #fallback a {
+      main a {
         color: #fff;
         text-decoration: underline;
+      }
+      @media (max-width: 600px) {
+        body {
+          padding: 1rem;
+        }
       }
     </style>
     <script>
@@ -66,13 +73,26 @@
   </head>
 
   <body>
-    <div id="fallback">
+    <header>
+      <nav>
+        <a href="/" aria-label="Sahadhyayi home">
+          <img src="/lovable-uploads/sahadhyayi-logo-digital-reading.png" alt="Sahadhyayi logo" style="height:40px" />
+        </a>
+      </nav>
+    </header>
+    <main id="fallback">
       <h1>Page not found</h1>
-      <p>
-        The page you're looking for doesn't exist or the application failed to load.
-        You can try refreshing the page or return to the
-        <a href="/">homepage</a>.
-      </p>
-    </div>
+      <p>The page you're looking for doesn't exist or the application failed to load.</p>
+      <ul>
+        <li>Refresh the page</li>
+        <li>
+          Return to the
+          <a href="/">homepage</a>
+        </li>
+      </ul>
+    </main>
+    <footer>
+      <small>&copy; 2024 Sahadhyayi</small>
+    </footer>
   </body>
 </html>

--- a/src/components/home/UpcomingEvents.tsx
+++ b/src/components/home/UpcomingEvents.tsx
@@ -16,7 +16,7 @@ const UpcomingEvents: React.FC = () => (
           {events.map((event, idx) => (
             <CarouselItem key={idx} className="basis-3/4 sm:basis-1/2 lg:basis-1/3">
               <div className="p-4 bg-neutral rounded shadow text-center h-full flex flex-col justify-between">
-                <img src={event.image} alt="" className="mb-4 h-32 w-full object-cover rounded" />
+                <img src={event.image} alt={event.title} className="mb-4 h-32 w-full object-cover rounded" />
                 <div>
                   <h3 className="text-lg font-semibold text-gray-800 mb-2">{event.title}</h3>
                   <p className="text-sm text-gray-600">{event.date}</p>

--- a/src/components/library/ResultsList.tsx
+++ b/src/components/library/ResultsList.tsx
@@ -49,7 +49,7 @@ export default function ResultsList({ results, loading, error }: Props) {
               }}
             >
               {book.cover_url && (
-                <img src={book.cover_url} alt="" className="w-16 h-24 object-cover" />
+                <img src={book.cover_url} alt={`Cover of ${book.title}`} className="w-16 h-24 object-cover" />
               )}
               <div className="flex-1">
                 <h3 className="font-semibold">

--- a/src/components/social/ReadersNearMeMap.tsx
+++ b/src/components/social/ReadersNearMeMap.tsx
@@ -318,7 +318,7 @@ export const ReadersNearMeMap: React.FC = () => {
           <div style="padding: 12px; max-width: 250px;">
             <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
               <div style="width: 40px; height: 40px; background: ${isFriend ? '#10b981' : '#f97316'}; color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: bold;">
-                ${reader.avatar_img_url ? `<img src="${reader.avatar_img_url}" style="width: 40px; height: 40px; border-radius: 50%; object-fit: cover;" />` : reader.full_name.charAt(0).toUpperCase()}
+                  ${reader.avatar_img_url ? `<img src="${reader.avatar_img_url}" alt="Avatar of ${reader.full_name}" style="width: 40px; height: 40px; border-radius: 50%; object-fit: cover;" />` : reader.full_name.charAt(0).toUpperCase()}
               </div>
               <div>
                 <h3 style="margin: 0; font-size: 16px; font-weight: 600;">


### PR DESCRIPTION
## Summary
- add semantic structure and responsive styles to 404 page
- provide descriptive alt text for event and book images
- include alt text for user avatars in map popups

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b043e059a48320a10bd58efac24b88