### PR TITLE
feat: add session client login helper

### DIFF
--- a/src/security/sessionClient.ts
+++ b/src/security/sessionClient.ts
@@ -1,0 +1,16 @@
+import { setCsrfToken } from "./useSecureApi";
+
+/** Call this to mint a fresh server session + csrf, without React hooks */
+export async function sessionClientLogin() {
+  const res = await fetch("/api/session", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (!res.ok) throw new Error(`/api/session failed: ${res.status}`);
+  const data = await res.json().catch(() => ({}));
+  if (!data?.csrfToken) throw new Error("No csrfToken in /api/session response");
+  setCsrfToken(data.csrfToken);
+  return data.csrfToken as string;
+}


### PR DESCRIPTION
## Summary
- add a plain sessionClient helper to mint server sessions and CSRF tokens without React hooks

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b57d81a6ec83208f15b9048a09b768