### PR TITLE
Fix HTML entry to load Vite bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <meta name="referrer" content="no-referrer" />
 
     <!-- CSP is normally set via HTTP headers in server.js. Meta is a fallback for static preview only. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://static.cloudflareinsights.com">
 
     <!-- Enhanced Structured Data -->
     <script type="application/ld+json">
@@ -181,7 +181,6 @@
         }
       }
     </style>
-    <link rel="stylesheet" href="/assets/index-PajtKCTs.css">
   </head>
 
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -74,7 +74,7 @@
     <meta name="referrer" content="no-referrer" />
 
     <!-- CSP is normally set via HTTP headers in server.js. Meta is a fallback for static preview only. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://static.cloudflareinsights.com">
 
     <!-- Enhanced Structured Data -->
     <script type="application/ld+json">
@@ -181,7 +181,6 @@
         }
       }
     </style>
-    <link rel="stylesheet" href="/assets/index-PajtKCTs.css">
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- relax fallback CSP to allow blob URLs and Cloudflare script
- drop stale pre-built asset links so Vite injects its hashed bundle

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6328ebd488320be91778f51071fa1