### PR TITLE
Wire secure API auth and CSRF handling

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, ReactNode } from "react
 import { createClient, Session, User } from "@supabase/supabase-js";
 import { setCsrfToken } from "../security/useSecureApi";
 import { sessionClientLogin } from "../security/sessionClient";
+import { secureFetch } from "../security/secureFetch";
 
 const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL!,
@@ -63,7 +64,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setCsrfToken(null);
     // optional: tell backend to clear cookie
     try {
-      await fetch("/api/session", { method: "DELETE", credentials: "include" });
+      await secureFetch("/api/session", { method: "DELETE" });
     } catch {
       /* ignore */
     }

--- a/src/hooks/useGoodreadsIntegration.ts
+++ b/src/hooks/useGoodreadsIntegration.ts
@@ -1,4 +1,4 @@
-import { secureFetch } from '@/lib/secureFetch';
+import { secureFetch } from "../security/secureFetch";
 
 export interface GoodreadsBook {
   id: string;

--- a/src/hooks/useSecureApi.ts
+++ b/src/hooks/useSecureApi.ts
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { secureFetch } from '@/lib/secureFetch';
-import { supabase } from '@/integrations/supabase/client-universal';
-import { setCSRFToken } from '@/utils/security';
+import { useCallback } from "react";
+import { secureFetch } from "../security/secureFetch";
+import { supabase } from "@/integrations/supabase/client-universal";
+import { setCSRFToken } from "@/utils/security";
 
 export function useSecureApi() {
   const fetcher = useCallback((url: string, opts?: RequestInit) => secureFetch(url, opts), []);

--- a/src/hooks/useSpeechToText.ts
+++ b/src/hooks/useSpeechToText.ts
@@ -1,6 +1,6 @@
 
-import * as React from 'react';
-import { secureFetch } from '@/lib/secureFetch';
+import * as React from "react";
+import { secureFetch } from "../security/secureFetch";
 
 interface UseSpeechToTextOptions {
   onTranscript: (text: string) => void;

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { useAuth } from '@/contexts/authHelpers';
+import { useAuth } from '@/contexts/AuthContext';
 import { LogIn, Mail, Lock } from 'lucide-react';
 import SEO from '@/components/SEO';
 import { validateEmail, sanitizeInput, isRateLimited } from '@/utils/validation';
@@ -84,34 +84,25 @@ const SignIn = () => {
 
     try {
       const sanitizedEmail = sanitizeInput(formData.email.trim().toLowerCase(), 254);
-      
-      // Log security event for failed attempts
-      const { error } = await signIn(sanitizedEmail, formData.password);
 
-      if (error) {
-        // Enhanced error handling with user-friendly messages
-        let errorMessage = error.message;
-        
-        if (error.message.includes('Invalid login credentials')) {
-          errorMessage = 'Invalid email or password. Please check your credentials and try again.';
-        } else if (error.message.includes('Email not confirmed')) {
-          errorMessage = 'Please check your email and click the confirmation link before signing in.';
-        } else if (error.message.includes('rate limit') || error.message.includes('too many')) {
-          errorMessage = 'Too many sign-in attempts. Please wait a moment before trying again.';
-        } else if (error.message.includes('Invalid email')) {
-          errorMessage = 'Please enter a valid email address.';
-        } else {
-          errorMessage = 'Sign-in failed. Please try again.';
-        }
-        
-        setError(errorMessage);
-        return;
-      }
+      await signIn(sanitizedEmail, formData.password);
 
       // Success will be handled by the useEffect above
-    } catch (error: unknown) {
+    } catch (error: any) {
       console.error('Signin error:', error);
-      setError('An unexpected error occurred. Please try again.');
+      let errorMessage = error?.message || 'Sign-in failed. Please try again.';
+
+      if (errorMessage.includes('Invalid login credentials')) {
+        errorMessage = 'Invalid email or password. Please check your credentials and try again.';
+      } else if (errorMessage.includes('Email not confirmed')) {
+        errorMessage = 'Please check your email and click the confirmation link before signing in.';
+      } else if (errorMessage.includes('rate limit') || errorMessage.includes('too many')) {
+        errorMessage = 'Too many sign-in attempts. Please wait a moment before trying again.';
+      } else if (errorMessage.includes('Invalid email')) {
+        errorMessage = 'Please enter a valid email address.';
+      }
+
+      setError(errorMessage);
     } finally {
       setLoading(false);
     }

--- a/src/utils/libgenApi.ts
+++ b/src/utils/libgenApi.ts
@@ -1,4 +1,4 @@
-import { secureFetch } from '@/lib/secureFetch';
+import { secureFetch } from "../security/secureFetch";
 
 export interface LibgenBook {
   id: string;


### PR DESCRIPTION
## Summary
- Use centralized secureFetch and sessionClient helpers for CSRF-protected requests
- Run sessionClientLogin after Supabase sign-in and clear server session on sign-out
- Update SignIn and API hooks to rely on new auth context and secureFetch

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b582cde97883208928849aa218dc59