### PR TITLE
Relax CSP to allow inline and blob scripts for hydration

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,8 +24,8 @@ Sentry.init({ dsn: process.env.SENTRY_DSN });
 
 const CSP = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com",
-  "style-src 'self' https://fonts.googleapis.com",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://maps.googleapis.com https://static.cloudflareinsights.com",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "img-src 'self' data: blob: https:",
   "font-src 'self' https://fonts.gstatic.com",
   "connect-src 'self' https://*.supabase.co wss:",

--- a/src/utils/securityConfig.ts
+++ b/src/utils/securityConfig.ts
@@ -13,8 +13,8 @@ export const SECURITY_CONFIG = {
   // Content Security Policy
   CSP: {
     'default-src': ["'self'"],
-    'script-src': ["'self'", "https://maps.googleapis.com"],
-    'style-src': ["'self'", "https://fonts.googleapis.com"],
+    'script-src': ["'self'", "'unsafe-inline'", "'unsafe-eval'", "blob:", "https://maps.googleapis.com", "https://static.cloudflareinsights.com"],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
     'img-src': ["'self'", "data:", "blob:", "https:"],
     'font-src': ["'self'", "https://fonts.gstatic.com"],
     'connect-src': ["'self'", "https://*.supabase.co", "wss:"],


### PR DESCRIPTION
## Summary
- Allow inline/eval scripts, blob URLs, and Cloudflare beacon in CSP config
- Permit inline styles in CSP config
- Mirror CSP updates in server header configuration

## Testing
- `npm run lint` (warnings only)
- `npm run build` *(fails: Rollup failed to resolve import "/assets/index-CG3Ev_sc.js" from "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_68b6144c10788320803ff7ad9ac56c25