### PR TITLE
chore: restore SPA entry and regenerate server utils

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,74 +161,9 @@
     
     <!-- Preload critical resources -->
     <link rel="preload" href="/lovable-uploads/sahadhyayi-logo-digital-reading.png" as="image" type="image/png" />
-    <style>
-      #loader {
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        width: 40px;
-        height: 40px;
-        border: 4px solid #555;
-        border-top: 4px solid #ffffff;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-        z-index: 9999;
-      }
-      @keyframes spin {
-        to {
-          transform: rotate(360deg);
-        }
-      }
-    </style>
   </head>
 
   <body>
-    <div id="loader"></div>
-    <script>
-      // Support GitHub Pages-style SPA redirects (?p=/path)
-      const params = new URLSearchParams(window.location.search);
-      const p = params.get('p');
-      if (p) {
-        try {
-          const target = decodeURIComponent(p);
-          history.replaceState(null, '', target);
-        } catch {}
-      }
-
-      // Legacy sessionStorage-based redirect support
-      const redirectPath = sessionStorage.redirectPath;
-      if (redirectPath) {
-        sessionStorage.removeItem('redirectPath');
-        history.replaceState(null, '', redirectPath);
-      }
-
-      // Hide the loader as soon as the DOM is ready
-      const hideLoader = () => {
-        const loader = document.getElementById('loader');
-        if (loader) {
-          loader.style.display = 'none';
-        }
-      };
-
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', hideLoader);
-      } else {
-        hideLoader();
-      }
-
-      // Fallback in case DOMContentLoaded doesn't fire
-      window.addEventListener('load', hideLoader);
-    </script>
-    <!-- Google Search Console verification -->
-    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
-    <header
-      id="static-content"
-      style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;"
-    >
-      <h1>Welcome to Sahadhyayi – Your Digital Book Club &amp; Library</h1>
-      <p>Join our digital reading community, connect with readers, and track your progress.</p>
-    </header>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -74,7 +74,7 @@
     <meta name="referrer" content="no-referrer" />
 
     <!-- CSP is normally set via HTTP headers in server.js. Meta is a fallback for static preview only. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval">
 
     <!-- Enhanced Structured Data -->
     <script type="application/ld+json">
@@ -161,82 +161,10 @@
     
     <!-- Preload critical resources -->
     <link rel="preload" href="/lovable-uploads/sahadhyayi-logo-digital-reading.png" as="image" type="image/png" />
-    <style>
-      #loader {
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        width: 40px;
-        height: 40px;
-        border: 4px solid #555;
-        border-top: 4px solid #ffffff;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-        z-index: 9999;
-      }
-      @keyframes spin {
-        to {
-          transform: rotate(360deg);
-        }
-      }
-    </style>
-    <script type="module" crossorigin src="/assets/index-CG3Ev_sc.js"></script>
-    <link rel="modulepreload" crossorigin href="/assets/vendor-CoLTHTps.js">
-    <link rel="modulepreload" crossorigin href="/assets/ui-staLczIk.js">
-    <link rel="modulepreload" crossorigin href="/assets/supabase-B7QlIavh.js">
-    <link rel="modulepreload" crossorigin href="/assets/query-DKFV86vZ.js">
-    <link rel="modulepreload" crossorigin href="/assets/router-CazxjJiZ.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-PajtKCTs.css">
   </head>
 
   <body>
-    <div id="loader"></div>
-    <header
-      id="static-content"
-      style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;"
-    >
-      <h1>Welcome to Sahadhyayi – Your Digital Book Club &amp; Library</h1>
-      <p>Join our digital reading community, connect with readers, and track your progress.</p>
-    </header>
     <div id="root"></div>
-    <script>
-      // Support GitHub Pages-style SPA redirects (?p=/path)
-      const params = new URLSearchParams(window.location.search);
-      const p = params.get('p');
-      if (p) {
-        try {
-          const target = decodeURIComponent(p);
-          history.replaceState(null, '', target);
-        } catch {}
-      }
-
-      // Legacy sessionStorage-based redirect support
-      const redirectPath = sessionStorage.redirectPath;
-      if (redirectPath) {
-        sessionStorage.removeItem('redirectPath');
-        history.replaceState(null, '', redirectPath);
-      }
-
-      // Hide the loader as soon as the DOM is ready
-      const hideLoader = () => {
-        const loader = document.getElementById('loader');
-        if (loader) {
-          loader.style.display = 'none';
-        }
-      };
-
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', hideLoader);
-      } else {
-        hideLoader();
-      }
-
-      // Fallback in case DOMContentLoaded doesn't fire
-      window.addEventListener('load', hideLoader);
-    </script>
-    <!-- Google Search Console verification -->
-    <!-- <meta name="google-site-verification" content="YOUR_VERIFICATION_CODE_HERE" /> -->
-    <script type="module" crossorigin src="/assets/index-CG3Ev_sc.js"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/server-utils/chatbotKnowledge.js
+++ b/server-utils/chatbotKnowledge.js
@@ -1,0 +1,197 @@
+// src/utils/chatbotKnowledge.ts
+var BOOK_CATEGORIES = [
+  {
+    name: "Fiction",
+    description: "Immerse yourself in captivating stories from classic and contemporary fiction",
+    popularBooks: ["Literary masterpieces", "Contemporary novels", "Short story collections", "Classic literature"],
+    keyAuthors: ["Renowned fiction writers", "Award-winning novelists"]
+  },
+  {
+    name: "Science",
+    description: "Explore the wonders of scientific discovery and technological innovation",
+    popularBooks: ["Physics explorations", "Biology research", "Technology guides", "Scientific breakthroughs"],
+    keyAuthors: ["Leading scientists", "Research pioneers"]
+  },
+  {
+    name: "Hindi Literature",
+    description: "Discover the rich tapestry of Hindi literature from classical to modern works",
+    popularBooks: ["Classical Hindi texts", "Modern Hindi novels", "Poetry collections", "Cultural narratives"],
+    keyAuthors: ["Distinguished Hindi authors", "Contemporary Hindi writers"]
+  },
+  {
+    name: "Devotional",
+    description: "Find spiritual guidance and inspiration through devotional texts",
+    popularBooks: ["Sacred scriptures", "Spiritual guides", "Devotional poetry", "Religious philosophy"],
+    keyAuthors: ["Spiritual teachers", "Religious scholars"]
+  },
+  {
+    name: "Biography",
+    description: "Learn from the life journeys of remarkable personalities",
+    popularBooks: ["Inspiring autobiographies", "Historical biographies", "Contemporary profiles", "Leadership stories"],
+    keyAuthors: ["Notable personalities", "Historical figures"]
+  },
+  {
+    name: "History",
+    description: "Journey through time with engaging historical accounts and cultural studies",
+    popularBooks: ["World history", "Cultural heritage", "Historical analysis", "Ancient civilizations"],
+    keyAuthors: ["Historians", "Cultural experts"]
+  }
+];
+var PLATFORM_FEATURES = [
+  {
+    name: "Digital Library",
+    route: "/library",
+    description: "Your gateway to 10,000+ books with powerful search and discovery tools",
+    keyFunctions: [
+      "Advanced search by title, author, genre, or keywords",
+      "Smart filtering by language, publication year, and category",
+      "Free PDF downloads for all books",
+      "Detailed book pages with descriptions and author bios",
+      "Personal bookshelf management with reading statuses"
+    ]
+  },
+  {
+    name: "Reading Dashboard",
+    route: "/dashboard",
+    description: "Your personal reading command center for tracking progress and goals",
+    keyFunctions: [
+      "Set and monitor personalized reading goals",
+      "Track reading progress with detailed statistics",
+      "Manage your bookshelf with multiple reading statuses",
+      "Get AI-powered book recommendations",
+      "View reading achievements and milestones"
+    ]
+  },
+  {
+    name: "Author Connection",
+    route: "/authors",
+    description: "Connect directly with authors and discover their literary worlds",
+    keyFunctions: [
+      "Explore comprehensive author profiles and biographies",
+      "Browse complete author book collections",
+      "Send direct messages to authors",
+      "Attend virtual author events and sessions",
+      "Follow favorite authors for latest updates"
+    ]
+  },
+  {
+    name: "Social Reading Community",
+    route: "/social",
+    description: "Join a vibrant community of book lovers and reading enthusiasts",
+    keyFunctions: [
+      "Connect with fellow readers and book enthusiasts",
+      "Share detailed book reviews and ratings",
+      "Join or create reading groups and book clubs",
+      "Participate in engaging book discussions",
+      "Discover books through social recommendations"
+    ]
+  },
+  {
+    name: "User Profile",
+    route: "/profile",
+    description: "Customize your reading experience and manage your account",
+    keyFunctions: [
+      "Set reading preferences and favorite genres",
+      "Manage privacy and notification settings",
+      "View comprehensive reading history and statistics",
+      "Connect social media accounts for sharing",
+      "Customize your reading goals and targets"
+    ]
+  }
+];
+var RESPONSE_PATTERNS = {
+  bookSearch: [
+    "Let me help you find the perfect book! What genre or topic interests you most?",
+    "I'd love to help you discover your next great read! Are you looking for something specific?",
+    "Book discovery time! Tell me about your reading preferences - fiction, non-fiction, or something specific?"
+  ],
+  genreExploration: [
+    "Excellent choice! That genre has some fantastic options in our library.",
+    "Great selection! We have an amazing collection in that category.",
+    "Perfect! That's one of our most popular genres with incredible variety."
+  ],
+  featureGuidance: [
+    "I'll guide you through that feature step by step!",
+    "Let me show you how to make the most of that section!",
+    "That's a powerful feature - here's how to use it effectively:"
+  ],
+  encouragement: [
+    "That sounds like a great reading journey ahead!",
+    "Wonderful! You're going to love exploring that.",
+    "Excellent choice! I think you'll find exactly what you're looking for."
+  ],
+  bookRecommendations: [
+    "Based on your interest, I'd recommend exploring our {genre} section. We have some incredible titles that might capture your attention!",
+    "That's a fascinating topic! Our library has several books that dive deep into {topic}. Would you like me to suggest some specific titles?",
+    "Great question! For {topic}, I'd suggest checking out our curated collection. You can find them by visiting our Library and filtering by genre."
+  ],
+  generalHelp: [
+    "I'm here to help you make the most of Sahadhyayi! Whether you're looking for your next great read, want to track your reading progress, or connect with our amazing community of readers, I can guide you.",
+    "Let's explore what Sahadhyayi has to offer together! From discovering new books to connecting with authors and fellow readers, there's so much to explore.",
+    "Great to chat with you! I can help you navigate our extensive library, set up reading goals, find author connections, or join our reading community.",
+    "Welcome! I'm excited to help you discover everything Sahadhyayi offers. Whether it's finding the perfect book, tracking your reading journey, or connecting with other book lovers, I'm here to guide you."
+  ]
+};
+var generateContextualResponse = (userQuery) => {
+  const query = userQuery.toLowerCase();
+  console.log("Generating contextual response for query:", query);
+  if (query.includes("book") && (query.includes("find") || query.includes("search") || query.includes("looking for"))) {
+    const response = RESPONSE_PATTERNS.bookSearch[Math.floor(Math.random() * RESPONSE_PATTERNS.bookSearch.length)] + " You can explore our Library section with 10,000+ books across all genres, or tell me your preferences for personalized recommendations!";
+    console.log("Using book search response");
+    return response;
+  }
+  if (query.includes("recommend") || query.includes("suggest") || query.includes("what should i read")) {
+    console.log("Using recommendation response");
+    return "I'd love to recommend some great reads! What draws you in - compelling characters, fascinating facts, spiritual insights, or perhaps historical adventures? Our library spans Fiction, Science, Hindi Literature, Devotional texts, Biographies, and History. Visit our Library section to explore, or tell me more about your preferences!";
+  }
+  if (query.includes("track") && (query.includes("reading") || query.includes("progress"))) {
+    console.log("Using reading tracking response");
+    return "Your reading journey deserves proper tracking! In your Dashboard, you can set reading goals, monitor your progress through books, and see detailed statistics of your reading habits. Want help setting up your first reading goal?";
+  }
+  if (query.includes("author") && (query.includes("connect") || query.includes("contact") || query.includes("meet"))) {
+    console.log("Using author connection response");
+    return "Author connections are one of our unique features! You can browse author profiles, read their biographies, explore their complete works, and even send them direct messages. Some authors also host virtual sessions. Are you looking for a specific author?";
+  }
+  if (query.includes("community") || query.includes("social") || query.includes("friends") || query.includes("group")) {
+    console.log("Using community response");
+    return "Our reading community is incredibly active! You can join reading groups, share book reviews, connect with fellow readers, and discover books through social recommendations. It's like having a book club that never sleeps! Want to explore the social features?";
+  }
+  if (query.includes("download") || query.includes("pdf") || query.includes("free")) {
+    console.log("Using download response");
+    return "Absolutely! Every book in our library offers free PDF downloads - we believe knowledge should be accessible to everyone. Just visit any book's page and hit the download button. Looking for a specific book to download?";
+  }
+  if (query.includes("hindi") || query.includes("\u0939\u093F\u0902\u0926\u0940")) {
+    console.log("Using Hindi literature response");
+    return "Our Hindi Literature section is a treasure trove! From classical works to contemporary Hindi novels and poetry collections. We celebrate the rich tradition of Hindi literature. Any particular Hindi author or genre you're interested in?";
+  }
+  if (query.includes("about") && (query.includes("book") || query.includes("title"))) {
+    console.log("Using specific book response");
+    return "I'd be happy to help you learn about specific books! You can search for any book in our Library section, or tell me the title you're interested in and I'll help you find information about it, including summaries, author details, and reader reviews.";
+  }
+  const mentionedGenre = BOOK_CATEGORIES.find(
+    (category) => query.includes(category.name.toLowerCase()) || category.name.toLowerCase().includes(query.replace(/books?/g, "").trim())
+  );
+  if (mentionedGenre) {
+    const randomEncouragement = RESPONSE_PATTERNS.genreExploration[Math.floor(Math.random() * RESPONSE_PATTERNS.genreExploration.length)];
+    console.log("Using genre-specific response for:", mentionedGenre.name);
+    return `${randomEncouragement} ${mentionedGenre.description}. Our ${mentionedGenre.name} collection includes ${mentionedGenre.popularBooks.slice(0, 2).join(" and ")} among many others. Visit our Library and filter by "${mentionedGenre.name}" to explore everything we have!`;
+  }
+  const mentionedFeature = PLATFORM_FEATURES.find(
+    (feature) => query.includes(feature.name.toLowerCase()) || query.includes(feature.route.slice(1)) || feature.keyFunctions.some((func) => query.includes(func.toLowerCase().split(" ")[0]))
+  );
+  if (mentionedFeature) {
+    const randomGuidance = RESPONSE_PATTERNS.featureGuidance[Math.floor(Math.random() * RESPONSE_PATTERNS.featureGuidance.length)];
+    console.log("Using feature-specific response for:", mentionedFeature.name);
+    return `${randomGuidance} ${mentionedFeature.description}. Key features include ${mentionedFeature.keyFunctions.slice(0, 2).join(" and ")}. Head to ${mentionedFeature.route} to get started!`;
+  }
+  const helpfulResponses = RESPONSE_PATTERNS.generalHelp;
+  const randomResponse = helpfulResponses[Math.floor(Math.random() * helpfulResponses.length)];
+  console.log("Using general helpful response");
+  return randomResponse + " What interests you most - discovering new books, tracking your reading, or connecting with our community?";
+};
+export {
+  BOOK_CATEGORIES,
+  PLATFORM_FEATURES,
+  RESPONSE_PATTERNS,
+  generateContextualResponse
+};

--- a/server-utils/consoleOptimizer.js
+++ b/server-utils/consoleOptimizer.js
@@ -1,0 +1,42 @@
+// src/utils/consoleOptimizer.ts
+var logger = {
+  log: (...args) => {
+    if (import.meta.env.DEV) {
+      console.log(...args);
+    }
+  },
+  warn: (...args) => {
+    if (import.meta.env.DEV) {
+      console.warn(...args);
+    }
+  },
+  error: (...args) => {
+    console.error(...args);
+  },
+  info: (...args) => {
+    if (import.meta.env.DEV) {
+      console.info(...args);
+    }
+  },
+  debug: (...args) => {
+    if (import.meta.env.DEV) {
+      console.debug(...args);
+    }
+  }
+};
+var auditLogger = {
+  logUserAction: (userId, action, details) => {
+    if (import.meta.env.DEV) {
+      console.log(`[AUDIT] User ${userId} ${action}`, details ? `at ${(/* @__PURE__ */ new Date()).toISOString()}` : "", details || "");
+    }
+  },
+  logApiCall: (endpoint, method, status) => {
+    if (import.meta.env.DEV) {
+      console.log(`[API] ${method} ${endpoint}`, status ? `- ${status}` : "");
+    }
+  }
+};
+export {
+  auditLogger,
+  logger
+};

--- a/server-utils/enhancedChatbotKnowledge.js
+++ b/server-utils/enhancedChatbotKnowledge.js
@@ -1,0 +1,225 @@
+// src/integrations/supabase/client-universal.ts
+import { createClient } from "@supabase/supabase-js";
+var SUPABASE_URL = "https://rknxtatvlzunatpyqxro.supabase.co";
+var SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJrbnh0YXR2bHp1bmF0cHlxeHJvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MzI0MjUsImV4cCI6MjA2NTUwODQyNX0.NXIWEwm8NlvzHnxf55cgdsy1ljX2IbFKQL7OS8xlb-U";
+var supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: {
+    storage: typeof window !== "undefined" ? window.localStorage : void 0,
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    flowType: "pkce"
+  },
+  global: {
+    headers: {
+      "X-Client-Info": "sahadhyayi-app"
+    }
+  }
+});
+
+// src/utils/enhancedChatbotKnowledge.ts
+var getWebsiteContext = async () => {
+  try {
+    const { count: totalBooks } = await supabase.from("books_library").select("*", { count: "exact", head: true });
+    const { data: genreData } = await supabase.from("books_library").select("genre").not("genre", "is", null);
+    const genres = [...new Set(genreData == null ? void 0 : genreData.map((item) => item.genre).filter(Boolean))];
+    const { data: recentBooks } = await supabase.from("books_library").select("id, title, author, genre, description, language").order("created_at", { ascending: false }).limit(10);
+    return {
+      totalBooks: totalBooks || 0,
+      genres,
+      features: [
+        "Digital Library with 10,000+ books",
+        "Free PDF downloads",
+        "Reading progress tracking",
+        "Author connections",
+        "Social reading community",
+        "Book recommendations",
+        "Reading goals and statistics"
+      ],
+      recentBooks: recentBooks || []
+    };
+  } catch (error) {
+    console.error("Error fetching website context:", error);
+    return {
+      totalBooks: 1e4,
+      genres: ["Fiction", "Science", "Hindi Literature", "Devotional", "Biography", "History"],
+      features: ["Digital Library", "Free Downloads", "Progress Tracking", "Author Connections"],
+      recentBooks: []
+    };
+  }
+};
+var generateEnhancedPrompt = (userMessage, context) => {
+  const { totalBooks, genres, features, recentBooks } = context;
+  let prompt = "You are an AI assistant for the Sahadhyayi digital library. Use the website context to answer user questions.\n\n";
+  prompt += `Total books in library: ${totalBooks}.
+`;
+  if (genres.length > 0) {
+    prompt += `Available genres include: ${genres.join(", ")}.
+`;
+  }
+  if (features.length > 0) {
+    prompt += `Key features: ${features.join(", ")}.
+`;
+  }
+  if (recentBooks.length > 0) {
+    prompt += "Recent books:\n";
+    recentBooks.slice(0, 3).forEach((book) => {
+      prompt += `- "${book.title}" by ${book.author} (${book.genre})
+`;
+    });
+  }
+  prompt += `
+User query: ${userMessage}
+`;
+  prompt += "Provide a concise and helpful response referencing the context when relevant.";
+  return prompt;
+};
+var searchRelevantBooks = async (query, limit = 5) => {
+  try {
+    const { data, error } = await supabase.from("books_library").select("id, title, author, genre, description, language").or(`title.ilike.%${query}%,author.ilike.%${query}%,description.ilike.%${query}%,genre.ilike.%${query}%`).limit(limit);
+    if (error)
+      throw error;
+    return data || [];
+  } catch (error) {
+    console.error("Error searching books:", error);
+    return [];
+  }
+};
+var getBookSummaries = async (bookIds) => {
+  try {
+    const { data, error } = await supabase.from("book_summaries").select("content, book_id, books_library(title, author)").in("book_id", bookIds).limit(3);
+    if (error)
+      throw error;
+    return data || [];
+  } catch (error) {
+    console.error("Error fetching book summaries:", error);
+    return [];
+  }
+};
+var populateInitialTrainingData = async (userId) => {
+  const trainingData = [
+    {
+      prompt: JSON.stringify({
+        original_prompt: "What is Sahadhyayi?",
+        category: "platform_overview",
+        context: "website_knowledge",
+        metadata: {
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          platform: "sahadhyayi",
+          interaction_type: "knowledge_base"
+        }
+      }),
+      completion: "Sahadhyayi is a digital library platform with 10,000+ free books across Fiction, Science, Hindi Literature, Devotional, Biography, and History genres. You can download PDFs for free, track reading progress, and connect with authors and readers."
+    },
+    {
+      prompt: JSON.stringify({
+        original_prompt: "How do I find books?",
+        category: "book_discovery",
+        context: "website_knowledge",
+        metadata: {
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          platform: "sahadhyayi",
+          interaction_type: "navigation"
+        }
+      }),
+      completion: "Visit /library to browse our collection, use the search bar for specific titles/authors, or filter by genre. You can also get personalized recommendations based on your reading preferences."
+    },
+    {
+      prompt: JSON.stringify({
+        original_prompt: "What features does Sahadhyayi offer?",
+        category: "features",
+        context: "website_knowledge",
+        metadata: {
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          platform: "sahadhyayi",
+          interaction_type: "features"
+        }
+      }),
+      completion: "Key features include: free PDF downloads, reading progress tracking (/dashboard), author connections (/authors), social reading community (/social), book recommendations, and reading goals. All books are completely free to access."
+    },
+    {
+      prompt: JSON.stringify({
+        original_prompt: "How do I download books?",
+        category: "download_process",
+        context: "website_knowledge",
+        metadata: {
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          platform: "sahadhyayi",
+          interaction_type: "process"
+        }
+      }),
+      completion: "Find any book in our library, click on it to open the detail page, then click 'Download PDF'. All 10,000+ books are completely free to download with no registration required."
+    },
+    {
+      prompt: JSON.stringify({
+        original_prompt: "Tell me about Hindi literature",
+        category: "genre_specific",
+        context: "book_collection",
+        metadata: {
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          platform: "sahadhyayi",
+          interaction_type: "genre_inquiry"
+        }
+      }),
+      completion: "Our Hindi Literature collection includes classical and modern Hindi texts, poetry collections, and works by renowned Hindi authors. Browse the /library section and filter by 'Hindi Literature' to explore our extensive collection."
+    },
+    {
+      prompt: JSON.stringify({
+        original_prompt: "Can I track my reading progress?",
+        category: "progress_tracking",
+        context: "website_knowledge",
+        metadata: {
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          platform: "sahadhyayi",
+          interaction_type: "feature_inquiry"
+        }
+      }),
+      completion: "Yes! Visit your /dashboard to set reading goals, track progress, manage your bookshelf, and view detailed reading statistics. You can organize books by status: reading, completed, or want to read."
+    },
+    {
+      prompt: JSON.stringify({
+        original_prompt: "How do I connect with authors?",
+        category: "author_connection",
+        context: "website_knowledge",
+        metadata: {
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          platform: "sahadhyayi",
+          interaction_type: "social_feature"
+        }
+      }),
+      completion: "Visit /authors to browse author profiles, read their biographies, and connect with them directly. You can also attend virtual author events and join author-led reading discussions."
+    },
+    {
+      prompt: JSON.stringify({
+        original_prompt: "What genres are available?",
+        category: "genres",
+        context: "book_collection",
+        metadata: {
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          platform: "sahadhyayi",
+          interaction_type: "collection_inquiry"
+        }
+      }),
+      completion: "We offer 6 main genres: Fiction (novels, stories), Science (physics, biology, tech), Hindi Literature (classical, modern), Devotional (spiritual texts), Biography (life stories), and History (world, cultural heritage)."
+    }
+  ];
+  try {
+    for (const data of trainingData) {
+      await supabase.from("gemini_training_data").insert({
+        user_id: userId,
+        prompt: data.prompt,
+        completion: data.completion
+      });
+    }
+    console.log("Initial training data populated successfully");
+  } catch (error) {
+    console.error("Error populating training data:", error);
+  }
+};
+export {
+  generateEnhancedPrompt,
+  getBookSummaries,
+  getWebsiteContext,
+  populateInitialTrainingData,
+  searchRelevantBooks
+};

--- a/server-utils/errorHandler.js
+++ b/server-utils/errorHandler.js
@@ -1,0 +1,265 @@
+// src/hooks/use-toast.ts
+import { useState, useEffect } from "react";
+var TOAST_LIMIT = 1;
+var TOAST_REMOVE_DELAY = 1e6;
+var count = 0;
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER;
+  return count.toString();
+}
+var toastTimeouts = /* @__PURE__ */ new Map();
+var addToRemoveQueue = (toastId) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId
+    });
+  }, TOAST_REMOVE_DELAY);
+  toastTimeouts.set(toastId, timeout);
+};
+var reducer = (state, action) => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT)
+      };
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map(
+          (t) => t.id === action.toast.id ? { ...t, ...action.toast } : t
+        )
+      };
+    case "DISMISS_TOAST": {
+      const { toastId } = action;
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast2) => {
+          addToRemoveQueue(toast2.id);
+        });
+      }
+      return {
+        ...state,
+        toasts: state.toasts.map(
+          (t) => t.id === toastId || toastId === void 0 ? {
+            ...t,
+            open: false
+          } : t
+        )
+      };
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === void 0) {
+        return {
+          ...state,
+          toasts: []
+        };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId)
+      };
+  }
+};
+var listeners = [];
+var memoryState = { toasts: [] };
+function dispatch(action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => {
+    listener(memoryState);
+  });
+}
+function toast({ ...props }) {
+  const id = genId();
+  const update = (props2) => dispatch({
+    type: "UPDATE_TOAST",
+    toast: { ...props2, id }
+  });
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id });
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open)
+          dismiss();
+      }
+    }
+  });
+  return {
+    id,
+    dismiss,
+    update
+  };
+}
+
+// src/utils/errorHandler.ts
+var ErrorHandler = class _ErrorHandler {
+  static instance;
+  errorQueue = [];
+  maxErrors = 50;
+  isInitialized = false;
+  static getInstance() {
+    if (!_ErrorHandler.instance) {
+      _ErrorHandler.instance = new _ErrorHandler();
+    }
+    return _ErrorHandler.instance;
+  }
+  initialize() {
+    if (this.isInitialized || typeof window === "undefined")
+      return;
+    window.addEventListener("error", (event) => {
+      var _a, _b, _c, _d;
+      this.handleError({
+        message: ((_a = event.error) == null ? void 0 : _a.message) || event.message,
+        stack: (_b = event.error) == null ? void 0 : _b.stack,
+        type: "javascript",
+        context: this.createContext({
+          component: (_c = event.filename) == null ? void 0 : _c.split("/").pop()
+        }),
+        severity: this.determineSeverity(((_d = event.error) == null ? void 0 : _d.message) || event.message)
+      });
+    });
+    window.addEventListener("unhandledrejection", (event) => {
+      var _a, _b;
+      this.handleError({
+        message: ((_a = event.reason) == null ? void 0 : _a.message) || String(event.reason),
+        stack: (_b = event.reason) == null ? void 0 : _b.stack,
+        type: "promise",
+        context: this.createContext(),
+        severity: "high"
+      });
+    });
+    if ("navigator" in window && "onLine" in navigator) {
+      window.addEventListener("offline", () => {
+        this.handleError({
+          message: "Network connection lost",
+          type: "network",
+          context: this.createContext(),
+          severity: "medium"
+        });
+      });
+    }
+    this.isInitialized = true;
+  }
+  handleError(errorReport) {
+    this.errorQueue.push(errorReport);
+    if (this.errorQueue.length > this.maxErrors) {
+      this.errorQueue.shift();
+    }
+    if (import.meta.env.DEV) {
+      console.group(`\u{1F6A8} Runtime Error [${errorReport.severity}]`);
+      console.error("Message:", errorReport.message);
+      console.error("Type:", errorReport.type);
+      console.error("Context:", errorReport.context);
+      if (errorReport.stack) {
+        console.error("Stack:", errorReport.stack);
+      }
+      console.groupEnd();
+    }
+    this.showUserNotification(errorReport);
+    this.reportToService(errorReport);
+  }
+  createContext(additional = {}) {
+    return {
+      timestamp: Date.now(),
+      userAgent: navigator.userAgent,
+      route: window.location.pathname,
+      ...additional
+    };
+  }
+  determineSeverity(message) {
+    if (!message)
+      return "medium";
+    const criticalKeywords = ["chunk", "loading", "network", "fetch", "import"];
+    const highKeywords = ["undefined", "null", "cannot read", "permission"];
+    const lowerMessage = message.toLowerCase();
+    if (criticalKeywords.some((keyword) => lowerMessage.includes(keyword))) {
+      return "critical";
+    }
+    if (highKeywords.some((keyword) => lowerMessage.includes(keyword))) {
+      return "high";
+    }
+    return "medium";
+  }
+  showUserNotification(errorReport) {
+    const messages = {
+      critical: {
+        title: "Critical Error",
+        description: "Something went wrong. Please refresh the page."
+      },
+      high: {
+        title: "Error Occurred",
+        description: "An error occurred. Some features may not work properly."
+      },
+      medium: {
+        title: "Minor Issue",
+        description: "A minor issue was detected and has been logged."
+      },
+      low: {
+        title: "Info",
+        description: "A minor issue was detected."
+      }
+    };
+    const notification = messages[errorReport.severity];
+    if (errorReport.severity === "critical" || errorReport.severity === "high") {
+      toast({
+        title: notification.title,
+        description: notification.description,
+        variant: errorReport.severity === "critical" ? "destructive" : "default"
+      });
+    }
+  }
+  reportToService(errorReport) {
+    if (import.meta.env.PROD) {
+    }
+  }
+  // Method to manually report custom errors
+  reportCustomError(message, context, severity = "medium") {
+    this.handleError({
+      message,
+      type: "custom",
+      context: this.createContext(context),
+      severity
+    });
+  }
+  // Get error statistics for debugging
+  getErrorStats() {
+    const stats = this.errorQueue.reduce((acc, error) => {
+      acc[error.type] = (acc[error.type] || 0) + 1;
+      acc[`severity_${error.severity}`] = (acc[`severity_${error.severity}`] || 0) + 1;
+      return acc;
+    }, {});
+    return {
+      totalErrors: this.errorQueue.length,
+      stats,
+      recentErrors: this.errorQueue.slice(-5)
+    };
+  }
+  // Clear error queue
+  clearErrors() {
+    this.errorQueue = [];
+  }
+};
+var errorHandler = ErrorHandler.getInstance();
+var useErrorHandler = () => {
+  return {
+    reportError: (message, context, severity = "medium") => {
+      errorHandler.reportCustomError(message, context, severity);
+    },
+    getErrorStats: () => errorHandler.getErrorStats(),
+    clearErrors: () => errorHandler.clearErrors()
+  };
+};
+export {
+  errorHandler,
+  useErrorHandler
+};

--- a/server-utils/libgenApi.js
+++ b/server-utils/libgenApi.js
@@ -1,0 +1,91 @@
+// src/security/useSecureApi.ts
+import { useCallback } from "react";
+var CSRF_KEY = "csrfToken";
+function getCsrfToken() {
+  if (typeof window === "undefined")
+    return "";
+  try {
+    return localStorage.getItem(CSRF_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+function setCsrfToken(token) {
+  if (typeof window === "undefined")
+    return;
+  try {
+    if (!token)
+      localStorage.removeItem(CSRF_KEY);
+    else
+      localStorage.setItem(CSRF_KEY, token);
+  } catch {
+  }
+}
+
+// src/security/sessionClient.ts
+async function sessionClientLogin() {
+  const res = await fetch("/api/session", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: "{}"
+  });
+  if (!res.ok)
+    throw new Error(`/api/session failed: ${res.status}`);
+  const data = await res.json().catch(() => ({}));
+  if (!(data == null ? void 0 : data.csrfToken))
+    throw new Error("No csrfToken in /api/session response");
+  setCsrfToken(data.csrfToken);
+  return data.csrfToken;
+}
+
+// src/security/secureFetch.ts
+async function secureFetch(input, init = {}) {
+  let res = await doFetch(input, init);
+  res = await maybePersistRotatedCsrfAndReturn(res);
+  if (res.status === 401 || res.status === 403) {
+    try {
+      await sessionClientLogin();
+      const res2 = await doFetch(input, init);
+      return maybePersistRotatedCsrfAndReturn(res2);
+    } catch {
+      return res;
+    }
+  }
+  return res;
+}
+async function doFetch(input, init) {
+  const headers = new Headers(init.headers || {});
+  const csrf = getCsrfToken();
+  if (csrf)
+    headers.set("X-CSRF-Token", csrf);
+  return fetch(input, {
+    ...init,
+    headers,
+    credentials: "include"
+  });
+}
+async function maybePersistRotatedCsrfAndReturn(res) {
+  const newToken = res.headers.get("X-New-CSRF-Token");
+  if (newToken)
+    setCsrfToken(newToken);
+  return res;
+}
+
+// src/utils/libgenApi.ts
+async function searchLibgen(query) {
+  try {
+    const res = await secureFetch(`/api/libgen?q=${encodeURIComponent(query)}`);
+    return await res.json();
+  } catch (error) {
+    console.error("Error searching Libgen:", error);
+    return {
+      success: false,
+      books: [],
+      error: error instanceof Error ? error.message : "Failed to search Libgen"
+    };
+  }
+}
+export {
+  searchLibgen
+};

--- a/server-utils/libraryApiHelpers.js
+++ b/server-utils/libraryApiHelpers.js
@@ -1,0 +1,71 @@
+// src/utils/libraryApiHelpers.ts
+var constructImageUrl = (volumeInfo) => {
+  if (!(volumeInfo == null ? void 0 : volumeInfo.imageLinks))
+    return void 0;
+  const imageLinks = volumeInfo.imageLinks;
+  if (imageLinks.extraLarge)
+    return imageLinks.extraLarge;
+  if (imageLinks.large)
+    return imageLinks.large;
+  if (imageLinks.medium)
+    return imageLinks.medium;
+  if (imageLinks.small)
+    return imageLinks.small;
+  if (imageLinks.thumbnail)
+    return imageLinks.thumbnail;
+  if (imageLinks.smallThumbnail)
+    return imageLinks.smallThumbnail;
+  return void 0;
+};
+var cleanGoogleBooksData = (item) => {
+  var _a, _b, _c, _d;
+  const volumeInfo = item.volumeInfo || {};
+  return {
+    id: item.id || "",
+    title: volumeInfo.title || "Unknown Title",
+    author: ((_a = volumeInfo.authors) == null ? void 0 : _a.join(", ")) || "Unknown Author",
+    description: volumeInfo.description || "",
+    imageUrl: constructImageUrl(volumeInfo),
+    source: "google_books",
+    isbn: ((_c = (_b = volumeInfo.industryIdentifiers) == null ? void 0 : _b[0]) == null ? void 0 : _c.identifier) || "",
+    publishedDate: volumeInfo.publishedDate || "",
+    pageCount: volumeInfo.pageCount || 0,
+    language: volumeInfo.language || "en",
+    genre: ((_d = volumeInfo.categories) == null ? void 0 : _d[0]) || "General"
+  };
+};
+var cleanInternetArchiveData = (item) => {
+  var _a, _b, _c;
+  return {
+    id: item.identifier || "",
+    title: item.title || "Unknown Title",
+    author: ((_a = item.creator) == null ? void 0 : _a.join(", ")) || "Unknown Author",
+    description: item.description || "",
+    imageUrl: item.identifier ? `https://archive.org/services/img/${item.identifier}` : void 0,
+    source: "internet_archive",
+    publishedDate: item.date || "",
+    pageCount: 0,
+    language: ((_b = item.language) == null ? void 0 : _b[0]) || "en",
+    genre: ((_c = item.subject) == null ? void 0 : _c[0]) || "General"
+  };
+};
+var prepareBookForLibrary = (bookData) => {
+  return {
+    title: bookData.title,
+    author: bookData.author,
+    description: bookData.description,
+    cover_image_url: bookData.imageUrl,
+    isbn: bookData.isbn,
+    publication_year: bookData.publishedDate ? parseInt(bookData.publishedDate.split("-")[0]) : void 0,
+    pages: bookData.pageCount,
+    language: bookData.language,
+    genre: bookData.genre,
+    source: bookData.source
+  };
+};
+export {
+  cleanGoogleBooksData,
+  cleanInternetArchiveData,
+  constructImageUrl,
+  prepareBookForLibrary
+};

--- a/server-utils/navigation.js
+++ b/server-utils/navigation.js
@@ -1,0 +1,7 @@
+// src/utils/navigation.ts
+function redirectToUserHome(navigate) {
+  navigate("/dashboard", { replace: true });
+}
+export {
+  redirectToUserHome
+};

--- a/server-utils/schema.js
+++ b/server-utils/schema.js
@@ -1,0 +1,128 @@
+// src/utils/schema.ts
+var generateBookSchema = (book) => {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "Book",
+    "name": book.title,
+    "author": {
+      "@type": "Person",
+      "name": book.author
+    },
+    "description": book.description,
+    "url": book.url,
+    "bookFormat": "EBook",
+    "inLanguage": book.language || "en"
+  };
+  if (book.genre) {
+    schema.genre = book.genre;
+  }
+  if (book.isbn) {
+    schema.isbn = book.isbn;
+  }
+  if (book.publisher) {
+    schema.publisher = {
+      "@type": "Organization",
+      "name": book.publisher
+    };
+  }
+  if (book.publicationYear) {
+    schema.datePublished = book.publicationYear.toString();
+  }
+  if (book.pages) {
+    schema.numberOfPages = book.pages;
+  }
+  if (book.coverImage) {
+    schema.image = book.coverImage;
+  }
+  if (book.price && book.currency) {
+    schema.offers = {
+      "@type": "Offer",
+      "price": book.price.toString(),
+      "priceCurrency": book.currency,
+      "availability": "https://schema.org/InStock"
+    };
+  }
+  if (book.rating && book.ratingCount) {
+    schema.aggregateRating = {
+      "@type": "AggregateRating",
+      "ratingValue": book.rating.toString(),
+      "ratingCount": book.ratingCount.toString(),
+      "bestRating": "5",
+      "worstRating": "1"
+    };
+  }
+  return schema;
+};
+var generateAuthorSchema = (author) => {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": author.name,
+    "url": author.url,
+    "jobTitle": "Author"
+  };
+  if (author.bio) {
+    schema.description = author.bio;
+  }
+  if (author.image) {
+    schema.image = author.image;
+  }
+  if (author.sameAs && author.sameAs.length > 0) {
+    schema.sameAs = author.sameAs;
+  }
+  return schema;
+};
+var generateBreadcrumbSchema = (items) => {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": items.map((item, index) => ({
+      "@type": "ListItem",
+      "position": index + 1,
+      "name": item.name,
+      "item": item.url
+    }))
+  };
+};
+var generateWebsiteSchema = () => {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Sahadhyayi",
+    "alternateName": "Sahadhyayi Reading Community",
+    "url": "https://sahadhyayi.com",
+    "description": "Join Sahadhyayi's vibrant reading community. Discover books, connect with readers, and explore our digital library.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://sahadhyayi.com/library?search={search_term_string}",
+      "query-input": "required name=search_term_string"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Sahadhyayi",
+      "url": "https://sahadhyayi.com",
+      "logo": "https://sahadhyayi.com/lovable-uploads/sahadhyayi-logo-digital-reading.png"
+    }
+  };
+};
+var generateOrganizationSchema = () => {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Sahadhyayi",
+    "url": "https://sahadhyayi.com",
+    "logo": "https://sahadhyayi.com/lovable-uploads/sahadhyayi-logo-digital-reading.png",
+    "description": "Digital reading community platform connecting readers and authors worldwide",
+    "foundingDate": "2024",
+    "sameAs": [
+      "https://sahadhyayi.com/about"
+    ]
+  };
+};
+export {
+  generateAuthorSchema,
+  generateBookSchema,
+  generateBreadcrumbSchema,
+  generateOrganizationSchema,
+  generateWebsiteSchema
+};

--- a/server-utils/searchExternalSources.js
+++ b/server-utils/searchExternalSources.js
@@ -1,0 +1,47 @@
+// src/integrations/supabase/client.ts
+import { createClient } from "@supabase/supabase-js";
+var SUPABASE_URL = "https://rknxtatvlzunatpyqxro.supabase.co";
+var SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJrbnh0YXR2bHp1bmF0cHlxeHJvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MzI0MjUsImV4cCI6MjA2NTUwODQyNX0.NXIWEwm8NlvzHnxf55cgdsy1ljX2IbFKQL7OS8xlb-U";
+var supabase = createClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
+  auth: {
+    storage: typeof window !== "undefined" ? localStorage : void 0,
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    flowType: "pkce"
+  },
+  global: {
+    headers: {
+      "X-Client-Info": "sahadhyayi-app"
+    }
+  }
+});
+
+// src/utils/searchExternalSources.ts
+async function searchExternalSources(query) {
+  try {
+    const { data, error } = await supabase.functions.invoke("search-books-preview", {
+      body: { searchTerm: query }
+    });
+    if (error)
+      throw error;
+    return ((data == null ? void 0 : data.books) || []).filter((book) => book.pdf_url).map((book) => ({
+      id: book.isbn || book.title,
+      title: book.title || "Unknown Title",
+      author: book.author,
+      year: book.publication_year ? String(book.publication_year) : void 0,
+      language: book.language,
+      extension: book.pdf_url ? "pdf" : void 0,
+      size: book.pages ? `${book.pages} pages` : void 0,
+      md5: book.isbn || book.title,
+      downloadUrl: book.pdf_url,
+      source: "open_access"
+    }));
+  } catch (err) {
+    console.error("searchExternalSources error:", err);
+    return [];
+  }
+}
+export {
+  searchExternalSources
+};

--- a/server-utils/security.js
+++ b/server-utils/security.js
@@ -1,56 +1,81 @@
-export const generateCSRFToken = () => {
+// src/utils/security.ts
+var generateCSRFToken = () => {
   const arr = new Uint8Array(32);
   crypto.getRandomValues(arr);
-  return btoa(String.fromCharCode(...arr)).replace(/=/g, '');
+  return btoa(String.fromCharCode(...arr)).replace(/=/g, "");
 };
-
-export const setCSRFToken = (token) => {
-  if (typeof window === 'undefined') return;
+var setCSRFToken = (token) => {
+  if (typeof window === "undefined")
+    return;
   if (!token) {
-    sessionStorage.removeItem('csrfToken');
-    document.cookie = 'csrfToken=; Path=/; Max-Age=0; SameSite=Strict; Secure';
+    sessionStorage.removeItem("csrfToken");
+    document.cookie = "csrfToken=; Path=/; Max-Age=0; SameSite=Strict; Secure";
   } else {
-    sessionStorage.setItem('csrfToken', token);
+    sessionStorage.setItem("csrfToken", token);
     document.cookie = `csrfToken=${token}; Path=/; SameSite=Strict; Secure`;
   }
 };
-
-export const getCSRFToken = () => {
-  if (typeof window === 'undefined') return null;
-  const s = sessionStorage.getItem('csrfToken');
-  if (s) return s;
+var getCSRFToken = () => {
+  if (typeof window === "undefined")
+    return null;
+  const s = sessionStorage.getItem("csrfToken");
+  if (s)
+    return s;
   const m = document.cookie.match(/(?:^|;\s*)csrfToken=([^;]+)/);
   return m ? decodeURIComponent(m[1]) : null;
 };
-
-export const clearCSRFToken = () => setCSRFToken(null);
-
-export const validateFileUpload = (file, allowedTypes = [], maxSize = 5 * 1024 * 1024) => {
-  if (!file) return { valid: false, error: 'No file provided' };
-  if (file.size > maxSize) return { valid: false, error: `File size exceeds ${Math.round(maxSize / (1024 * 1024))}MB limit` };
-  if (allowedTypes.length && !allowedTypes.includes(file.type)) return { valid: false, error: 'File type not allowed' };
+var clearCSRFToken = () => setCSRFToken(null);
+var validateFileUpload = (file, allowedTypes = [], maxSize = 5 * 1024 * 1024) => {
+  var _a;
+  if (!file)
+    return { valid: false, error: "No file provided" };
+  if (file.size > maxSize)
+    return { valid: false, error: `File size exceeds ${Math.round(maxSize / (1024 * 1024))}MB limit` };
+  if (allowedTypes.length && !allowedTypes.includes(file.type))
+    return { valid: false, error: "File type not allowed" };
   try {
-    const ext = file.name.split('.').pop()?.toLowerCase();
+    const ext = (_a = file.name.split(".").pop()) == null ? void 0 : _a.toLowerCase();
     const map = {
-      'image/jpeg': ['jpg', 'jpeg'],
-      'image/png': ['png'],
-      'image/gif': ['gif'],
-      'image/webp': ['webp'],
-      'application/pdf': ['pdf'],
-      'text/plain': ['txt'],
-      'application/json': ['json'],
+      "image/jpeg": ["jpg", "jpeg"],
+      "image/png": ["png"],
+      "image/gif": ["gif"],
+      "image/webp": ["webp"],
+      "application/pdf": ["pdf"],
+      "text/plain": ["txt"],
+      "application/json": ["json"]
     };
     const expected = map[file.type];
-    if (expected && ext && !expected.includes(ext)) return { valid: false, error: 'File extension does not match content type' };
-  } catch {}
+    if (expected && ext && !expected.includes(ext))
+      return { valid: false, error: "File extension does not match content type" };
+  } catch {
+  }
   return { valid: true };
 };
-
-export const createSecureHeaders = (includeCSRF = true) => {
-  const headers = { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' };
+var createSecureHeaders = (includeCSRF = true) => {
+  const headers = { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" };
   if (includeCSRF) {
     const token = getCSRFToken();
-    if (token) headers['X-CSRF-Token'] = token;
+    if (token)
+      headers["X-CSRF-Token"] = token;
   }
   return headers;
+};
+var initializeSecureSession = () => {
+  if (typeof window === "undefined")
+    return;
+  if (!getCSRFToken())
+    setCSRFToken(generateCSRFToken());
+};
+var initializeSecurity = () => {
+  initializeSecureSession();
+};
+export {
+  clearCSRFToken,
+  createSecureHeaders,
+  generateCSRFToken,
+  getCSRFToken,
+  initializeSecureSession,
+  initializeSecurity,
+  setCSRFToken,
+  validateFileUpload
 };

--- a/server-utils/securityConfig.js
+++ b/server-utils/securityConfig.js
@@ -1,34 +1,41 @@
-export const SECURITY_CONFIG = {
+// src/utils/securityConfig.ts
+var SECURITY_CONFIG = {
+  // Rate limiting configurations
   RATE_LIMITS: {
-    SIGNIN: { attempts: 5, windowMs: 300000 },
-    SIGNUP: { attempts: 3, windowMs: 600000 },
-    SEARCH: { attempts: 10, windowMs: 60000 },
-    COMMENT: { attempts: 20, windowMs: 300000 },
-    PROFILE_UPDATE: { attempts: 5, windowMs: 300000 },
+    SIGNIN: { attempts: 5, windowMs: 3e5 },
+    // 5 attempts per 5 minutes
+    SIGNUP: { attempts: 3, windowMs: 6e5 },
+    // 3 attempts per 10 minutes
+    SEARCH: { attempts: 10, windowMs: 6e4 },
+    // 10 searches per minute
+    COMMENT: { attempts: 20, windowMs: 3e5 },
+    // 20 comments per 5 minutes
+    PROFILE_UPDATE: { attempts: 5, windowMs: 3e5 }
+    // 5 updates per 5 minutes
   },
-
+  // Content Security Policy
   CSP: {
-    'default-src': ["'self'"],
-    'script-src': [
+    "default-src": ["'self'"],
+    "script-src": [
       "'self'",
       "'unsafe-inline'",
       "'unsafe-eval'",
-      'blob:',
-      'https://maps.googleapis.com',
-      'https://static.cloudflareinsights.com',
+      "blob:",
+      "https://maps.googleapis.com",
+      "https://static.cloudflareinsights.com"
     ],
-    'style-src': [
+    "style-src": [
       "'self'",
       "'unsafe-inline'",
-      'https://fonts.googleapis.com',
+      "https://fonts.googleapis.com"
     ],
-    'img-src': ["'self'", 'data:', 'blob:', 'https:'],
-    'font-src': ["'self'", 'https://fonts.gstatic.com'],
-    'connect-src': ["'self'", 'https://*.supabase.co', 'wss:'],
-    'frame-src': ["'self'"],
-    'report-uri': ['/csp-report']
+    "img-src": ["'self'", "data:", "blob:", "https:"],
+    "font-src": ["'self'", "https://fonts.gstatic.com"],
+    "connect-src": ["'self'", "https://*.supabase.co", "wss:"],
+    "frame-src": ["'self'"],
+    "report-uri": ["/csp-report"]
   },
-
+  // Input validation limits
   VALIDATION: {
     EMAIL_MAX_LENGTH: 254,
     PASSWORD_MIN_LENGTH: 8,
@@ -36,34 +43,147 @@ export const SECURITY_CONFIG = {
     NAME_MAX_LENGTH: 100,
     USERNAME_MAX_LENGTH: 30,
     SEARCH_QUERY_MAX_LENGTH: 100,
-    COMMENT_MAX_LENGTH: 1000,
-    DESCRIPTION_MAX_LENGTH: 2000,
+    COMMENT_MAX_LENGTH: 1e3,
+    DESCRIPTION_MAX_LENGTH: 2e3
   },
-
+  // File upload restrictions
   FILE_UPLOAD: {
-    ALLOWED_IMAGE_TYPES: ['image/png', 'image/jpeg', 'image/webp'],
+    ALLOWED_IMAGE_TYPES: ["image/png", "image/jpeg", "image/webp"],
     MAX_SIZE: 5 * 1024 * 1024
+    // 5MB
   },
-
+  // Session security
   SESSION: {
-    MAX_AGE: 24 * 60 * 60 * 1000,
-    INACTIVITY_TIMEOUT: 2 * 60 * 60 * 1000,
-    RENEWAL_THRESHOLD: 30 * 60 * 1000,
+    MAX_AGE: 24 * 60 * 60 * 1e3,
+    // 24 hours
+    INACTIVITY_TIMEOUT: 2 * 60 * 60 * 1e3,
+    // 2 hours
+    RENEWAL_THRESHOLD: 30 * 60 * 1e3
+    // 30 minutes
   },
-
+  // Trusted domains for external links
   TRUSTED_DOMAINS: [
-    'self',
-    '*.supabase.co',
-    'maps.googleapis.com',
-    'fonts.googleapis.com',
-    'fonts.gstatic.com'
+    "self",
+    "*.supabase.co",
+    "maps.googleapis.com",
+    "fonts.googleapis.com",
+    "fonts.gstatic.com"
   ],
-
+  // Security headers
   SECURITY_HEADERS: {
-    'X-Content-Type-Options': 'nosniff',
-    'X-Frame-Options': 'SAMEORIGIN',
-    'X-XSS-Protection': '1; mode=block',
-    'Referrer-Policy': 'strict-origin-when-cross-origin',
-    'Permissions-Policy': 'camera=(), microphone=(), geolocation=(self)',
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-XSS-Protection": "1; mode=block",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=(self)"
   }
+};
+var SecurityMiddleware = class {
+  static validateOrigin(origin) {
+    if (!origin)
+      return false;
+    try {
+      const url = new URL(origin);
+      return SECURITY_CONFIG.TRUSTED_DOMAINS.includes(url.hostname);
+    } catch {
+      return false;
+    }
+  }
+  static sanitizeUserAgent(userAgent) {
+    if (!userAgent || typeof userAgent !== "string")
+      return "Unknown";
+    return userAgent.replace(/[<>'"&]/g, "").substring(0, 200);
+  }
+  static validateReferer(referer) {
+    if (!referer)
+      return true;
+    try {
+      const url = new URL(referer);
+      return SECURITY_CONFIG.TRUSTED_DOMAINS.includes(url.hostname) || url.hostname === window.location.hostname;
+    } catch {
+      return false;
+    }
+  }
+  static createSecureRequestOptions(includeCredentials = true) {
+    const options = {
+      headers: {
+        "Content-Type": "application/json",
+        "X-Requested-With": "XMLHttpRequest",
+        ...SECURITY_CONFIG.SECURITY_HEADERS
+      }
+    };
+    if (includeCredentials) {
+      options.credentials = "same-origin";
+    }
+    return options;
+  }
+  static logSecurityViolation(violation, details = {}) {
+    const event = {
+      type: "SECURITY_VIOLATION",
+      violation,
+      details,
+      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+      userAgent: navigator.userAgent,
+      url: window.location.href,
+      referer: document.referrer
+    };
+    console.warn("[SECURITY]", event);
+    if (import.meta.env.PROD) {
+    }
+  }
+};
+var SecurityMonitor = class {
+  static events = [];
+  static MAX_EVENTS = 100;
+  static recordEvent(event, data = {}) {
+    const record = {
+      event,
+      data,
+      timestamp: Date.now(),
+      url: window.location.href
+    };
+    this.events.push(record);
+    if (this.events.length > this.MAX_EVENTS) {
+      this.events = this.events.slice(-this.MAX_EVENTS);
+    }
+    this.detectAnomalies();
+  }
+  static detectAnomalies() {
+    const recentEvents = this.events.filter(
+      (e) => Date.now() - e.timestamp < 6e4
+      // Last minute
+    );
+    if (recentEvents.length > 20) {
+      SecurityMiddleware.logSecurityViolation("RAPID_REQUESTS", {
+        count: recentEvents.length,
+        timeframe: "1_minute"
+      });
+    }
+    const failedLogins = recentEvents.filter(
+      (e) => e.event === "LOGIN_FAILED"
+    ).length;
+    if (failedLogins > 3) {
+      SecurityMiddleware.logSecurityViolation("MULTIPLE_LOGIN_FAILURES", {
+        count: failedLogins,
+        timeframe: "1_minute"
+      });
+    }
+  }
+  static getSecuritySummary() {
+    return {
+      totalEvents: this.events.length,
+      recentEvents: this.events.filter(
+        (e) => Date.now() - e.timestamp < 3e5
+        // Last 5 minutes
+      ).length,
+      eventTypes: [...new Set(this.events.map((e) => e.event))]
+    };
+  }
+};
+var securityConfig_default = SECURITY_CONFIG;
+export {
+  SECURITY_CONFIG,
+  SecurityMiddleware,
+  SecurityMonitor,
+  securityConfig_default as default
 };

--- a/server-utils/slugify.js
+++ b/server-utils/slugify.js
@@ -1,0 +1,7 @@
+// src/utils/slugify.ts
+var slugify = (text) => {
+  return text.toLowerCase().trim().replace(/[\s\W&&[^\u0900-\u097F\u00C0-\u024F\u1E00-\u1EFF]]+/g, "-").replace(/^-+|-+$/g, "") || text.replace(/\s+/g, "-").toLowerCase();
+};
+export {
+  slugify
+};

--- a/server-utils/trustAndSafety.js
+++ b/server-utils/trustAndSafety.js
@@ -1,0 +1,14 @@
+// src/utils/trustAndSafety.ts
+var bannedWords = [
+  "badword1",
+  "badword2",
+  "badword3"
+];
+var containsInappropriateLanguage = (text) => {
+  const lower = text.toLowerCase();
+  return bannedWords.some((w) => lower.includes(w));
+};
+export {
+  bannedWords,
+  containsInappropriateLanguage
+};

--- a/server-utils/validation.js
+++ b/server-utils/validation.js
@@ -1,37 +1,191 @@
-const encodeHTML = (str) => {
+// src/utils/validation.ts
+var encodeHTML = (str) => {
   const entityMap = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-    '/': '&#x2F;',
-    '`': '&#x60;',
-    '=': '&#x3D;'
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+    "/": "&#x2F;",
+    "`": "&#x60;",
+    "=": "&#x3D;"
   };
-  return String(str).replace(/[&<>"'`=/]/g, s => entityMap[s]);
+  return String(str).replace(/[&<>"'`=/]/g, (s) => entityMap[s]);
 };
-
-export const sanitizeHTML = (dirty) => {
-  let clean = dirty.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
-  clean = clean.replace(/javascript:/gi, '');
-  clean = clean.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, '');
-  clean = clean.replace(/\s*style\s*=\s*["'][^"']*["']/gi, '');
-  clean = clean.replace(/data:(?!image\/)[^;]+;/gi, '');
+var sanitizeHTML = (dirty) => {
+  let clean = dirty.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "");
+  clean = clean.replace(/javascript:/gi, "");
+  clean = clean.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, "");
+  clean = clean.replace(/\s*style\s*=\s*["'][^"']*["']/gi, "");
+  clean = clean.replace(/data:(?!image\/)[^;]+;/gi, "");
   return encodeHTML(clean);
 };
-
-export const sanitizeInput = (input, maxLength) => {
-  if (!input || typeof input !== 'string') return '';
-  let sanitized = input
-    .replace(/[<>]/g, '')
-    .replace(/javascript:/gi, '')
-    .replace(/on\w+\s*=/gi, '')
-    .replace(/data:(?!image\/)[^;]+;/gi, '')
-    .trim();
+var validateEmail = (email) => {
+  if (!email || typeof email !== "string")
+    return false;
+  const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  const trimmed = email.trim();
+  if (trimmed.length > 254)
+    return false;
+  if (trimmed.includes("..") || trimmed.startsWith(".") || trimmed.endsWith("."))
+    return false;
+  return emailRegex.test(trimmed);
+};
+var validatePassword = (password) => {
+  if (!password || typeof password !== "string") {
+    return { isValid: false, message: "Password is required" };
+  }
+  if (password.length < 8) {
+    return { isValid: false, message: "Password must be at least 8 characters long" };
+  }
+  if (password.length > 128) {
+    return { isValid: false, message: "Password must be less than 128 characters long" };
+  }
+  const hasUpperCase = /[A-Z]/.test(password);
+  const hasLowerCase = /[a-z]/.test(password);
+  const hasNumbers = /\d/.test(password);
+  const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+  if (!hasUpperCase || !hasLowerCase || !hasNumbers) {
+    return {
+      isValid: false,
+      message: "Password must contain at least one uppercase letter, one lowercase letter, and one number"
+    };
+  }
+  const weakPatterns = [
+    /(.)\1{2,}/,
+    // Repeated characters (aaa, 111)
+    /^(?:password|123456|qwerty|abc123|admin|user|guest|test)/i,
+    // Common passwords
+    /^\d+$/,
+    // Only numbers
+    /^[a-zA-Z]+$/
+    // Only letters
+  ];
+  for (const pattern of weakPatterns) {
+    if (pattern.test(password)) {
+      return { isValid: false, message: "Password is too weak. Avoid common patterns." };
+    }
+  }
+  return { isValid: true };
+};
+var validateUsername = (username) => {
+  if (!username || typeof username !== "string") {
+    return { isValid: false, message: "Username is required" };
+  }
+  const trimmed = username.trim();
+  if (trimmed.length < 3) {
+    return { isValid: false, message: "Username must be at least 3 characters long" };
+  }
+  if (trimmed.length > 30) {
+    return { isValid: false, message: "Username must be less than 30 characters long" };
+  }
+  const usernameRegex = /^[a-zA-Z0-9_-]+$/;
+  if (!usernameRegex.test(trimmed)) {
+    return {
+      isValid: false,
+      message: "Username can only contain letters, numbers, underscores, and hyphens"
+    };
+  }
+  const reservedNames = ["admin", "root", "user", "guest", "test", "api", "www", "mail", "ftp", "localhost", "system"];
+  if (reservedNames.includes(trimmed.toLowerCase())) {
+    return { isValid: false, message: "This username is reserved" };
+  }
+  return { isValid: true };
+};
+var sanitizeInput = (input, maxLength) => {
+  if (!input || typeof input !== "string")
+    return "";
+  let sanitized = input.replace(/[<>]/g, "").replace(/javascript:/gi, "").replace(/on\w+\s*=/gi, "").replace(/data:(?!image\/)[^;]+;/gi, "").trim();
   sanitized = encodeHTML(sanitized);
   if (maxLength && sanitized.length > maxLength) {
     sanitized = sanitized.substring(0, maxLength);
   }
   return sanitized;
+};
+var sanitizeSearchQuery = (query) => {
+  if (!query || typeof query !== "string")
+    return "";
+  return query.trim().replace(/[<>'"&;(){}]/g, "").replace(/\s+/g, " ").substring(0, 100);
+};
+var validateTextLength = (text, minLength, maxLength) => {
+  if (!text || typeof text !== "string") {
+    return { isValid: false, message: "Text is required" };
+  }
+  const trimmed = text.trim();
+  if (trimmed.length < minLength) {
+    return { isValid: false, message: `Text must be at least ${minLength} characters long` };
+  }
+  if (trimmed.length > maxLength) {
+    return { isValid: false, message: `Text must be less than ${maxLength} characters long` };
+  }
+  return { isValid: true };
+};
+var isValidUrl = (url) => {
+  if (!url || typeof url !== "string")
+    return false;
+  try {
+    const urlObj = new URL(url);
+    if (!["http:", "https:"].includes(urlObj.protocol)) {
+      return false;
+    }
+    const hostname = urlObj.hostname.toLowerCase();
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname.startsWith("192.168.") || hostname.startsWith("10.") || hostname.startsWith("172.")) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+var isRateLimited = (key, maxAttempts, windowMs) => {
+  if (typeof window === "undefined")
+    return false;
+  const now = Date.now();
+  const storageKey = `rate_limit_${key}`;
+  const stored = localStorage.getItem(storageKey);
+  if (!stored) {
+    localStorage.setItem(storageKey, JSON.stringify({ count: 1, firstAttempt: now }));
+    return false;
+  }
+  try {
+    const data = JSON.parse(stored);
+    if (now - data.firstAttempt > windowMs) {
+      localStorage.setItem(storageKey, JSON.stringify({ count: 1, firstAttempt: now }));
+      return false;
+    }
+    if (data.count >= maxAttempts) {
+      return true;
+    }
+    data.count++;
+    localStorage.setItem(storageKey, JSON.stringify(data));
+    return false;
+  } catch {
+    localStorage.setItem(storageKey, JSON.stringify({ count: 1, firstAttempt: now }));
+    return false;
+  }
+};
+var validateCSP = (content) => {
+  const dangerousPatterns = [
+    /<script/i,
+    /javascript:/i,
+    /on\w+\s*=/i,
+    /<iframe/i,
+    /<object/i,
+    /<embed/i,
+    /data:text\/html/i
+  ];
+  return !dangerousPatterns.some((pattern) => pattern.test(content));
+};
+export {
+  encodeHTML,
+  isRateLimited,
+  isValidUrl,
+  sanitizeHTML,
+  sanitizeInput,
+  sanitizeSearchQuery,
+  validateCSP,
+  validateEmail,
+  validatePassword,
+  validateTextLength,
+  validateUsername
 };


### PR DESCRIPTION
## Summary
- streamline SPA HTML entry with a single module script
- regenerate server utility bundle for runtime use

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b62a02d8088320a929ee8b6e711be2