### PR TITLE
feat: add secure fetch utility

### DIFF
--- a/src/security/secureFetch.ts
+++ b/src/security/secureFetch.ts
@@ -1,0 +1,52 @@
+import { getCsrfToken, setCsrfToken } from "./useSecureApi";
+
+/**
+ * Wraps fetch:
+ *  - includes credentials for cookie-based session
+ *  - attaches X-CSRF-Token from localStorage
+ *  - if 401/403, re-login via /api/session once, then retry the original request
+ *  - if server rotates CSRF and returns X-New-CSRF-Token, we persist it
+ */
+export async function secureFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  // first attempt
+  let res = await doFetch(input, init);
+  // handle rotation header
+  res = await maybePersistRotatedCsrfAndReturn(input, init, res);
+
+  if (res.status === 401 || res.status === 403) {
+    // refresh server session + CSRF
+    try {
+      const mod = await import("./sessionClient");
+      await mod.sessionClientLogin();
+      // retry once with fresh token
+      const res2 = await doFetch(input, init);
+      return maybePersistRotatedCsrfAndReturn(input, init, res2);
+    } catch {
+      return res;
+    }
+  }
+
+  return res;
+}
+
+async function doFetch(input: RequestInfo | URL, init: RequestInit) {
+  const headers = new Headers(init.headers || {});
+  const csrf = getCsrfToken();
+  if (csrf) headers.set("X-CSRF-Token", csrf);
+
+  return fetch(input, {
+    ...init,
+    headers,
+    credentials: "include",
+  });
+}
+
+async function maybePersistRotatedCsrfAndReturn(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  res: Response
+) {
+  const newToken = res.headers.get("X-New-CSRF-Token");
+  if (newToken) setCsrfToken(newToken);
+  return res;
+}


### PR DESCRIPTION
## Summary
- add secureFetch wrapper to automatically send CSRF tokens and retry on 401/403

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b57d739bd08320afca489aefc658ec