### PR TITLE
fix: handle CORS for book expert

### DIFF
--- a/supabase/functions/book-expert-gemini/index.ts
+++ b/supabase/functions/book-expert-gemini/index.ts
@@ -1,12 +1,31 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': 'https://rknxtatvlzunatpyqxro.supabase.co, https://www.sahadhyayi.com, https://sahadhyayi.com',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+// Handle CORS dynamically to support multiple allowed origins
+const ALLOWED_ORIGINS = [
+  "https://rknxtatvlzunatpyqxro.supabase.co",
+  "https://www.sahadhyayi.com",
+  "https://sahadhyayi.com",
+];
+
+function getCorsHeaders(origin: string | null) {
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Headers":
+      "authorization, x-client-info, apikey, content-type",
+  };
+
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    headers["Access-Control-Allow-Origin"] = origin;
+  } else {
+    headers["Access-Control-Allow-Origin"] = ALLOWED_ORIGINS[0];
+  }
+
+  return headers;
+}
 
 serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req.headers.get('origin'));
+
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }


### PR DESCRIPTION
## Summary
- handle CORS dynamically in the `book-expert-gemini` function to support multiple allowed origins

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2efdd9aa883208263779836409035