### PR TITLE
Fix social community data flows

### DIFF
--- a/server-utils/errorHandler.js
+++ b/server-utils/errorHandler.js
@@ -101,6 +101,68 @@ function toast({ ...props }) {
   };
 }
 
+// src/sentry.ts
+import * as Sentry from "@sentry/react";
+Sentry.init({
+  dsn: import.meta.env.VITE_SENTRY_DSN,
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration({
+      maskAllText: false,
+      blockAllMedia: false
+    })
+  ],
+  // Performance monitoring
+  tracesSampleRate: import.meta.env.PROD ? 0.1 : 1,
+  // Session replay for error debugging
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1,
+  // Environment configuration
+  environment: import.meta.env.MODE,
+  // Release tracking
+  release: import.meta.env.VITE_APP_VERSION || "1.0.0",
+  // Filter out known non-actionable errors
+  beforeSend(event, hint) {
+    const error = hint.originalException;
+    if (error instanceof Error) {
+      if (error.message.includes("ResizeObserver")) {
+        return null;
+      }
+      if (error.message.includes("extension") || error.message.includes("Extension")) {
+        return null;
+      }
+      if (error.message.includes("Failed to fetch") && !navigator.onLine) {
+        return null;
+      }
+    }
+    return event;
+  },
+  // Add extra context to errors
+  initialScope: {
+    tags: {
+      app: "sahadhyayi"
+    }
+  }
+});
+var addSentryBreadcrumb = (category, message, level = "info", data) => {
+  Sentry.addBreadcrumb({
+    category,
+    message,
+    level,
+    data,
+    timestamp: Date.now() / 1e3
+  });
+};
+var captureError = (error, context, level = "error") => {
+  Sentry.withScope((scope) => {
+    if (context) {
+      scope.setExtras(context);
+    }
+    scope.setLevel(level);
+    Sentry.captureException(error);
+  });
+};
+
 // src/utils/errorHandler.ts
 var ErrorHandler = class _ErrorHandler {
   static instance;
@@ -155,6 +217,15 @@ var ErrorHandler = class _ErrorHandler {
     if (this.errorQueue.length > this.maxErrors) {
       this.errorQueue.shift();
     }
+    addSentryBreadcrumb(
+      "error",
+      errorReport.message,
+      this.mapSeverityToSentryLevel(errorReport.severity),
+      {
+        type: errorReport.type,
+        ...errorReport.context
+      }
+    );
     if (import.meta.env.DEV) {
       console.group(`\u{1F6A8} Runtime Error [${errorReport.severity}]`);
       console.error("Message:", errorReport.message);
@@ -166,7 +237,19 @@ var ErrorHandler = class _ErrorHandler {
       console.groupEnd();
     }
     this.showUserNotification(errorReport);
-    this.reportToService(errorReport);
+    this.reportToSentry(errorReport);
+  }
+  mapSeverityToSentryLevel(severity) {
+    switch (severity) {
+      case "critical":
+        return "fatal";
+      case "high":
+        return "error";
+      case "medium":
+        return "warning";
+      case "low":
+        return "info";
+    }
   }
   createContext(additional = {}) {
     return {
@@ -218,8 +301,17 @@ var ErrorHandler = class _ErrorHandler {
       });
     }
   }
-  reportToService(errorReport) {
-    if (import.meta.env.PROD) {
+  reportToSentry(errorReport) {
+    if (import.meta.env.PROD || import.meta.env.VITE_SENTRY_DSN) {
+      const error = new Error(errorReport.message);
+      if (errorReport.stack) {
+        error.stack = errorReport.stack;
+      }
+      captureError(error, {
+        errorType: errorReport.type,
+        severity: errorReport.severity,
+        ...errorReport.context
+      }, this.mapSeverityToSentryLevel(errorReport.severity));
     }
   }
   // Method to manually report custom errors

--- a/server-utils/getCoverQualityScore.js
+++ b/server-utils/getCoverQualityScore.js
@@ -1,0 +1,17 @@
+// src/utils/getCoverQualityScore.ts
+function getCoverQualityScore(url) {
+  if (!url)
+    return 0;
+  if (url.includes("supabase"))
+    return 500;
+  if (url.includes("openlibrary") && url.includes("-L"))
+    return 400;
+  if (url.includes("openlibrary"))
+    return 250;
+  if (url.includes("googleusercontent") || url.includes("google.com/books"))
+    return 200;
+  return 100;
+}
+export {
+  getCoverQualityScore
+};

--- a/server-utils/normalizeCoverUrl.js
+++ b/server-utils/normalizeCoverUrl.js
@@ -1,0 +1,12 @@
+// src/utils/normalizeCoverUrl.ts
+function normalizeCoverUrl(url) {
+  if (!url)
+    return null;
+  const trimmed = url.trim();
+  if (trimmed === "" || trimmed === "null" || trimmed === "undefined")
+    return null;
+  return trimmed;
+}
+export {
+  normalizeCoverUrl
+};

--- a/server-utils/slugify.js
+++ b/server-utils/slugify.js
@@ -1,6 +1,8 @@
 // src/utils/slugify.ts
 var slugify = (text) => {
-  return text.toLowerCase().trim().replace(/[\s\W&&[^\u0900-\u097F\u00C0-\u024F\u1E00-\u1EFF]]+/g, "-").replace(/^-+|-+$/g, "") || text.replace(/\s+/g, "-").toLowerCase();
+  if (!text)
+    return "";
+  return text.toLowerCase().trim().replace(/[^\p{L}\p{N}]+/gu, "-").replace(/^-+|-+$/g, "") || text.replace(/\s+/g, "-").toLowerCase();
 };
 export {
   slugify

--- a/server-utils/trustAndSafety.js
+++ b/server-utils/trustAndSafety.js
@@ -1,12 +1,44 @@
 // src/utils/trustAndSafety.ts
 var bannedWords = [
-  "nigger", "nigga", "faggot", "fag", "retard", "retarded",
-  "kike", "spic", "chink", "wetback", "beaner", "gook",
-  "tranny", "shemale",
-  "fuck", "shit", "bitch", "asshole", "cunt", "dick", "cock", "pussy",
-  "kill yourself", "kys", "go die", "neck yourself",
-  "porn", "hentai", "xxx", "nsfw",
-  "buy now", "click here", "free money", "make money fast"
+  // Slurs and hate speech
+  "nigger",
+  "nigga",
+  "faggot",
+  "fag",
+  "retard",
+  "retarded",
+  "kike",
+  "spic",
+  "chink",
+  "wetback",
+  "beaner",
+  "gook",
+  "tranny",
+  "shemale",
+  // Severe profanity
+  "fuck",
+  "shit",
+  "bitch",
+  "asshole",
+  "cunt",
+  "dick",
+  "cock",
+  "pussy",
+  // Violence and threats
+  "kill yourself",
+  "kys",
+  "go die",
+  "neck yourself",
+  // Sexual content
+  "porn",
+  "hentai",
+  "xxx",
+  "nsfw",
+  // Spam/scam indicators
+  "buy now",
+  "click here",
+  "free money",
+  "make money fast"
 ];
 var containsInappropriateLanguage = (text) => {
   const lower = text.toLowerCase();

--- a/src/components/social/ReadingGroups.tsx
+++ b/src/components/social/ReadingGroups.tsx
@@ -1,5 +1,4 @@
 
-import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -11,7 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Users, Plus, Search, Calendar, MapPin, Book, MessageCircle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useUserJoinedGroups } from '@/hooks/useUserGroups';
-import { useCreateGroup, useGroups, useJoinGroup, useLeaveGroup } from '@/hooks/useGroupManagement';
+import { type GroupChat, useCreateGroup, useGroups, useJoinGroup, useLeaveGroup } from '@/hooks/useGroupManagement';
 
 interface ReadingGroup {
   id: string;
@@ -29,7 +28,11 @@ interface ReadingGroup {
   createdAt?: string;
 }
 
-const toReadingGroup = (group: any, joinedGroupIds: Set<string>): ReadingGroup => ({
+type GroupListItem = GroupChat & {
+  group_members?: Array<{ count?: number | null }> | null;
+};
+
+const toReadingGroup = (group: GroupListItem, joinedGroupIds: Set<string>): ReadingGroup => ({
   id: group.id,
   name: group.name || 'Untitled group',
   description: group.description || 'No description available.',
@@ -91,10 +94,8 @@ export const ReadingGroups = () => {
     try {
       if (group.isJoined) {
         await leaveGroupMutation.mutateAsync(group.id);
-        toast({ title: 'Left group successfully!' });
       } else {
         await joinGroupMutation.mutateAsync(group.id);
-        toast({ title: 'Joined group successfully!' });
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Please try again.';

--- a/src/components/social/ReadingGroups.tsx
+++ b/src/components/social/ReadingGroups.tsx
@@ -11,7 +11,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Users, Plus, Search, Calendar, MapPin, Book, MessageCircle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useUserJoinedGroups } from '@/hooks/useUserGroups';
-import { useCreateGroup } from '@/hooks/useGroupManagement';
+import { useCreateGroup, useGroups, useJoinGroup, useLeaveGroup } from '@/hooks/useGroupManagement';
 
 interface ReadingGroup {
   id: string;
@@ -26,66 +26,28 @@ interface ReadingGroup {
   isJoined: boolean;
   isPrivate: boolean;
   genre: string[];
+  createdAt?: string;
 }
 
-const mockGroups: ReadingGroup[] = [
-  {
-    id: '1',
-    name: 'NYC Fiction Lovers',
-    description: 'A community for fiction enthusiasts in New York City. We meet monthly to discuss contemporary fiction and classics.',
-    coverImage: 'https://via.placeholder.com/100/60/orange/white?text=Fiction',
-    members: 45,
-    maxMembers: 50,
-    currentBook: 'The Seven Husbands of Evelyn Hugo',
-    nextMeeting: 'Dec 15, 2024',
-    location: 'Central Park Library',
-    isJoined: true,
-    isPrivate: false,
-    genre: ['Fiction', 'Contemporary']
-  },
-  {
-    id: '2',
-    name: 'Self-Improvement Circle',
-    description: 'Transform your life one book at a time. We focus on personal development, productivity, and mindfulness.',
-    coverImage: 'https://via.placeholder.com/100/60/orange/white?text=SelfHelp',
-    members: 32,
-    maxMembers: 40,
-    currentBook: 'Atomic Habits',
-    nextMeeting: 'Dec 20, 2024',
-    location: 'Online',
-    isJoined: false,
-    isPrivate: false,
-    genre: ['Self-Help', 'Productivity']
-  },
-  {
-    id: '3',
-    name: 'Sci-Fi Adventures',
-    description: 'Explore new worlds and future possibilities. From classic Asimov to modern space operas.',
-    coverImage: 'https://via.placeholder.com/100/60/orange/white?text=SciFi',
-    members: 28,
-    maxMembers: 35,
-    currentBook: 'Dune',
-    nextMeeting: 'Jan 5, 2025',
-    location: 'Brooklyn Public Library',
-    isJoined: false,
-    isPrivate: true,
-    genre: ['Sci-Fi', 'Fantasy']
-  }
-];
+const toReadingGroup = (group: any, joinedGroupIds: Set<string>): ReadingGroup => ({
+  id: group.id,
+  name: group.name || 'Untitled group',
+  description: group.description || 'No description available.',
+  coverImage: group.image_url || '',
+  members: Array.isArray(group.group_members) ? (group.group_members[0]?.count ?? 0) : 0,
+  maxMembers: 50,
+  currentBook: '',
+  nextMeeting: '',
+  location: 'Online',
+  isJoined: joinedGroupIds.has(group.id),
+  isPrivate: false,
+  genre: [],
+  createdAt: group.created_at,
+});
 
 export const ReadingGroups = () => {
   const navigate = useNavigate();
-  const [groups, setGroups] = useState<ReadingGroup[]>(() => {
-    if (typeof window !== 'undefined') {
-      try {
-        const stored = localStorage.getItem('reading-groups');
-        return stored ? JSON.parse(stored) : mockGroups;
-      } catch {
-        return mockGroups;
-      }
-    }
-    return mockGroups;
-  });
+  const [groups, setGroups] = useState<ReadingGroup[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [newGroup, setNewGroup] = useState({
@@ -98,7 +60,26 @@ export const ReadingGroups = () => {
   
   // Use real data from database
   const { data: userGroups = [] } = useUserJoinedGroups();
+  const { data: allGroups = [], isLoading: isLoadingGroups } = useGroups();
   const createGroupMutation = useCreateGroup();
+  const joinGroupMutation = useJoinGroup();
+  const leaveGroupMutation = useLeaveGroup();
+
+  useEffect(() => {
+    const joinedGroupIds = new Set(userGroups.map((membership) => membership.group_id));
+
+    const normalizedGroups = allGroups.map((group) => toReadingGroup(group, joinedGroupIds));
+    const joinedOnlyGroups = userGroups
+      .map((membership) => membership.groups)
+      .filter(Boolean)
+      .map((group) => toReadingGroup(group, joinedGroupIds));
+
+    const mergedGroups = [...joinedOnlyGroups, ...normalizedGroups].filter((group, index, array) =>
+      array.findIndex(candidate => candidate.id === group.id) === index
+    );
+
+    setGroups(mergedGroups);
+  }, [allGroups, userGroups]);
 
   const filteredGroups = groups.filter(group =>
     (group.name || '').toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -106,21 +87,23 @@ export const ReadingGroups = () => {
     group.genre?.some(g => (g || '').toLowerCase().includes(searchQuery.toLowerCase()))
   );
 
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('reading-groups', JSON.stringify(groups));
+  const handleJoinGroup = async (group: ReadingGroup) => {
+    try {
+      if (group.isJoined) {
+        await leaveGroupMutation.mutateAsync(group.id);
+        toast({ title: 'Left group successfully!' });
+      } else {
+        await joinGroupMutation.mutateAsync(group.id);
+        toast({ title: 'Joined group successfully!' });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Please try again.';
+      toast({
+        title: group.isJoined ? 'Failed to leave group' : 'Failed to join group',
+        description: message,
+        variant: 'destructive'
+      });
     }
-  }, [groups]);
-
-  const handleJoinGroup = (groupId: string) => {
-    setGroups(prev =>
-      prev.map(group =>
-        group.id === groupId
-          ? { ...group, isJoined: !group.isJoined, members: group.isJoined ? group.members - 1 : group.members + 1 }
-          : group
-      )
-    );
-    toast({ title: 'Group membership updated!' });
   };
 
   const handleCreateGroup = async () => {
@@ -370,7 +353,11 @@ export const ReadingGroups = () => {
       <div className="space-y-4">
         <h3 className="text-lg font-semibold text-gray-900">Discover Groups</h3>
         <div className="grid gap-4">
-          {filteredGroups.map((group) => (
+          {isLoadingGroups ? (
+            <Card className="bg-white shadow-sm border-0 rounded-xl">
+              <CardContent className="p-8 text-center text-gray-500">Loading groups...</CardContent>
+            </Card>
+          ) : filteredGroups.map((group) => (
           <Card key={group.id} className="bg-white shadow-sm border-0 rounded-xl">
             <CardContent className="p-4">
               <div className="flex gap-4">
@@ -416,7 +403,7 @@ export const ReadingGroups = () => {
                       </div>
                     </div>
                     <Button
-                      onClick={() => handleJoinGroup(group.id)}
+                      onClick={() => handleJoinGroup(group)}
                       variant={group.isJoined ? "outline" : "default"}
                       className={`${group.isJoined 
                         ? "border-orange-300 text-orange-700 hover:bg-orange-50" 
@@ -471,7 +458,7 @@ export const ReadingGroups = () => {
         </div>
       </div>
 
-      {filteredGroups.length === 0 && (
+      {!isLoadingGroups && filteredGroups.length === 0 && (
         <Card className="bg-white shadow-sm border-0 rounded-xl">
           <CardContent className="p-8 text-center">
             <Users className="w-12 h-12 text-gray-400 mx-auto mb-4" />

--- a/src/hooks/useGroupManagement.ts
+++ b/src/hooks/useGroupManagement.ts
@@ -43,6 +43,7 @@ export const useGroups = () => {
       
       return data || [];
     },
+    enabled: !!user?.id,
   });
 };
 

--- a/src/hooks/useSocialPosts.ts
+++ b/src/hooks/useSocialPosts.ts
@@ -164,17 +164,19 @@ export const useCreatePost = () => {
       const { data, error } = await supabase
         .from('posts')
         .insert([payload])
-        .select(`
-          *,
-          profiles!posts_user_id_fkey(id, full_name, username, profile_photo_url),
-          books_library(id, title, author, cover_image_url)
-        `)
+        .select('*')
         .single();
 
       if (error) throw error;
-      return data;
+      return {
+        ...data,
+        profiles: undefined,
+        books_library: undefined,
+        user_liked: false,
+      };
     },
-    onSuccess: () => {
+    onSuccess: (createdPost) => {
+      queryClient.setQueryData<SocialPost[]>(['social-posts'], (old = []) => [createdPost as SocialPost, ...old]);
       queryClient.invalidateQueries({ queryKey: ['social-posts'] });
       toast({
         title: 'Success',

--- a/src/hooks/useUserSearch.ts
+++ b/src/hooks/useUserSearch.ts
@@ -34,16 +34,15 @@ export const useUserSearch = (searchTerm: string) => {
       
       try {
         const { data, error } = await supabase
-          .rpc('get_public_profiles_for_search', { search_term: debouncedSearchTerm })
-          .neq('id', user?.id || '');
+          .rpc('get_public_profiles_for_search', { search_term: debouncedSearchTerm });
         
         if (error) {
           console.error('User search API error:', error);
           // Return empty array on error rather than throwing
           return [];
         }
-        
-        return data as SearchUser[];
+
+        return (data as SearchUser[]).filter(profile => profile.id !== user?.id);
       } catch (err) {
         console.error('User search exception:', err);
         return [];
@@ -89,19 +88,19 @@ export const useAllUsers = () => {
         });
 
         // Combine all IDs to exclude (friends + pending requests + current user)
-        const excludeIds = [...friendIds, ...pendingIds, user?.id || ''];
+        const excludeIds = new Set([...friendIds, ...pendingIds, user?.id || '']);
 
         const { data, error } = await supabase
-          .rpc('get_public_profiles_for_search', { search_term: '' })
-          .not('id', 'in', `(${excludeIds.map(id => `"${id}"`).join(',')})`)
-          .limit(50);
+          .rpc('get_public_profiles_for_search', { search_term: '' });
         
         if (error) {
           console.error('All users API error:', error);
           return [];
         }
-        
-        return data as SearchUser[];
+
+        return (data as SearchUser[])
+          .filter(profile => !excludeIds.has(profile.id))
+          .slice(0, 50);
       } catch (err) {
         console.error('All users exception:', err);
         return [];

--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -31,7 +31,7 @@ const SocialMedia = () => {
             <div className="w-20 h-20 rounded-2xl bg-brand-primary/10 flex items-center justify-center mx-auto mb-6">
               <Users className="w-10 h-10 text-brand-primary" />
             </div>
-            <h1 className="text-3xl font-bold text-foreground mb-3">Social Reading Community</h1>
+            <h1 className="text-3xl font-bold text-foreground mb-3">Social Media</h1>
             <p className="text-muted-foreground mb-8 leading-relaxed">
               Connect with fellow readers, share what you're reading, join reading groups, and discover friends who love the same books.
             </p>
@@ -93,7 +93,7 @@ const SocialMedia = () => {
                 <Sparkles className="w-5 h-5 text-brand-primary" />
               </div>
               <div>
-                <h1 className="text-2xl font-bold text-foreground">Community</h1>
+                <h1 className="text-2xl font-bold text-foreground">Social Media</h1>
                 <p className="text-sm text-muted-foreground">Connect, share, and discover with fellow readers</p>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- The Social section was using local/mock state and fragile relational selects which caused post creation to fail, group discovery to show only mock data, and the Discover users list to omit available profiles. 
- Fixes were needed to reliably surface backend data for posts, groups, and user discovery so the UI reflects actual Supabase state.

### Description
- Wire the Reading Groups UI to real backend data by using `useGroups`, `useJoinGroup`, and `useLeaveGroup` instead of local/mock/localStorage-only state in `src/components/social/ReadingGroups.tsx`, and merge the user's joined groups with the global group list for discovery. 
- Use the real join/leave mutations for group membership and keep newly created groups visible immediately in the UI after creation in `ReadingGroups.tsx`.
- Make post creation more resilient in `src/hooks/useSocialPosts.ts` by inserting the post with a simple `.select('*')`, seeding the local feed cache with the created record, and then invalidating `['social-posts']` rather than relying on an immediate relational re-select that could fail. 
- Fix user discovery by fetching RPC results and applying client-side filtering in `src/hooks/useUserSearch.ts`/`useAllUsers` so `Discover` shows the expected profiles (instead of depending on server-side post-filters that could omit users). 
- The build step regenerated helpers under `server-utils/` as part of the repository build process and those outputs are included alongside the changes.

### Testing
- Ran `npm run lint`, which completed successfully with repository warnings (no new errors) and returned existing non-blocking warnings. 
- Ran `npm run build`, which completed successfully (Vite build succeeded; non-blocking warnings about chunking/Browserslist age reported). 
- Verified the code compiles and the changed hooks/components are included in the production bundle; no automated test failures were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc272bb3b88320bf9b43e4d7fb6a3c)