### PR TITLE
fix: add methods header for book expert CORS

### DIFF
--- a/supabase/functions/book-expert-gemini/index.ts
+++ b/supabase/functions/book-expert-gemini/index.ts
@@ -12,6 +12,7 @@ function getCorsHeaders(origin: string | null) {
   const headers: Record<string, string> = {
     "Access-Control-Allow-Headers":
       "authorization, x-client-info, apikey, content-type",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
   };
 
   if (origin && ALLOWED_ORIGINS.includes(origin)) {


### PR DESCRIPTION
## Summary
- include `Access-Control-Allow-Methods` in book expert function CORS headers to allow POST requests

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2f45c78108320ab01f755e54a63a0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-origin compatibility by explicitly allowing POST and OPTIONS methods, ensuring browser preflight (OPTIONS) requests succeed.
  * Reduced CORS-related failures, resulting in more reliable API calls from web clients across different origins.
  * Users should experience fewer blocked requests and error messages when interacting with the service from browser-based applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->