### PR TITLE
Add server-side utility shims

### DIFF
--- a/server-utils/security.js
+++ b/server-utils/security.js
@@ -1,0 +1,71 @@
+// src/utils/security.ts
+var generateCSRFToken = () => {
+  const arr = new Uint8Array(32);
+  crypto.getRandomValues(arr);
+  return btoa(String.fromCharCode(...arr)).replace(/=/g, "");
+};
+var setCSRFToken = (token) => {
+  if (typeof window === "undefined") return;
+  if (!token) {
+    sessionStorage.removeItem("csrfToken");
+    document.cookie = "csrfToken=; Path=/; Max-Age=0; SameSite=Strict; Secure";
+  } else {
+    sessionStorage.setItem("csrfToken", token);
+    document.cookie = `csrfToken=${token}; Path=/; SameSite=Strict; Secure`;
+  }
+};
+var getCSRFToken = () => {
+  if (typeof window === "undefined") return null;
+  const s = sessionStorage.getItem("csrfToken");
+  if (s) return s;
+  const m = document.cookie.match(/(?:^|;\s*)csrfToken=([^;]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+};
+var clearCSRFToken = () => setCSRFToken(null);
+var validateFileUpload = (file, allowedTypes = [], maxSize = 5 * 1024 * 1024) => {
+  var _a;
+  if (!file) return { valid: false, error: "No file provided" };
+  if (file.size > maxSize) return { valid: false, error: `File size exceeds ${Math.round(maxSize / (1024 * 1024))}MB limit` };
+  if (allowedTypes.length && !allowedTypes.includes(file.type)) return { valid: false, error: "File type not allowed" };
+  try {
+    const ext = (_a = file.name.split(".").pop()) == null ? void 0 : _a.toLowerCase();
+    const map = {
+      "image/jpeg": ["jpg", "jpeg"],
+      "image/png": ["png"],
+      "image/gif": ["gif"],
+      "image/webp": ["webp"],
+      "application/pdf": ["pdf"],
+      "text/plain": ["txt"],
+      "application/json": ["json"]
+    };
+    const expected = map[file.type];
+    if (expected && ext && !expected.includes(ext)) return { valid: false, error: "File extension does not match content type" };
+  } catch {
+  }
+  return { valid: true };
+};
+var createSecureHeaders = (includeCSRF = true) => {
+  const headers = { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" };
+  if (includeCSRF) {
+    const token = getCSRFToken();
+    if (token) headers["X-CSRF-Token"] = token;
+  }
+  return headers;
+};
+var initializeSecureSession = () => {
+  if (typeof window === "undefined") return;
+  if (!getCSRFToken()) setCSRFToken(generateCSRFToken());
+};
+var initializeSecurity = () => {
+  initializeSecureSession();
+};
+export {
+  clearCSRFToken,
+  createSecureHeaders,
+  generateCSRFToken,
+  getCSRFToken,
+  initializeSecureSession,
+  initializeSecurity,
+  setCSRFToken,
+  validateFileUpload
+};

--- a/server-utils/securityConfig.js
+++ b/server-utils/securityConfig.js
@@ -1,0 +1,186 @@
+// src/utils/securityConfig.ts
+var SECURITY_CONFIG = {
+  // Rate limiting configurations
+  RATE_LIMITS: {
+    SIGNIN: { attempts: 5, windowMs: 3e5 },
+    // 5 attempts per 5 minutes
+    SIGNUP: { attempts: 3, windowMs: 6e5 },
+    // 3 attempts per 10 minutes
+    SEARCH: { attempts: 10, windowMs: 6e4 },
+    // 10 searches per minute
+    COMMENT: { attempts: 20, windowMs: 3e5 },
+    // 20 comments per 5 minutes
+    PROFILE_UPDATE: { attempts: 5, windowMs: 3e5 }
+    // 5 updates per 5 minutes
+  },
+  // Content Security Policy
+  CSP: {
+    "default-src": ["'self'"],
+    "script-src": [
+      "'self'",
+      "'unsafe-inline'",
+      "'unsafe-eval'",
+      "blob:",
+      "https://maps.googleapis.com",
+      "https://static.cloudflareinsights.com"
+    ],
+    "style-src": [
+      "'self'",
+      "'unsafe-inline'",
+      "https://fonts.googleapis.com"
+    ],
+    "img-src": ["'self'", "data:", "blob:", "https:"],
+    "font-src": ["'self'", "https://fonts.gstatic.com"],
+    "connect-src": ["'self'", "https://*.supabase.co", "wss:"],
+    "frame-src": ["'self'"],
+    "report-uri": ["/csp-report"]
+  },
+  // Input validation limits
+  VALIDATION: {
+    EMAIL_MAX_LENGTH: 254,
+    PASSWORD_MIN_LENGTH: 8,
+    PASSWORD_MAX_LENGTH: 128,
+    NAME_MAX_LENGTH: 100,
+    USERNAME_MAX_LENGTH: 30,
+    SEARCH_QUERY_MAX_LENGTH: 100,
+    COMMENT_MAX_LENGTH: 1e3,
+    DESCRIPTION_MAX_LENGTH: 2e3
+  },
+  // File upload restrictions
+  FILE_UPLOAD: {
+    ALLOWED_IMAGE_TYPES: ["image/png", "image/jpeg", "image/webp"],
+    MAX_SIZE: 5 * 1024 * 1024
+    // 5MB
+  },
+  // Session security
+  SESSION: {
+    MAX_AGE: 24 * 60 * 60 * 1e3,
+    // 24 hours
+    INACTIVITY_TIMEOUT: 2 * 60 * 60 * 1e3,
+    // 2 hours
+    RENEWAL_THRESHOLD: 30 * 60 * 1e3
+    // 30 minutes
+  },
+  // Trusted domains for external links
+  TRUSTED_DOMAINS: [
+    "self",
+    "*.supabase.co",
+    "maps.googleapis.com",
+    "fonts.googleapis.com",
+    "fonts.gstatic.com"
+  ],
+  // Security headers
+  SECURITY_HEADERS: {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-XSS-Protection": "1; mode=block",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=(self)"
+  }
+};
+var SecurityMiddleware = class {
+  static validateOrigin(origin) {
+    if (!origin) return false;
+    try {
+      const url = new URL(origin);
+      return SECURITY_CONFIG.TRUSTED_DOMAINS.includes(url.hostname);
+    } catch {
+      return false;
+    }
+  }
+  static sanitizeUserAgent(userAgent) {
+    if (!userAgent || typeof userAgent !== "string") return "Unknown";
+    return userAgent.replace(/[<>'"&]/g, "").substring(0, 200);
+  }
+  static validateReferer(referer) {
+    if (!referer) return true;
+    try {
+      const url = new URL(referer);
+      return SECURITY_CONFIG.TRUSTED_DOMAINS.includes(url.hostname) || url.hostname === window.location.hostname;
+    } catch {
+      return false;
+    }
+  }
+  static createSecureRequestOptions(includeCredentials = true) {
+    const options = {
+      headers: {
+        "Content-Type": "application/json",
+        "X-Requested-With": "XMLHttpRequest",
+        ...SECURITY_CONFIG.SECURITY_HEADERS
+      }
+    };
+    if (includeCredentials) {
+      options.credentials = "same-origin";
+    }
+    return options;
+  }
+  static logSecurityViolation(violation, details = {}) {
+    const event = {
+      type: "SECURITY_VIOLATION",
+      violation,
+      details,
+      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+      userAgent: navigator.userAgent,
+      url: window.location.href,
+      referer: document.referrer
+    };
+    console.warn("[SECURITY]", event);
+    if (import.meta.env.PROD) {
+    }
+  }
+};
+var SecurityMonitor = class {
+  static events = [];
+  static MAX_EVENTS = 100;
+  static recordEvent(event, data = {}) {
+    const record = {
+      event,
+      data,
+      timestamp: Date.now(),
+      url: window.location.href
+    };
+    this.events.push(record);
+    if (this.events.length > this.MAX_EVENTS) {
+      this.events = this.events.slice(-this.MAX_EVENTS);
+    }
+    this.detectAnomalies();
+  }
+  static detectAnomalies() {
+    const recentEvents = this.events.filter(
+      (e) => Date.now() - e.timestamp < 6e4
+      // Last minute
+    );
+    if (recentEvents.length > 20) {
+      SecurityMiddleware.logSecurityViolation("RAPID_REQUESTS", {
+        count: recentEvents.length,
+        timeframe: "1_minute"
+      });
+    }
+    const failedLogins = recentEvents.filter(
+      (e) => e.event === "LOGIN_FAILED"
+    ).length;
+    if (failedLogins > 3) {
+      SecurityMiddleware.logSecurityViolation("MULTIPLE_LOGIN_FAILURES", {
+        count: failedLogins,
+        timeframe: "1_minute"
+      });
+    }
+  }
+  static getSecuritySummary() {
+    return {
+      totalEvents: this.events.length,
+      recentEvents: this.events.filter(
+        (e) => Date.now() - e.timestamp < 3e5
+        // Last 5 minutes
+      ).length,
+      eventTypes: [...new Set(this.events.map((e) => e.event))]
+    };
+  }
+};
+var securityConfig_default = SECURITY_CONFIG;
+export {
+  SECURITY_CONFIG,
+  SecurityMiddleware,
+  SecurityMonitor,
+  securityConfig_default as default
+};

--- a/server-utils/validation.js
+++ b/server-utils/validation.js
@@ -1,0 +1,184 @@
+// src/utils/validation.ts
+var encodeHTML = (str) => {
+  const entityMap = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+    "/": "&#x2F;",
+    "`": "&#x60;",
+    "=": "&#x3D;"
+  };
+  return String(str).replace(/[&<>"'`=/]/g, (s) => entityMap[s]);
+};
+var sanitizeHTML = (dirty) => {
+  let clean = dirty.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "");
+  clean = clean.replace(/javascript:/gi, "");
+  clean = clean.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, "");
+  clean = clean.replace(/\s*style\s*=\s*["'][^"']*["']/gi, "");
+  clean = clean.replace(/data:(?!image\/)[^;]+;/gi, "");
+  return encodeHTML(clean);
+};
+var validateEmail = (email) => {
+  if (!email || typeof email !== "string") return false;
+  const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  const trimmed = email.trim();
+  if (trimmed.length > 254) return false;
+  if (trimmed.includes("..") || trimmed.startsWith(".") || trimmed.endsWith(".")) return false;
+  return emailRegex.test(trimmed);
+};
+var validatePassword = (password) => {
+  if (!password || typeof password !== "string") {
+    return { isValid: false, message: "Password is required" };
+  }
+  if (password.length < 8) {
+    return { isValid: false, message: "Password must be at least 8 characters long" };
+  }
+  if (password.length > 128) {
+    return { isValid: false, message: "Password must be less than 128 characters long" };
+  }
+  const hasUpperCase = /[A-Z]/.test(password);
+  const hasLowerCase = /[a-z]/.test(password);
+  const hasNumbers = /\d/.test(password);
+  const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+  if (!hasUpperCase || !hasLowerCase || !hasNumbers) {
+    return {
+      isValid: false,
+      message: "Password must contain at least one uppercase letter, one lowercase letter, and one number"
+    };
+  }
+  const weakPatterns = [
+    /(.)\1{2,}/,
+    // Repeated characters (aaa, 111)
+    /^(?:password|123456|qwerty|abc123|admin|user|guest|test)/i,
+    // Common passwords
+    /^\d+$/,
+    // Only numbers
+    /^[a-zA-Z]+$/
+    // Only letters
+  ];
+  for (const pattern of weakPatterns) {
+    if (pattern.test(password)) {
+      return { isValid: false, message: "Password is too weak. Avoid common patterns." };
+    }
+  }
+  return { isValid: true };
+};
+var validateUsername = (username) => {
+  if (!username || typeof username !== "string") {
+    return { isValid: false, message: "Username is required" };
+  }
+  const trimmed = username.trim();
+  if (trimmed.length < 3) {
+    return { isValid: false, message: "Username must be at least 3 characters long" };
+  }
+  if (trimmed.length > 30) {
+    return { isValid: false, message: "Username must be less than 30 characters long" };
+  }
+  const usernameRegex = /^[a-zA-Z0-9_-]+$/;
+  if (!usernameRegex.test(trimmed)) {
+    return {
+      isValid: false,
+      message: "Username can only contain letters, numbers, underscores, and hyphens"
+    };
+  }
+  const reservedNames = ["admin", "root", "user", "guest", "test", "api", "www", "mail", "ftp", "localhost", "system"];
+  if (reservedNames.includes(trimmed.toLowerCase())) {
+    return { isValid: false, message: "This username is reserved" };
+  }
+  return { isValid: true };
+};
+var sanitizeInput = (input, maxLength) => {
+  if (!input || typeof input !== "string") return "";
+  let sanitized = input.replace(/[<>]/g, "").replace(/javascript:/gi, "").replace(/on\w+\s*=/gi, "").replace(/data:(?!image\/)[^;]+;/gi, "").trim();
+  sanitized = encodeHTML(sanitized);
+  if (maxLength && sanitized.length > maxLength) {
+    sanitized = sanitized.substring(0, maxLength);
+  }
+  return sanitized;
+};
+var sanitizeSearchQuery = (query) => {
+  if (!query || typeof query !== "string") return "";
+  return query.trim().replace(/[<>'"&;(){}]/g, "").replace(/\s+/g, " ").substring(0, 100);
+};
+var validateTextLength = (text, minLength, maxLength) => {
+  if (!text || typeof text !== "string") {
+    return { isValid: false, message: "Text is required" };
+  }
+  const trimmed = text.trim();
+  if (trimmed.length < minLength) {
+    return { isValid: false, message: `Text must be at least ${minLength} characters long` };
+  }
+  if (trimmed.length > maxLength) {
+    return { isValid: false, message: `Text must be less than ${maxLength} characters long` };
+  }
+  return { isValid: true };
+};
+var isValidUrl = (url) => {
+  if (!url || typeof url !== "string") return false;
+  try {
+    const urlObj = new URL(url);
+    if (!["http:", "https:"].includes(urlObj.protocol)) {
+      return false;
+    }
+    const hostname = urlObj.hostname.toLowerCase();
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname.startsWith("192.168.") || hostname.startsWith("10.") || hostname.startsWith("172.")) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+var isRateLimited = (key, maxAttempts, windowMs) => {
+  if (typeof window === "undefined") return false;
+  const now = Date.now();
+  const storageKey = `rate_limit_${key}`;
+  const stored = localStorage.getItem(storageKey);
+  if (!stored) {
+    localStorage.setItem(storageKey, JSON.stringify({ count: 1, firstAttempt: now }));
+    return false;
+  }
+  try {
+    const data = JSON.parse(stored);
+    if (now - data.firstAttempt > windowMs) {
+      localStorage.setItem(storageKey, JSON.stringify({ count: 1, firstAttempt: now }));
+      return false;
+    }
+    if (data.count >= maxAttempts) {
+      return true;
+    }
+    data.count++;
+    localStorage.setItem(storageKey, JSON.stringify(data));
+    return false;
+  } catch {
+    localStorage.setItem(storageKey, JSON.stringify({ count: 1, firstAttempt: now }));
+    return false;
+  }
+};
+var validateCSP = (content) => {
+  const dangerousPatterns = [
+    /<script/i,
+    /javascript:/i,
+    /on\w+\s*=/i,
+    /<iframe/i,
+    /<object/i,
+    /<embed/i,
+    /data:text\/html/i
+  ];
+  return !dangerousPatterns.some((pattern) => pattern.test(content));
+};
+export {
+  encodeHTML,
+  isRateLimited,
+  isValidUrl,
+  sanitizeHTML,
+  sanitizeInput,
+  sanitizeSearchQuery,
+  validateCSP,
+  validateEmail,
+  validatePassword,
+  validateTextLength,
+  validateUsername
+};


### PR DESCRIPTION
## Summary
- add compiled server-side utilities for security helpers
- expose SECURITY_CONFIG constant for server use
- provide HTML and input sanitization functions in server-utils

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6251339388320a8e665301a8819d6