### PR TITLE
fix: standardize Vite entry and update CSP directives

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,6 @@
       <h1>Welcome to Sahadhyayi – Your Digital Book Club &amp; Library</h1>
       <p>Join our digital reading community, connect with readers, and track your progress.</p>
     </header>
-    <div id="root"></div>
     <script>
       // Support GitHub Pages-style SPA redirects (?p=/path)
       const params = new URLSearchParams(window.location.search);
@@ -230,6 +229,7 @@
     </script>
     <!-- Google Search Console verification -->
     <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
-    <script type="module" crossorigin src="/assets/index-CG3Ev_sc.js"></script>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -24,8 +24,8 @@ Sentry.init({ dsn: process.env.SENTRY_DSN });
 
 const CSP = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com",
-  "style-src 'self' https://fonts.googleapis.com",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://maps.googleapis.com https://static.cloudflareinsights.com",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "img-src 'self' data: blob: https:",
   "font-src 'self' https://fonts.gstatic.com",
   "connect-src 'self' https://*.supabase.co wss:",

--- a/src/utils/securityConfig.ts
+++ b/src/utils/securityConfig.ts
@@ -13,8 +13,15 @@ export const SECURITY_CONFIG = {
   // Content Security Policy
   CSP: {
     'default-src': ["'self'"],
-    'script-src': ["'self'", "https://maps.googleapis.com"],
-    'style-src': ["'self'", "https://fonts.googleapis.com"],
+    'script-src': [
+      "'self'",
+      "'unsafe-inline'",
+      "'unsafe-eval'",
+      'blob:',
+      'https://maps.googleapis.com',
+      'https://static.cloudflareinsights.com'
+    ],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
     'img-src': ["'self'", "data:", "blob:", "https:"],
     'font-src': ["'self'", "https://fonts.gstatic.com"],
     'connect-src': ["'self'", "https://*.supabase.co", "wss:"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,81 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
 
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
-import path from "path";
-import { componentTagger } from "lovable-tagger";
-import compression from "vite-plugin-compression";
-
-// https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  base: "/",
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' && componentTagger(),
-    compression({
-      algorithm: 'gzip',
-      ext: '.gz',
-    }),
-    compression({
-      algorithm: 'brotliCompress',
-      ext: '.br',
-    }),
-  ].filter(Boolean),
-  optimizeDeps: {
-    include: [
-      '@radix-ui/react-dialog',
-      '@radix-ui/react-toast',
-      '@tanstack/react-query',
-      'react',
-      'react-dom',
-      'react-router-dom'
-    ],
-    force: true,
-    exclude: ['@supabase/supabase-js']
-  },
-  define: {
-    'process.env.NODE_ENV': JSON.stringify(mode),
-    global: 'globalThis',
-  },
+export default defineConfig({
+  plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
-    dedupe: ['react', 'react-dom', 'react/jsx-runtime'],
   },
   build: {
-    assetsDir: 'assets',
-    sourcemap: false,
-    minify: 'terser',
-    target: 'esnext',
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          router: ['react-router-dom'],
-          ui: ['@radix-ui/react-dialog', '@radix-ui/react-toast'],
-          query: ['@tanstack/react-query'],
-          supabase: ['@supabase/supabase-js']
-        }
-      }
-    },
-    terserOptions: {
-      compress: {
-        drop_console: true,
-        drop_debugger: true,
-        pure_funcs: ['console.log', 'console.info', 'console.debug']
-      },
-      mangle: {
-        safari10: true,
-      },
-    },
-    chunkSizeWarningLimit: 1000,
+    outDir: 'dist',
   },
-  assetsInclude: ['**/*.webp', '**/*.avif'],
-  esbuild: {
-    drop: mode === 'production' ? ['console', 'debugger'] : [],
-  },
-}));
+});
+


### PR DESCRIPTION
## Summary
- remove hardcoded asset script in index.html and use `/src/main.tsx` as Vite entry
- broaden CSP directives for inline scripts, blob modules, and external services
- simplify Vite config to standard React setup with alias resolution

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6162c42888320a3f4b3b51957f365