### PR TITLE
Return 404 for disallowed well-known and proxy probing routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -496,6 +496,17 @@ app.use((err, req, res, _next) => {
   return jsonError(res, status, msg, code, err.details);
 });
 
+// Explicitly return 404 for disallowed well-known/proxy probing routes.
+const blockedRoutes = new Set([
+  '/.well-known/apple-app-site-association',
+  '/apple-app-site-association',
+  '/cdn-cgi/content',
+]);
+
+app.get([...blockedRoutes], (_req, res) => {
+  res.status(404).type('text/plain').send('Not Found');
+});
+
 // Handle client-side routing by returning the main index.html for other routes
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'dist', 'index.html'));


### PR DESCRIPTION
### Motivation
- Prevent automated probing and misconfigured clients from retrieving or attempting proxying of sensitive well-known and CDN probe endpoints by explicitly returning 404 for those paths.

### Description
- Add a `blockedRoutes` set containing `/.well-known/apple-app-site-association`, `/apple-app-site-association`, and `/cdn-cgi/content` and mount an `app.get([...blockedRoutes], ...)` handler that responds with `404` and plain `Not Found` text. 

### Testing
- Ran the project test and lint scripts (`npm test`, `npm run lint`) against the modified server and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75a45927c8320ae1abb83b433f471)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of system probe requests to properly return `404 Not Found` responses instead of serving the application fallback page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->