### PR TITLE
Fix loader not hiding on home page by allowing inline scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <meta name="referrer" content="no-referrer" />
 
     <!-- CSP is normally set via HTTP headers in server.js. Meta is a fallback for static preview only. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'" />
 
     <!-- Enhanced Structured Data -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- allow inline scripts in fallback CSP so loader removal script runs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b60b686bac83208478b40189e7b7c3