### PR TITLE
Use secureFetch for backend API calls

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, ReactNode } from "react
 import { createClient, Session, User } from "@supabase/supabase-js";
 import { setCsrfToken } from "../security/useSecureApi";
 import { sessionClientLogin } from "../security/sessionClient";
+import { secureFetch } from "../security/secureFetch";
 
 const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL!,
@@ -63,7 +64,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setCsrfToken(null);
     // optional: tell backend to clear cookie
     try {
-      await fetch("/api/session", { method: "DELETE", credentials: "include" });
+      await secureFetch("/api/session", { method: "DELETE" });
     } catch {
       /* ignore */
     }

--- a/src/hooks/useGoodreadsIntegration.ts
+++ b/src/hooks/useGoodreadsIntegration.ts
@@ -1,4 +1,4 @@
-import { secureFetch } from '@/lib/secureFetch';
+import { secureFetch } from '@/security/secureFetch';
 
 export interface GoodreadsBook {
   id: string;

--- a/src/hooks/useSecureApi.ts
+++ b/src/hooks/useSecureApi.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { secureFetch } from '@/lib/secureFetch';
+import { secureFetch } from '@/security/secureFetch';
 import { supabase } from '@/integrations/supabase/client-universal';
 import { setCSRFToken } from '@/utils/security';
 

--- a/src/hooks/useSpeechToText.ts
+++ b/src/hooks/useSpeechToText.ts
@@ -1,6 +1,6 @@
 
 import * as React from 'react';
-import { secureFetch } from '@/lib/secureFetch';
+import { secureFetch } from '@/security/secureFetch';
 
 interface UseSpeechToTextOptions {
   onTranscript: (text: string) => void;

--- a/src/security/useSecureApi.ts
+++ b/src/security/useSecureApi.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { secureFetch } from "./secureFetch";
 
 const CSRF_KEY = "csrfToken";
 
@@ -19,9 +20,8 @@ export function setCsrfToken(token: string | null) {
  */
 export function useSecureApi() {
   const login = useCallback(async () => {
-    const res = await fetch("/api/session", {
+    const res = await secureFetch("/api/session", {
       method: "POST",
-      credentials: "include",
       headers: { "Content-Type": "application/json" },
       body: "{}",
     });
@@ -34,7 +34,7 @@ export function useSecureApi() {
 
   const logout = useCallback(async () => {
     try {
-      await fetch("/api/session", { method: "DELETE", credentials: "include" });
+      await secureFetch("/api/session", { method: "DELETE" });
     } finally {
       setCsrfToken(null);
     }

--- a/src/utils/libgenApi.ts
+++ b/src/utils/libgenApi.ts
@@ -1,4 +1,4 @@
-import { secureFetch } from '@/lib/secureFetch';
+import { secureFetch } from '@/security/secureFetch';
 
 export interface LibgenBook {
   id: string;


### PR DESCRIPTION
## Summary
- route backend session cleanup through CSRF-aware secureFetch
- ensure security API hook uses secureFetch for login/logout
- standardize secureFetch imports across hooks and utilities

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b58257df8c8320af97b45500b436a0