### PR TITLE
feat: encode sitemap slugs

### DIFF
--- a/scripts/generateSitemap.js
+++ b/scripts/generateSitemap.js
@@ -66,7 +66,13 @@ if (authors.length === 0) {
   ];
 }
 
-const slugify = text => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+const slugify = text =>
+  encodeURIComponent(
+    text
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+  );
 
 const urls = [];
 const today = new Date().toISOString().split('T')[0];


### PR DESCRIPTION
## Summary
- encode sitemap slugs to preserve non-Latin characters

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2efc22b8483209ba866197ec01b33